### PR TITLE
feat(preflight): add guarded preflight workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,8 @@ htmlcov/
 _pydevd_bundle/
 _pydevd_frame_eval/
 pydevd_attach_to_process/
+
+### Tiny Swarm World local runtime artifacts ###
+/.tiny-swarm-world/
+.env
+.env.local

--- a/OPERATIONAL_READINESS_CHECKLIST.md
+++ b/OPERATIONAL_READINESS_CHECKLIST.md
@@ -6,11 +6,15 @@
 - [ ] Multipass installed and accessible.
 - [ ] Docker CLI/Engine installed and accessible.
 - [ ] WSL2 status verified when on Windows.
+- [ ] Full-run resources meet the integration contract: 4 vCPU, 16 GiB RAM,
+      and 60 GiB free disk available to the Linux/WSL target.
 
 ## Python environment readiness
 - [ ] Virtual environment creation documented.
 - [ ] Dependencies installed from canonical file.
 - [ ] Canonical entrypoint runs from repo root.
+- [ ] `python3 tools/quality_gate.py quality` runs as the authoritative
+      default quality gate.
 
 ## Multipass readiness
 - [ ] VM definitions validated against config schema.
@@ -52,18 +56,47 @@
 - [ ] RabbitMQ reachable.
 - [ ] SonarQube reachable.
 - [ ] Swagger/NGINX reachable.
+- [ ] Any resource-gated service omission has Three Amigos approval and is
+      recorded as `PASS_WITH_RESOURCE_GATES`, not `PASS`.
 
 ## Test readiness
-- [ ] `pytest` runs from repo root without manual PYTHONPATH edits.
+- [ ] `python3 tools/quality_gate.py quality` passes from the repository root.
+- [ ] Optional `pytest` compatibility, if introduced later, is documented as
+      secondary and does not replace `tools/quality_gate.py`.
 - [ ] Critical orchestration units have active tests.
 
 ## Smoke test readiness
 - [ ] Cluster bootstrap smoke test passes.
 - [ ] Service reachability smoke test passes.
 
+## Live consent readiness
+- [ ] Live runner requires `--live`.
+- [ ] Live runner requires
+      `TSW_LIVE_INFRASTRUCTURE_CONSENT=I_UNDERSTAND_THIS_CHANGES_LOCAL_INFRASTRUCTURE`.
+- [ ] Live runner requires the interactive phrase
+      `RUN TINY SWARM WORLD LIVE INSTALLATION`.
+- [ ] Non-interactive live execution is refused until a future workflow defines
+      a separate consent contract.
+- [ ] Missing consent produces `REFUSED_LIVE_CONSENT_MISSING` before any
+      Multipass, Docker Swarm, netplan, socat, compose/stack or bootstrap
+      command runs.
+
+## Evidence and secret readiness
+- [ ] Evidence path is `.tiny-swarm-world/evidence/live-installation/<run-id>/`.
+- [ ] Evidence root is ignored by Git before live evidence is written.
+- [ ] Evidence bundle includes manifest, summary, preflight, consent/refusal,
+      phase results, command results, probes, redaction report and checksums.
+- [ ] Evidence redacts secrets, tokens, join tokens, URLs with credentials,
+      HTTP authorization headers and service bootstrap credentials.
+- [ ] Secrets come only from environment variables or ignored local files.
+- [ ] Missing secrets fail during preflight before stack deployment.
+
 ## Logging/observability readiness
 - [ ] Orchestrator logs clearly indicate phase success/failure.
 - [ ] Failure exit codes are non-zero and actionable.
+- [ ] Failure reports classify blockers as host prerequisite, configuration,
+      secret, deterministic defect, flaky readiness, architecture ambiguity,
+      product-scope ambiguity or resource limitation.
 
 ## Documentation completeness
 - [ ] README includes canonical end-to-end runbook.

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,60 +1,61 @@
 {
-  "workflowVersion": "installation-integration-verification-20260523",
-  "workflowBranch": "docs/workflow-installation-integration-test-20260523",
+  "workflowVersion": "init-safety-boundary-separation-20260523",
+  "workflowBranch": "architecture/workflow-init-service-boundaries-20260523",
   "processStrand": "workflow create",
   "executionProfile": "FULL_PATH",
   "createdDate": "2026-05-23",
   "requirement": {
-    "summary": "Create a workflow for an opt-in integration test that verifies full installation and full functionality.",
-    "blockerPolicy": "Self-remediate blockers when confidence is at least 90 percent; otherwise start Three Amigos Q&A.",
-    "temporaryBaseline": [
-      "user request",
-      "AGENTS.md",
-      "QUALITY.md",
-      "AUDIT_REPORT.md",
-      "OPERATIONAL_READINESS_CHECKLIST.md",
-      "active workflow requirement record",
-      "documentation/architecture/adr-separate-platform-artifacts-deployment.adoc"
-    ],
+    "summary": "Create a workflow for non-destructive init, separate reconcile/reset/destroy workflows, real Platform/Artifacts/Deployment service separation, workflow-level CLI, Nexus stack deployment extraction, typed command YAMLs, state/inventory modeling, and verify-after-apply enforcement.",
     "decision": "READY_FOR_WORKFLOW",
-    "confidence": 92
+    "confidence": 91,
+    "epicTraceability": "No documentation/epics source exists; temporary baseline is the user request plus AGENTS.md, QUALITY.md, architecture docs, arc42, ADR and subagent reviews.",
+    "acceptedAssumptions": [
+      "init creates or prepares missing managed resources without deletion",
+      "reconcile converges existing managed resources non-destructively",
+      "reset explicitly reinitializes selected managed runtime resources after confirmation",
+      "destroy explicitly tears down selected managed runtime resources after confirmation",
+      "verify inspects state without mutation",
+      "desired inventory belongs to committed product configuration",
+      "observed runtime inventory and evidence belong under ignored local state/evidence roots"
+    ]
   },
   "baseline": {
     "defaultQualityGate": "python3 tools/quality_gate.py quality",
     "liveInfrastructureInDefaultGate": false,
-    "liveEvidenceGapRecordedIn": "AUDIT_REPORT.md",
-    "readinessChecklist": "OPERATIONAL_READINESS_CHECKLIST.md",
-    "slice01Contracts": [
-      "live-run-consent",
-      "refusal-before-live-command",
-      "evidence-bundle",
-      "redaction",
-      "credential-source-validation",
-      "resource-gated-result-semantics"
-    ]
+    "normalInitCurrentlyDestructive": true,
+    "cleanupYamlContainsDeleteAllAndPurge": true,
+    "compositionCurrentlyPlatformOnly": true,
+    "cliCurrentlyServiceLevel": true,
+    "nexusStackCurrentlyUnderNexus": true,
+    "typedCommandYamlContractExists": false,
+    "stateInventoryModelExists": false,
+    "verifyAfterApplyEnforced": false
   },
   "affectedAreas": [
     "documentation/workflow",
-    "OPERATIONAL_READINESS_CHECKLIST.md",
+    "documentation/architecture",
+    "documentation/arc42",
     "README.md",
-    "documentation",
-    "src/tiny_swarm_world",
+    "documentation/user_guide",
+    "src/tiny_swarm_world/__main__.py",
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "src/tiny_swarm_world/domain",
+    "src/tiny_swarm_world/application",
+    "src/tiny_swarm_world/infrastructure/adapters",
     "infra/config",
     "infra/compose",
     "infra/prepare",
-    "tools",
+    "infra/swarm",
     "tests"
   ],
   "forbiddenAreasWithoutRefinement": [
     "src/main/java/**",
     "Windows-native runtime support",
     "default CI execution of live Multipass or Docker Swarm",
-    "committed secrets or hardcoded credentials",
-    "implicit destructive VM, stack or network cleanup",
-    "live Multipass execution before explicit live-run approval",
-    "live Docker Swarm execution before explicit live-run approval",
-    "netplan or socat mutation before explicit live-run approval",
-    "service bootstrap before explicit live-run approval"
+    "committed secrets, observed runtime state, local evidence or host-specific absolute paths",
+    "implicit VM deletion or purge in init or reconcile",
+    "microservice claims for Platform, Artifacts and Deployment without runtime independence evidence",
+    "live Multipass, Docker Swarm, netplan, socat, compose, Portainer, Nexus, Jenkins, RabbitMQ, SonarQube or Swagger/NGINX commands"
   ],
   "requiredRoles": [
     "Senior Requirement Engineer",
@@ -62,14 +63,36 @@
     "Senior Python Automation Developer",
     "Senior React Frontend Developer",
     "Senior Tester",
-    "Senior DevOps Engineer",
     "Senior Security Sandbox Engineer",
-    "Senior Documentation Engineer"
+    "Senior Documentation Engineer",
+    "Senior Workflow Architect"
   ],
   "conditionalRoles": [
-    "Senior Workflow Architect",
+    "Senior DevOps Engineer",
     "Release and Branch Governance",
     "Security Threat Modeling"
+  ],
+  "subagentReviews": [
+    {
+      "role": "Senior Requirement Engineer",
+      "status": "completed"
+    },
+    {
+      "role": "Senior System Architect",
+      "status": "completed"
+    },
+    {
+      "role": "Senior Python Automation Developer",
+      "status": "completed"
+    },
+    {
+      "role": "Senior React Frontend Developer",
+      "status": "completed"
+    },
+    {
+      "role": "Senior Tester",
+      "status": "completed"
+    }
   ],
   "qualityCommands": {
     "workflowCreation": [
@@ -86,67 +109,106 @@
     "final": [
       "python3 tools/quality_gate.py quality"
     ],
-    "liveIntegration": {
-      "status": "planned-artifact",
+    "liveInfrastructure": {
+      "allowedDuringWorkflowCreation": false,
       "includedInDefaultQualityGate": false
     }
   },
   "slices": [
     {
       "id": "01",
-      "name": "Integration Test Contract",
-      "dependencies": []
+      "name": "Requirement And Safety Contract",
+      "dependencies": [],
+      "parallelGroup": "A"
     },
     {
       "id": "02",
-      "name": "Preflight And Configuration Validation",
+      "name": "ADR And arc42 Baseline",
       "dependencies": [
         "01"
-      ]
+      ],
+      "parallelGroup": "B"
     },
     {
       "id": "03",
-      "name": "Canonical Full-Installation Plan",
+      "name": "Typed Command YAML Contract",
       "dependencies": [
         "01",
         "02"
-      ]
+      ],
+      "parallelGroup": "C"
     },
     {
       "id": "04",
-      "name": "Platform Runtime Readiness Probes",
+      "name": "State And Inventory Model",
       "dependencies": [
-        "03"
-      ]
+        "01",
+        "02"
+      ],
+      "parallelGroup": "C"
     },
     {
       "id": "05",
-      "name": "Deployment And Service Readiness Probes",
+      "name": "Workflow Taxonomy And Non-Destructive Init",
       "dependencies": [
-        "03"
-      ]
+        "03",
+        "04"
+      ],
+      "parallelGroup": "D"
     },
     {
       "id": "06",
-      "name": "Live Integration Runner And Evidence Bundle",
+      "name": "Service Wiring Separation",
       "dependencies": [
-        "04",
-        "05"
-      ]
+        "02",
+        "04"
+      ],
+      "parallelGroup": "D"
     },
     {
       "id": "07",
-      "name": "Documentation And Readiness Synchronization",
+      "name": "Nexus Stack Deployment Extraction",
       "dependencies": [
         "06"
-      ]
+      ],
+      "parallelGroup": "E"
     },
     {
       "id": "08",
-      "name": "Controlled Live Verification",
+      "name": "Workflow-Level CLI",
       "dependencies": [
+        "05",
+        "06",
         "07"
-      ]
+      ],
+      "parallelGroup": "F"
+    },
+    {
+      "id": "09",
+      "name": "Verify After Every Apply",
+      "dependencies": [
+        "03",
+        "04",
+        "05",
+        "07",
+        "08"
+      ],
+      "parallelGroup": "G"
+    },
+    {
+      "id": "10",
+      "name": "Documentation, Quality Sync, And Legacy Quarantine",
+      "dependencies": [
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+        "07",
+        "08",
+        "09"
+      ],
+      "parallelGroup": "H"
     }
   ],
   "governingHashes": [
@@ -159,14 +221,6 @@
       "sha256": "d327e4060ff1729f17ffde844b1a2d6208fe203e149ae9d1af185bef0aed2155"
     },
     {
-      "path": "AUDIT_REPORT.md",
-      "sha256": "b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816"
-    },
-    {
-      "path": "OPERATIONAL_READINESS_CHECKLIST.md",
-      "sha256": "d8e54cd328674c8ce4e6237abadf86346f5f00a0e6333677e2214881e159ddd7"
-    },
-    {
       "path": ".agents/skills/workflow-authoring/SKILL.md",
       "sha256": "087658240296e3b1ec74205c60a96a9a4c67a17cf653f7867e6f316bd9afa94e"
     },
@@ -175,25 +229,70 @@
       "sha256": "23de7d9aac9d2694eae26fac2765d65f369c101ac348dac24d5f3bbe9e2d3ba4"
     },
     {
-      "path": ".agents/skills/quality-gate-orchestrator/SKILL.md",
-      "sha256": "3f9ef8278091f7781eacd58d000675fa6a996d81f96802a0abd37cc2a821d40f"
+      "path": ".agents/skills/swarm-coordination/SKILL.md",
+      "sha256": "8e6d032e4b609212ad7229b26fe1aa72af4afc0d6594a01cc945053a0b3e9ba7"
     },
     {
       "path": "documentation/architecture/adr-separate-platform-artifacts-deployment.adoc",
       "sha256": "e93d07dc6ce9485208a40d77b6a2c52a5d5442f36845192eac0963a86dc00297"
     },
     {
+      "path": "documentation/architecture/migration-plan.md",
+      "sha256": "dbf5618e62b96935b669cf880b3be84710c8a29ba7ce9a4f4aaf08ccf5a21e2f"
+    },
+    {
+      "path": "documentation/architecture/responsibility-separation-analysis.md",
+      "sha256": "38b08d772951f87b168f9432a8aadbd8b3705d5fedd2cc8511c8ad4a36eec078"
+    },
+    {
       "path": "src/tiny_swarm_world/__main__.py",
-      "sha256": "543c594c9df79faf04e83abcdc1182f05771c16494d48dd5a30cee73a05d2947"
+      "sha256": "5cf743ac4c186418a2e649458965b917e52f9cd78605c2eb3cf55febd7e7f4e3"
+    },
+    {
+      "path": "src/tiny_swarm_world/infrastructure/composition.py",
+      "sha256": "67aae1f2cf4a769500b16e27d2551981568a01fc24cc3b39d26eee05e111339a"
+    },
+    {
+      "path": "src/tiny_swarm_world/application/services/multipass/multipass_init_vms.py",
+      "sha256": "bc65b41f859e99eb7ff5ce8d6d59c33e062d1358a89588eb133735383f149b79"
+    },
+    {
+      "path": "infra/config/multipass/command_multipass_clean_repository_yaml.yaml",
+      "sha256": "bb483b476e21b225971051c07515948b33ab53a1778bbe1a2d62761361ed2deb"
+    },
+    {
+      "path": "infra/config/network/netplant/command_netplant_setup_yaml.yaml",
+      "sha256": "614f6206b97de2cd0e31c60986cddc5ef5dba759c2856ca8f6eb0e730c4670e4"
+    },
+    {
+      "path": "tests/architecture/test_hexagonal_imports.py",
+      "sha256": "1d9a78e08bc3f8f893ca0343d3bd2aaf544c997e09278345f5472b70114cc0be"
+    },
+    {
+      "path": "tests/architecture/test_infra_responsibility_boundaries.py",
+      "sha256": "973b13559bf11304a0023713a4cf842d223962309198660f710598d37bd97ba8"
     }
   ],
+  "worktreeCaveat": {
+    "nonWorkflowSourceChangesObserved": true,
+    "workflowAuthoringTouchedOnly": [
+      "documentation/workflow/workflow.md",
+      "documentation/workflow/context-pack.md",
+      "documentation/workflow/context-pack.json",
+      "documentation/workflow/execution-report.md"
+    ],
+    "executionInstruction": "Resolve ownership of existing source/preflight changes before executing slices with overlapping file locks."
+  },
   "staleWhen": [
     "any recorded governing hash changes",
-    "documentation/workflow/** changes outside the active workflow branch",
     "AGENTS.md or QUALITY.md changes",
-    "live integration commands are implemented without updating this workflow",
-    "mandatory service scope changes",
-    "secret handling or destructive cleanup policy changes",
-    "arc42 runtime, deployment, quality or risk sections are updated without checking this workflow"
+    "responsibility ADR is accepted, superseded or edited",
+    "command YAML schema changes",
+    "destructive-operation policy changes",
+    "state/inventory model changes",
+    "workflow-level CLI contract changes",
+    "documentation/workflow/** changes outside the active workflow branch",
+    "source/preflight worktree changes overlap an implementation slice without a handoff",
+    "arc42 runtime, deployment, concept, quality or risk sections change without checking this workflow"
   ]
 }

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -7,6 +7,15 @@
   "requirement": {
     "summary": "Create a workflow for an opt-in integration test that verifies full installation and full functionality.",
     "blockerPolicy": "Self-remediate blockers when confidence is at least 90 percent; otherwise start Three Amigos Q&A.",
+    "temporaryBaseline": [
+      "user request",
+      "AGENTS.md",
+      "QUALITY.md",
+      "AUDIT_REPORT.md",
+      "OPERATIONAL_READINESS_CHECKLIST.md",
+      "active workflow requirement record",
+      "documentation/architecture/adr-separate-platform-artifacts-deployment.adoc"
+    ],
     "decision": "READY_FOR_WORKFLOW",
     "confidence": 92
   },
@@ -14,7 +23,15 @@
     "defaultQualityGate": "python3 tools/quality_gate.py quality",
     "liveInfrastructureInDefaultGate": false,
     "liveEvidenceGapRecordedIn": "AUDIT_REPORT.md",
-    "readinessChecklist": "OPERATIONAL_READINESS_CHECKLIST.md"
+    "readinessChecklist": "OPERATIONAL_READINESS_CHECKLIST.md",
+    "slice01Contracts": [
+      "live-run-consent",
+      "refusal-before-live-command",
+      "evidence-bundle",
+      "redaction",
+      "credential-source-validation",
+      "resource-gated-result-semantics"
+    ]
   },
   "affectedAreas": [
     "documentation/workflow",
@@ -147,7 +164,7 @@
     },
     {
       "path": "OPERATIONAL_READINESS_CHECKLIST.md",
-      "sha256": "bcc8dd6c332e94405d8f8aa471134b4cb319058fcc837cfc597d262ac561a94d"
+      "sha256": "d8e54cd328674c8ce4e6237abadf86346f5f00a0e6333677e2214881e159ddd7"
     },
     {
       "path": ".agents/skills/workflow-authoring/SKILL.md",

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,41 +1,43 @@
 {
-  "workflowVersion": "tasklist-remediation-20260523",
-  "workflowBranch": "architecture/workflow-tasklist-remediation-20260523",
+  "workflowVersion": "installation-integration-verification-20260523",
+  "workflowBranch": "docs/workflow-installation-integration-test-20260523",
   "processStrand": "workflow create",
   "executionProfile": "FULL_PATH",
   "createdDate": "2026-05-23",
-  "convertedSources": [
-    {
-      "path": "TASKLIST.md",
-      "status": "converted-and-deleted",
-      "sha256": "96295c760ceaee6217e7987ff0b7bbd034479332d3f3d8341d2bcc4e55df9f48"
-    },
-    {
-      "path": "AUDIT_REPORT.md",
-      "status": "retained-as-audit-evidence",
-      "sha256": "b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816"
-    }
-  ],
+  "requirement": {
+    "summary": "Create a workflow for an opt-in integration test that verifies full installation and full functionality.",
+    "blockerPolicy": "Self-remediate blockers when confidence is at least 90 percent; otherwise start Three Amigos Q&A.",
+    "decision": "READY_FOR_WORKFLOW",
+    "confidence": 92
+  },
+  "baseline": {
+    "defaultQualityGate": "python3 tools/quality_gate.py quality",
+    "liveInfrastructureInDefaultGate": false,
+    "liveEvidenceGapRecordedIn": "AUDIT_REPORT.md",
+    "readinessChecklist": "OPERATIONAL_READINESS_CHECKLIST.md"
+  },
   "affectedAreas": [
     "documentation/workflow",
-    "src/tiny_swarm_world",
-    "infra",
-    "tests",
+    "OPERATIONAL_READINESS_CHECKLIST.md",
     "README.md",
     "documentation",
-    "QUALITY.md when explicitly changed by a slice",
-    "tools/quality_gate.py when explicitly changed by a slice"
+    "src/tiny_swarm_world",
+    "infra/config",
+    "infra/compose",
+    "infra/prepare",
+    "tools",
+    "tests"
   ],
   "forbiddenAreasWithoutRefinement": [
     "src/main/java/**",
-    "live Multipass execution",
-    "live Docker Swarm execution",
-    "compose deployments",
-    "netplan mutation",
-    "socat forwarding",
-    "service bootstrap scripts",
-    "frontend package/tooling creation",
-    "restoring TASKLIST.md as an active planning artifact"
+    "Windows-native runtime support",
+    "default CI execution of live Multipass or Docker Swarm",
+    "committed secrets or hardcoded credentials",
+    "implicit destructive VM, stack or network cleanup",
+    "live Multipass execution before explicit live-run approval",
+    "live Docker Swarm execution before explicit live-run approval",
+    "netplan or socat mutation before explicit live-run approval",
+    "service bootstrap before explicit live-run approval"
   ],
   "requiredRoles": [
     "Senior Requirement Engineer",
@@ -44,20 +46,20 @@
     "Senior React Frontend Developer",
     "Senior Tester",
     "Senior DevOps Engineer",
+    "Senior Security Sandbox Engineer",
     "Senior Documentation Engineer"
   ],
   "conditionalRoles": [
-    "Senior Security Sandbox Engineer",
-    "Senior Bash Specialist when available"
+    "Senior Workflow Architect",
+    "Release and Branch Governance",
+    "Security Threat Modeling"
   ],
   "qualityCommands": {
     "workflowCreation": [
       "git diff --check",
-      "python3 -m json.tool documentation/workflow/context-pack.json",
-      "python3 tools/quality_gate.py arch-tests"
+      "python3 -m json.tool documentation/workflow/context-pack.json"
     ],
     "targeted": [
-      "git diff --check",
       "python3 tools/quality_gate.py lint",
       "python3 tools/quality_gate.py arch-lint",
       "python3 tools/quality_gate.py arch-tests",
@@ -67,10 +69,69 @@
     "final": [
       "python3 tools/quality_gate.py quality"
     ],
-    "optionalShellSyntax": [
-      "find infra -name '*.sh' -print0 | xargs -0 bash -n"
-    ]
+    "liveIntegration": {
+      "status": "planned-artifact",
+      "includedInDefaultQualityGate": false
+    }
   },
+  "slices": [
+    {
+      "id": "01",
+      "name": "Integration Test Contract",
+      "dependencies": []
+    },
+    {
+      "id": "02",
+      "name": "Preflight And Configuration Validation",
+      "dependencies": [
+        "01"
+      ]
+    },
+    {
+      "id": "03",
+      "name": "Canonical Full-Installation Plan",
+      "dependencies": [
+        "01",
+        "02"
+      ]
+    },
+    {
+      "id": "04",
+      "name": "Platform Runtime Readiness Probes",
+      "dependencies": [
+        "03"
+      ]
+    },
+    {
+      "id": "05",
+      "name": "Deployment And Service Readiness Probes",
+      "dependencies": [
+        "03"
+      ]
+    },
+    {
+      "id": "06",
+      "name": "Live Integration Runner And Evidence Bundle",
+      "dependencies": [
+        "04",
+        "05"
+      ]
+    },
+    {
+      "id": "07",
+      "name": "Documentation And Readiness Synchronization",
+      "dependencies": [
+        "06"
+      ]
+    },
+    {
+      "id": "08",
+      "name": "Controlled Live Verification",
+      "dependencies": [
+        "07"
+      ]
+    }
+  ],
   "governingHashes": [
     {
       "path": "AGENTS.md",
@@ -85,8 +146,8 @@
       "sha256": "b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816"
     },
     {
-      "path": ".agents/orchestrator/routing-rules.md",
-      "sha256": "a524843f96fa91adc56cbe8b02156abc56a299b263eb8ad6715204bee52cfd31"
+      "path": "OPERATIONAL_READINESS_CHECKLIST.md",
+      "sha256": "bcc8dd6c332e94405d8f8aa471134b4cb319058fcc837cfc597d262ac561a94d"
     },
     {
       "path": ".agents/skills/workflow-authoring/SKILL.md",
@@ -97,31 +158,25 @@
       "sha256": "23de7d9aac9d2694eae26fac2765d65f369c101ac348dac24d5f3bbe9e2d3ba4"
     },
     {
-      "path": ".agents/skills/execution-profile-router/SKILL.md",
-      "sha256": "a1e1195387d55b8ba3baa6b5a891aac982f6ffc734a80c1ab32dc594d4cfc51b"
+      "path": ".agents/skills/quality-gate-orchestrator/SKILL.md",
+      "sha256": "3f9ef8278091f7781eacd58d000675fa6a996d81f96802a0abd37cc2a821d40f"
     },
     {
-      "path": ".agents/skills/quality-gate/SKILL.md",
-      "sha256": "90fe1c9de050f21cb8635fab1b498b93439fffdc050d3b7ceb04bd8d2deea174"
+      "path": "documentation/architecture/adr-separate-platform-artifacts-deployment.adoc",
+      "sha256": "e93d07dc6ce9485208a40d77b6a2c52a5d5442f36845192eac0963a86dc00297"
     },
     {
-      "path": ".agents/skills/quality-architecture-validation/SKILL.md",
-      "sha256": "a00a8e7e2ea24c4878533272f0f98b687156e0279a8fa84f67676248b8000e78"
-    },
-    {
-      "path": ".importlinter",
-      "sha256": "4c5c879ddc20bf7ccb8adca2b907538264f9c3cf9c1c54e3076e7c008f1a62b4"
-    },
-    {
-      "path": "tools/quality_gate.py",
-      "sha256": "89425bfc2348fcbc9948a6f654d00fa80aeaa03ce46403912fbb207d137fe0ea"
+      "path": "src/tiny_swarm_world/__main__.py",
+      "sha256": "543c594c9df79faf04e83abcdc1182f05771c16494d48dd5a30cee73a05d2947"
     }
   ],
   "staleWhen": [
     "any recorded governing hash changes",
-    "documentation/workflow/** changes outside the active slice",
+    "documentation/workflow/** changes outside the active workflow branch",
     "AGENTS.md or QUALITY.md changes",
-    "a deleted TASKLIST.md entry cannot be traced through the workflow",
-    "workflow execution changes architecture, quality, live-infra or secret handling policy without updating the workflow"
+    "live integration commands are implemented without updating this workflow",
+    "mandatory service scope changes",
+    "secret handling or destructive cleanup policy changes",
+    "arc42 runtime, deployment, quality or risk sections are updated without checking this workflow"
   ]
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -22,6 +22,11 @@ workflow that verifies complete installation and complete functionality, with
 self-remediation for blockers that are at least 90 percent solvable and Three
 Amigos Q&A escalation otherwise.
 
+Until a dedicated EPIC exists, the temporary requirement baseline is the user
+request, root `AGENTS.md`, root `QUALITY.md`, `AUDIT_REPORT.md`,
+`OPERATIONAL_READINESS_CHECKLIST.md`, the active workflow requirement record
+and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`.
+
 ## Verified Baseline
 
 - The default quality gate is `python3 tools/quality_gate.py quality`.
@@ -32,6 +37,9 @@ Amigos Q&A escalation otherwise.
   tests, observability and documentation.
 - The current entrypoint exposes explicit service-level commands, not a proven
   full-installation command.
+- Slice 01 defines live consent, refusal, evidence bundle, redaction,
+  credential-source and resource-gating contracts for later implementation
+  slices.
 
 ## Affected Areas
 
@@ -105,7 +113,7 @@ commands until their implementation slice adds them.
 | `AGENTS.md` | `6c0995195e99a2a748ad63d065706c35341977388d3c1c4402a548b388a4755e` |
 | `QUALITY.md` | `d327e4060ff1729f17ffde844b1a2d6208fe203e149ae9d1af185bef0aed2155` |
 | `AUDIT_REPORT.md` | `b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816` |
-| `OPERATIONAL_READINESS_CHECKLIST.md` | `bcc8dd6c332e94405d8f8aa471134b4cb319058fcc837cfc597d262ac561a94d` |
+| `OPERATIONAL_READINESS_CHECKLIST.md` | `d8e54cd328674c8ce4e6237abadf86346f5f00a0e6333677e2214881e159ddd7` |
 | `.agents/skills/workflow-authoring/SKILL.md` | `087658240296e3b1ec74205c60a96a9a4c67a17cf653f7867e6f316bd9afa94e` |
 | `.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md` | `23de7d9aac9d2694eae26fac2765d65f369c101ac348dac24d5f3bbe9e2d3ba4` |
 | `.agents/skills/quality-gate-orchestrator/SKILL.md` | `3f9ef8278091f7781eacd58d000675fa6a996d81f96802a0abd37cc2a821d40f` |

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -2,49 +2,61 @@
 
 ## Workflow Identity
 
-- Workflow version: `tasklist-remediation-20260523`
-- Workflow branch: `architecture/workflow-tasklist-remediation-20260523`
+- Workflow version: `installation-integration-verification-20260523`
+- Workflow branch: `docs/workflow-installation-integration-test-20260523`
 - Process strand: `workflow create`
 - Execution profile: `FULL_PATH`
 - Created on: `2026-05-23`
 
 ## Purpose
 
-This context pack records the governing inputs used to convert `TASKLIST.md`
-into the active remediation workflow and remove the stale task-list artifact.
-It is a navigation aid only. Root `AGENTS.md`, `QUALITY.md`, the active workflow
-and repository files remain authoritative.
+This context pack records the governing inputs used to create the full
+installation integration-verification workflow. It is a navigation aid only.
+Root `AGENTS.md`, `QUALITY.md`, ADRs, arc42 and repository files remain
+authoritative.
 
-## Converted Source Artifacts
+## Requirement Source
 
-| Artifact | Status | SHA-256 |
-|---|---|---|
-| `TASKLIST.md` | converted and deleted | `96295c760ceaee6217e7987ff0b7bbd034479332d3f3d8341d2bcc4e55df9f48` |
-| `AUDIT_REPORT.md` | retained as audit evidence | `b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816` |
+The workflow was created from the user request to define an integration test
+workflow that verifies complete installation and complete functionality, with
+self-remediation for blockers that are at least 90 percent solvable and Three
+Amigos Q&A escalation otherwise.
+
+## Verified Baseline
+
+- The default quality gate is `python3 tools/quality_gate.py quality`.
+- The default quality gate must not run live infrastructure.
+- `AUDIT_REPORT.md` records missing live Multipass/Docker/Swarm evidence.
+- `OPERATIONAL_READINESS_CHECKLIST.md` records open readiness checks for host,
+  VM, network, Docker, Swarm, stack deployment, service reachability, smoke
+  tests, observability and documentation.
+- The current entrypoint exposes explicit service-level commands, not a proven
+  full-installation command.
 
 ## Affected Areas
 
 - `documentation/workflow`
-- `src/tiny_swarm_world`
-- `infra`
-- `tests`
+- `OPERATIONAL_READINESS_CHECKLIST.md`
 - `README.md`
 - `documentation`
-- `QUALITY.md` only if a later slice explicitly changes quality policy
-- `tools/quality_gate.py` only if a later slice explicitly changes gate
-  behavior
+- `src/tiny_swarm_world`
+- `infra/config`
+- `infra/compose`
+- `infra/prepare`
+- `tools`
+- `tests`
 
 ## Forbidden Areas Without Refinement
 
 - `src/main/java/**`
-- live Multipass execution
-- live Docker Swarm execution
-- compose deployments
-- netplan mutation
-- `socat` forwarding
-- service bootstrap scripts
-- frontend package/tooling creation
-- restoring `TASKLIST.md` as an active planning artifact
+- Windows-native runtime support
+- default CI execution of live Multipass or Docker Swarm
+- committed secrets or hardcoded credentials
+- implicit destructive VM, stack or network cleanup
+- live Multipass execution before explicit live-run approval
+- live Docker Swarm execution before explicit live-run approval
+- netplan or socat mutation before explicit live-run approval
+- service bootstrap before explicit live-run approval
 
 ## Required Roles
 
@@ -54,13 +66,15 @@ and repository files remain authoritative.
 - Senior React Frontend Developer
 - Senior Tester
 - Senior DevOps Engineer
+- Senior Security Sandbox Engineer
 - Senior Documentation Engineer
 
 ## Conditional Roles
 
-- Senior Security Sandbox Engineer for secret handling and live-infra safety.
-- Senior Bash Specialist if the previous Bash specialist workflow has been
-  executed and the role exists.
+- Senior Workflow Architect when slice dependency changes are requested.
+- Release and Branch Governance before commit, push or PR.
+- Security Threat Modeling if secret handling or exposed service defaults
+  change.
 
 ## Quality Commands
 
@@ -74,11 +88,15 @@ python3 tools/quality_gate.py test
 python3 tools/quality_gate.py quality
 ```
 
-Optional shell syntax check for shell slices:
+Workflow-creation checks:
 
 ```bash
-find infra -name '*.sh' -print0 | xargs -0 bash -n
+git diff --check
+python3 -m json.tool documentation/workflow/context-pack.json
 ```
+
+Live integration commands are planned artifacts and are not current quality-gate
+commands until their implementation slice adds them.
 
 ## Governing Hashes
 
@@ -87,22 +105,22 @@ find infra -name '*.sh' -print0 | xargs -0 bash -n
 | `AGENTS.md` | `6c0995195e99a2a748ad63d065706c35341977388d3c1c4402a548b388a4755e` |
 | `QUALITY.md` | `d327e4060ff1729f17ffde844b1a2d6208fe203e149ae9d1af185bef0aed2155` |
 | `AUDIT_REPORT.md` | `b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816` |
-| `.agents/orchestrator/routing-rules.md` | `a524843f96fa91adc56cbe8b02156abc56a299b263eb8ad6715204bee52cfd31` |
+| `OPERATIONAL_READINESS_CHECKLIST.md` | `bcc8dd6c332e94405d8f8aa471134b4cb319058fcc837cfc597d262ac561a94d` |
 | `.agents/skills/workflow-authoring/SKILL.md` | `087658240296e3b1ec74205c60a96a9a4c67a17cf653f7867e6f316bd9afa94e` |
 | `.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md` | `23de7d9aac9d2694eae26fac2765d65f369c101ac348dac24d5f3bbe9e2d3ba4` |
-| `.agents/skills/execution-profile-router/SKILL.md` | `a1e1195387d55b8ba3baa6b5a891aac982f6ffc734a80c1ab32dc594d4cfc51b` |
-| `.agents/skills/quality-gate/SKILL.md` | `90fe1c9de050f21cb8635fab1b498b93439fffdc050d3b7ceb04bd8d2deea174` |
-| `.agents/skills/quality-architecture-validation/SKILL.md` | `a00a8e7e2ea24c4878533272f0f98b687156e0279a8fa84f67676248b8000e78` |
-| `.importlinter` | `4c5c879ddc20bf7ccb8adca2b907538264f9c3cf9c1c54e3076e7c008f1a62b4` |
-| `tools/quality_gate.py` | `89425bfc2348fcbc9948a6f654d00fa80aeaa03ce46403912fbb207d137fe0ea` |
+| `.agents/skills/quality-gate-orchestrator/SKILL.md` | `3f9ef8278091f7781eacd58d000675fa6a996d81f96802a0abd37cc2a821d40f` |
+| `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc` | `e93d07dc6ce9485208a40d77b6a2c52a5d5442f36845192eac0963a86dc00297` |
+| `src/tiny_swarm_world/__main__.py` | `543c594c9df79faf04e83abcdc1182f05771c16494d48dd5a30cee73a05d2947` |
 
 ## Staleness Rules
 
 This context pack is stale when:
 
 - any recorded governing hash changes;
-- `documentation/workflow/**` changes outside the active slice;
+- `documentation/workflow/**` changes outside the active workflow branch;
 - `AGENTS.md` or `QUALITY.md` changes;
-- a deleted `TASKLIST.md` entry cannot be traced through the workflow;
-- workflow execution changes architecture, quality, live-infra or secret
-  handling policy without updating the workflow.
+- live integration commands are implemented without updating this workflow;
+- mandatory service scope changes;
+- secret handling or destructive cleanup policy changes;
+- arc42 runtime, deployment, quality or risk sections are updated without
+  checking this workflow.

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -2,56 +2,71 @@
 
 ## Workflow Identity
 
-- Workflow version: `installation-integration-verification-20260523`
-- Workflow branch: `docs/workflow-installation-integration-test-20260523`
+- Workflow version: `init-safety-boundary-separation-20260523`
+- Workflow branch: `architecture/workflow-init-service-boundaries-20260523`
 - Process strand: `workflow create`
 - Execution profile: `FULL_PATH`
 - Created on: `2026-05-23`
 
 ## Purpose
 
-This context pack records the governing inputs used to create the full
-installation integration-verification workflow. It is a navigation aid only.
-Root `AGENTS.md`, `QUALITY.md`, ADRs, arc42 and repository files remain
-authoritative.
+This context pack records the governing inputs used to create the workflow for
+non-destructive init, separated reconcile/reset/destroy workflows, real
+Platform/Artifacts/Deployment service boundaries, workflow-level CLI, Nexus
+stack deployment extraction, typed command YAMLs, state/inventory modeling and
+verify-after-apply enforcement.
+
+It is a navigation aid only. Root `AGENTS.md`, `QUALITY.md`, ADRs, arc42,
+repository source and workflow files remain authoritative.
 
 ## Requirement Source
 
-The workflow was created from the user request to define an integration test
-workflow that verifies complete installation and complete functionality, with
-self-remediation for blockers that are at least 90 percent solvable and Three
-Amigos Q&A escalation otherwise.
+The workflow was created from the user request:
 
-Until a dedicated EPIC exists, the temporary requirement baseline is the user
-request, root `AGENTS.md`, root `QUALITY.md`, `AUDIT_REPORT.md`,
-`OPERATIONAL_READINESS_CHECKLIST.md`, the active workflow requirement record
-and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`.
+- remove destructive VM cleanup from normal init;
+- introduce reconcile/reset/destroy as separate workflows;
+- truly separate PlatformServices, ArtifactServices and DeploymentServices;
+- rebuild the CLI around workflow-level commands;
+- extract Nexus stack deployment from Artifacts/Nexus;
+- strengthen command YAML typing;
+- introduce a state/inventory model;
+- force verify steps after every apply;
+- use subagent review during workflow creation.
+
+No dedicated EPIC exists under `documentation/epics`. The temporary baseline is
+the user request, `AGENTS.md`, `QUALITY.md`, subagent review output, current
+architecture docs, arc42 and the proposed Platform/Artifacts/Deployment ADR.
 
 ## Verified Baseline
 
-- The default quality gate is `python3 tools/quality_gate.py quality`.
-- The default quality gate must not run live infrastructure.
-- `AUDIT_REPORT.md` records missing live Multipass/Docker/Swarm evidence.
-- `OPERATIONAL_READINESS_CHECKLIST.md` records open readiness checks for host,
-  VM, network, Docker, Swarm, stack deployment, service reachability, smoke
-  tests, observability and documentation.
-- The current entrypoint exposes explicit service-level commands, not a proven
-  full-installation command.
-- Slice 01 defines live consent, refusal, evidence bundle, redaction,
-  credential-source and resource-gating contracts for later implementation
-  slices.
+- Default quality gate: `python3 tools/quality_gate.py quality`.
+- Default quality gate must not run live infrastructure.
+- Normal init currently calls the Multipass cleanup command YAML.
+- The cleanup command YAML contains `multipass delete --all` and
+  `multipass purge`.
+- Composition currently exposes platform services only.
+- CLI currently exposes low-level service choices.
+- Nexus stack deployment currently lives under Nexus service code.
+- Command YAML validation is not yet a typed schema contract.
+- Desired inventory and observed runtime state are not yet separated.
+- Netplan apply has no mandatory typed verification gate.
 
 ## Affected Areas
 
 - `documentation/workflow`
-- `OPERATIONAL_READINESS_CHECKLIST.md`
+- `documentation/architecture`
+- `documentation/arc42`
 - `README.md`
-- `documentation`
-- `src/tiny_swarm_world`
+- `documentation/user_guide`
+- `src/tiny_swarm_world/__main__.py`
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/domain`
+- `src/tiny_swarm_world/application`
+- `src/tiny_swarm_world/infrastructure/adapters`
 - `infra/config`
 - `infra/compose`
 - `infra/prepare`
-- `tools`
+- `infra/swarm`
 - `tests`
 
 ## Forbidden Areas Without Refinement
@@ -59,12 +74,13 @@ and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`
 - `src/main/java/**`
 - Windows-native runtime support
 - default CI execution of live Multipass or Docker Swarm
-- committed secrets or hardcoded credentials
-- implicit destructive VM, stack or network cleanup
-- live Multipass execution before explicit live-run approval
-- live Docker Swarm execution before explicit live-run approval
-- netplan or socat mutation before explicit live-run approval
-- service bootstrap before explicit live-run approval
+- committed secrets, observed runtime state, local evidence or host-specific
+  absolute paths
+- implicit VM deletion or purge in `init` or `reconcile`
+- treating Platform, Artifacts and Deployment as independently deployable
+  microservices without runtime evidence
+- live Multipass, Docker Swarm, netplan, socat, compose, Portainer, Nexus,
+  Jenkins, RabbitMQ, SonarQube or Swagger/NGINX commands
 
 ## Required Roles
 
@@ -73,62 +89,95 @@ and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`
 - Senior Python Automation Developer
 - Senior React Frontend Developer
 - Senior Tester
-- Senior DevOps Engineer
 - Senior Security Sandbox Engineer
 - Senior Documentation Engineer
+- Senior Workflow Architect
 
 ## Conditional Roles
 
-- Senior Workflow Architect when slice dependency changes are requested.
+- Senior DevOps Engineer for shell/script and live-operation safety review.
 - Release and Branch Governance before commit, push or PR.
-- Security Threat Modeling if secret handling or exposed service defaults
-  change.
+- Security Threat Modeling if reset/destroy confirmation or secret handling is
+  changed.
 
 ## Quality Commands
 
-```bash
-git diff --check
-python3 tools/quality_gate.py lint
-python3 tools/quality_gate.py arch-lint
-python3 tools/quality_gate.py arch-tests
-python3 tools/quality_gate.py typecheck
-python3 tools/quality_gate.py test
-python3 tools/quality_gate.py quality
-```
-
-Workflow-creation checks:
+Workflow creation:
 
 ```bash
 git diff --check
 python3 -m json.tool documentation/workflow/context-pack.json
 ```
 
-Live integration commands are planned artifacts and are not current quality-gate
-commands until their implementation slice adds them.
+Targeted development gates:
+
+```bash
+python3 tools/quality_gate.py lint
+python3 tools/quality_gate.py arch-lint
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py typecheck
+python3 tools/quality_gate.py test
+```
+
+Final implementation gate:
+
+```bash
+python3 tools/quality_gate.py quality
+```
+
+## Slice Summary
+
+| Slice | Name | Dependencies |
+| --- | --- | --- |
+| 01 | Requirement And Safety Contract | none |
+| 02 | ADR And arc42 Baseline | 01 |
+| 03 | Typed Command YAML Contract | 01, 02 |
+| 04 | State And Inventory Model | 01, 02 |
+| 05 | Workflow Taxonomy And Non-Destructive Init | 03, 04 |
+| 06 | Service Wiring Separation | 02, 04 |
+| 07 | Nexus Stack Deployment Extraction | 06 |
+| 08 | Workflow-Level CLI | 05, 06, 07 |
+| 09 | Verify After Every Apply | 03, 04, 05, 07, 08 |
+| 10 | Documentation, Quality Sync, And Legacy Quarantine | 02-09 |
 
 ## Governing Hashes
 
 | Path | SHA-256 |
-|---|---|
+| --- | --- |
 | `AGENTS.md` | `6c0995195e99a2a748ad63d065706c35341977388d3c1c4402a548b388a4755e` |
 | `QUALITY.md` | `d327e4060ff1729f17ffde844b1a2d6208fe203e149ae9d1af185bef0aed2155` |
-| `AUDIT_REPORT.md` | `b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816` |
-| `OPERATIONAL_READINESS_CHECKLIST.md` | `d8e54cd328674c8ce4e6237abadf86346f5f00a0e6333677e2214881e159ddd7` |
 | `.agents/skills/workflow-authoring/SKILL.md` | `087658240296e3b1ec74205c60a96a9a4c67a17cf653f7867e6f316bd9afa94e` |
 | `.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md` | `23de7d9aac9d2694eae26fac2765d65f369c101ac348dac24d5f3bbe9e2d3ba4` |
-| `.agents/skills/quality-gate-orchestrator/SKILL.md` | `3f9ef8278091f7781eacd58d000675fa6a996d81f96802a0abd37cc2a821d40f` |
+| `.agents/skills/swarm-coordination/SKILL.md` | `8e6d032e4b609212ad7229b26fe1aa72af4afc0d6594a01cc945053a0b3e9ba7` |
 | `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc` | `e93d07dc6ce9485208a40d77b6a2c52a5d5442f36845192eac0963a86dc00297` |
-| `src/tiny_swarm_world/__main__.py` | `543c594c9df79faf04e83abcdc1182f05771c16494d48dd5a30cee73a05d2947` |
+| `documentation/architecture/migration-plan.md` | `dbf5618e62b96935b669cf880b3be84710c8a29ba7ce9a4f4aaf08ccf5a21e2f` |
+| `documentation/architecture/responsibility-separation-analysis.md` | `38b08d772951f87b168f9432a8aadbd8b3705d5fedd2cc8511c8ad4a36eec078` |
+| `src/tiny_swarm_world/__main__.py` | `5cf743ac4c186418a2e649458965b917e52f9cd78605c2eb3cf55febd7e7f4e3` |
+| `src/tiny_swarm_world/infrastructure/composition.py` | `67aae1f2cf4a769500b16e27d2551981568a01fc24cc3b39d26eee05e111339a` |
+| `src/tiny_swarm_world/application/services/multipass/multipass_init_vms.py` | `bc65b41f859e99eb7ff5ce8d6d59c33e062d1358a89588eb133735383f149b79` |
+| `infra/config/multipass/command_multipass_clean_repository_yaml.yaml` | `bb483b476e21b225971051c07515948b33ab53a1778bbe1a2d62761361ed2deb` |
+| `infra/config/network/netplant/command_netplant_setup_yaml.yaml` | `614f6206b97de2cd0e31c60986cddc5ef5dba759c2856ca8f6eb0e730c4670e4` |
+| `tests/architecture/test_hexagonal_imports.py` | `1d9a78e08bc3f8f893ca0343d3bd2aaf544c997e09278345f5472b70114cc0be` |
+| `tests/architecture/test_infra_responsibility_boundaries.py` | `973b13559bf11304a0023713a4cf842d223962309198660f710598d37bd97ba8` |
+
+## Worktree Caveat
+
+During workflow creation, uncommitted source/preflight changes appeared outside
+`documentation/workflow/**`. This workflow authoring step did not edit those
+files. Workflow execution must inspect and resolve ownership before any slice
+touches overlapping paths.
 
 ## Staleness Rules
 
 This context pack is stale when:
 
 - any recorded governing hash changes;
-- `documentation/workflow/**` changes outside the active workflow branch;
 - `AGENTS.md` or `QUALITY.md` changes;
-- live integration commands are implemented without updating this workflow;
-- mandatory service scope changes;
-- secret handling or destructive cleanup policy changes;
-- arc42 runtime, deployment, quality or risk sections are updated without
+- the responsibility ADR is accepted, superseded or edited;
+- command YAML schema, destructive-operation policy, inventory model or CLI
+  workflow contract changes;
+- `documentation/workflow/**` changes outside the active workflow branch;
+- source/preflight worktree changes overlap an implementation slice without a
+  recorded handoff;
+- arc42 runtime, deployment, concept, quality or risk sections change without
   checking this workflow.

--- a/documentation/workflow/execution-report.md
+++ b/documentation/workflow/execution-report.md
@@ -1,77 +1,66 @@
 # Workflow Execution Report
 
-Workflow version: `tasklist-remediation-20260523`
-Workflow branch: `architecture/workflow-tasklist-remediation-20260523`
+## Status
 
-## Slice 01: Baseline, Entrypoint And Failure Semantics
+- Workflow: `installation-integration-verification-20260523`
+- Branch: `docs/workflow-installation-integration-test-20260523`
+- Status: `CREATED_NOT_EXECUTED`
+- Created on: `2026-05-23`
 
-Status: `completed`
+## Creation Summary
 
-Responsible role:
+The active workflow was regenerated to define a full installation integration
+verification path. No live Multipass, Docker Swarm, netplan, socat, compose
+deployment or service bootstrap command was executed during workflow creation.
 
-- Senior Python Automation Developer
+## Requirement Gate Decision
 
-Subagent reviews:
+```text
+READY_FOR_WORKFLOW
+```
 
-- Senior Swarm Orchestrator: S3D metadata and ordering reviewed.
-- Senior System Architect: architecture-sensitive Slice 01 repair reviewed.
-- Senior Python Automation Developer: smallest safe implementation reviewed.
-- Senior Tester: Slice 01 test strategy reviewed.
+Confidence:
 
-Changed files:
+- 92 percent for workflow creation.
+- Live execution remains gated because host state, secrets, resource policy and
+  cleanup consent are environment-specific.
 
-- `README.md`
-- `src/tiny_swarm_world/__main__.py`
-- `src/tiny_swarm_world/application/ports/commands/executable_command.py`
-- `src/tiny_swarm_world/application/ports/commands/parameter_type.py`
-- `src/tiny_swarm_world/application/ports/commands/port_command_workflow.py`
-- `src/tiny_swarm_world/application/services/commands/command_builder/vm_parameter/**`
-- `src/tiny_swarm_world/application/services/commands/command_executer/**`
-- `src/tiny_swarm_world/application/services/multipass/multipass_docker_swarm_init.py`
-- `src/tiny_swarm_world/application/services/vm/**`
-- `src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py`
-- `src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py`
-- `src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py`
-- `tests/architecture/test_hexagonal_imports.py`
-- `tests/application/services/commands/test_command_executer.py`
-- `tests/infrastructure/adapters/command_runner/test_command_workflow_configuration.py`
-- `tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py`
-- `tests/test_package_entrypoint.py`
+## Created Artifacts
 
-Quality-gate commands:
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `documentation/workflow/execution-report.md`
 
-- `PYTHONPATH=src python3 -m tiny_swarm_world`: pass
-- `PYTHONPATH=src python3 -m tiny_swarm_world --list-services`: pass
-- `PYTHONPATH=src python3 -m unittest tests.test_package_entrypoint tests.application.services.commands.test_command_executer tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics tests.infrastructure.test_composition tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.command_runner.test_command_workflow_configuration tests.application.services.platform.test_platform_service_exports tests.architecture.test_legacy_surface_documentation tests.architecture.test_hexagonal_imports`: pass
-- `git diff --check`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py lint`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py arch-lint`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py arch-tests`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py typecheck`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py test`: pass
-- `/tmp/tiny-swarm-world-quality-venv/bin/python tools/quality_gate.py quality`: pass
+## Commands To Verify Creation
 
-Quality-gate result: `pass`
+```bash
+git diff --check
+python3 -m json.tool documentation/workflow/context-pack.json
+```
 
-Rollback reference:
+Result:
 
-- Previous checkpoint before Slice 01: `adf7065`
-- Checkpoint commit: recorded by Git history for this slice checkpoint.
+- `git diff --check`: passed.
+- `python3 -m json.tool documentation/workflow/context-pack.json`: passed.
 
-arc42 update status:
+## Live Execution Status
 
-- `not changed`
-- Rationale: Slice 01 verifies and repairs entrypoint/failure semantics and
-  preserves existing architecture boundaries. No new runtime topology or
-  deployment behavior was introduced.
+Live execution has not started. Workflow execution must complete Slices 01
+through 07 and obtain explicit live-run approval before Slice 08 can run.
 
-ADR update status:
+## Blockers
 
-- `not required`
-- Rationale: The entrypoint now requires explicit service selection, and
-  command failures propagate instead of being hidden. This refines existing
-  behavior without changing an architectural decision.
+No blockers remain for workflow creation.
 
-Push result:
+Potential blockers for future execution:
 
-- Pending until Slice 01 checkpoint commit is pushed.
+- missing Multipass or Docker on the host;
+- insufficient CPU, memory or disk for all services;
+- missing secrets or unsafe default credentials;
+- ambiguous mandatory service scope under constrained host resources;
+- non-idempotent VM, Swarm or stack behavior discovered during implementation.
+
+If a future blocker cannot be solved with at least 90 percent confidence, the
+executor must stop and record Three Amigos questions in this report before
+continuing.

--- a/documentation/workflow/execution-report.md
+++ b/documentation/workflow/execution-report.md
@@ -64,3 +64,76 @@ Potential blockers for future execution:
 If a future blocker cannot be solved with at least 90 percent confidence, the
 executor must stop and record Three Amigos questions in this report before
 continuing.
+
+## Slice 01: Integration Test Contract
+
+Status: `completed`
+
+Responsible role:
+
+- Senior Requirement Engineer
+
+Subagent reviews:
+
+- Senior Swarm Orchestrator: S3D returned `EXECUTION_PLAN`; Slice 01 is first
+  executable slice, dependency-free, with no lock conflict.
+- Senior Requirement Engineer: follow-up review returned `READY` after the
+  temporary requirement baseline, resource-gated semantics, consent contract,
+  evidence bundle and checklist alignment were documented.
+- Senior System Architect: follow-up review returned `READY`; changes remain
+  inside `documentation/workflow/**` and `OPERATIONAL_READINESS_CHECKLIST.md`.
+- Senior Security Sandbox Engineer: follow-up review returned `READY`; live
+  consent, refusal, redaction, evidence and credential-source rules are
+  concrete.
+- Senior Tester: review returned `READY`; documentation-only gate is sufficient
+  for Slice 01 and the full Python gate is not claimed.
+
+Changed files:
+
+- `OPERATIONAL_READINESS_CHECKLIST.md`
+- `documentation/workflow/context-pack.json`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/execution-report.md`
+- `documentation/workflow/workflow.md`
+
+Quality-gate commands:
+
+- `git diff --check`: pass
+- `python3 -m json.tool documentation/workflow/context-pack.json`: pass
+
+Quality-gate result: `pass`
+
+Skipped checks:
+
+- `python3 tools/quality_gate.py quality`: skipped because Slice 01 is
+  documentation/readiness-only and the slice-required D8 gate is
+  `git diff --check`.
+
+Live infrastructure:
+
+- Not run. No Multipass, Docker Swarm, netplan, socat, compose/stack or
+  service bootstrap command was executed.
+
+Rollback reference:
+
+- Previous checkpoint before Slice 01: `2b14c5c`
+
+Checkpoint commit:
+
+- Pending until the Slice 01 checkpoint commit is created.
+
+arc42 update status:
+
+- `checked, not changed`
+- Rationale: Slice 01 clarifies integration-test contracts and live-safety
+  semantics. It does not change runtime topology or architecture decisions.
+
+ADR update status:
+
+- `checked, not changed`
+- Rationale: The existing platform/artifacts/deployment responsibility ADR
+  remains compatible with the Slice 01 contract.
+
+Push result:
+
+- Pending until the Slice 01 checkpoint commit is pushed.

--- a/documentation/workflow/execution-report.md
+++ b/documentation/workflow/execution-report.md
@@ -120,7 +120,7 @@ Rollback reference:
 
 Checkpoint commit:
 
-- Pending until the Slice 01 checkpoint commit is created.
+- `31f6e12`
 
 arc42 update status:
 
@@ -136,4 +136,5 @@ ADR update status:
 
 Push result:
 
-- Pending until the Slice 01 checkpoint commit is pushed.
+- `git push origin HEAD:docs/workflow-installation-integration-test-20260523`:
+  pass

--- a/documentation/workflow/execution-report.md
+++ b/documentation/workflow/execution-report.md
@@ -2,16 +2,40 @@
 
 ## Status
 
-- Workflow: `installation-integration-verification-20260523`
-- Branch: `docs/workflow-installation-integration-test-20260523`
+- Workflow: `init-safety-boundary-separation-20260523`
+- Branch: `architecture/workflow-init-service-boundaries-20260523`
 - Status: `CREATED_NOT_EXECUTED`
 - Created on: `2026-05-23`
 
 ## Creation Summary
 
-The active workflow was regenerated to define a full installation integration
-verification path. No live Multipass, Docker Swarm, netplan, socat, compose
-deployment or service bootstrap command was executed during workflow creation.
+The active workflow was regenerated for the user request to remove destructive
+cleanup from normal init, split reconcile/reset/destroy workflows, separate
+Platform/Artifacts/Deployment services, move the CLI to workflow level, extract
+Nexus stack deployment, type command YAMLs, introduce state/inventory, and
+enforce verify-after-apply.
+
+No live Multipass, Docker Swarm, netplan, socat, compose, Portainer, Nexus,
+Jenkins, RabbitMQ, SonarQube, or Swagger/NGINX command was executed during
+workflow creation.
+
+## Branch Verification
+
+- Dedicated branch created and active:
+  `architecture/workflow-init-service-boundaries-20260523`
+- Local ref verification succeeded before workflow artifacts were written.
+- Active branch verification succeeded before workflow artifacts were written.
+
+## Regenerated Artifacts
+
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `documentation/workflow/execution-report.md`
+
+The previous `documentation/workflow` contents belonged to a different workflow
+version. They were replaced on this workflow branch according to the
+workflow-authoring regeneration rule.
 
 ## Requirement Gate Decision
 
@@ -21,120 +45,99 @@ READY_FOR_WORKFLOW
 
 Confidence:
 
-- 92 percent for workflow creation.
-- Live execution remains gated because host state, secrets, resource policy and
-  cleanup consent are environment-specific.
+- 91 percent for workflow creation.
+- Implementation remains gated by Slice 01 because reset/destroy confirmation
+  and retention semantics must be finalized before destructive code changes.
 
-## Created Artifacts
+EPIC traceability:
 
-- `documentation/workflow/workflow.md`
-- `documentation/workflow/context-pack.md`
-- `documentation/workflow/context-pack.json`
-- `documentation/workflow/execution-report.md`
+- No `documentation/epics` files exist.
+- The workflow records this as a traceability gap and uses the user request,
+  root `AGENTS.md`, root `QUALITY.md`, architecture docs, arc42, ADR and
+  subagent reviews as the temporary baseline.
 
-## Commands To Verify Creation
+## Subagent Reviews
+
+Read-only subagent reviews completed:
+
+- Senior Requirement Engineer: completed.
+- Senior System Architect: completed.
+- Senior Python Automation Developer: completed.
+- Senior React Frontend Developer: completed.
+- Senior Tester: completed.
+
+Subagents reported no live infrastructure execution.
+
+## Worktree Note
+
+During workflow creation, uncommitted source/preflight changes appeared outside
+`documentation/workflow/**`:
+
+- `src/tiny_swarm_world/__main__.py`
+- `src/tiny_swarm_world/application/services/platform/__init__.py`
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/application/ports/preflight/**`
+- `src/tiny_swarm_world/application/services/platform/preflight_service.py`
+- `src/tiny_swarm_world/domain/preflight/**`
+- `src/tiny_swarm_world/infrastructure/adapters/preflight/**`
+- `tools/preflight.py`
+
+This workflow creation step did not edit those files. Workflow execution must
+treat them as existing user or parallel work and resolve ownership before any
+slice touches overlapping paths.
+
+## Ordered Slices
+
+1. Slice 01 - Requirement And Safety Contract
+2. Slice 02 - ADR And arc42 Baseline
+3. Slice 03 - Typed Command YAML Contract
+4. Slice 04 - State And Inventory Model
+5. Slice 05 - Workflow Taxonomy And Non-Destructive Init
+6. Slice 06 - Service Wiring Separation
+7. Slice 07 - Nexus Stack Deployment Extraction
+8. Slice 08 - Workflow-Level CLI
+9. Slice 09 - Verify After Every Apply
+10. Slice 10 - Documentation, Quality Sync, And Legacy Quarantine
+
+## Verification Plan
+
+Workflow creation checks:
 
 ```bash
 git diff --check
 python3 -m json.tool documentation/workflow/context-pack.json
 ```
 
-Result:
+Implementation final gate:
 
-- `git diff --check`: passed.
-- `python3 -m json.tool documentation/workflow/context-pack.json`: passed.
+```bash
+python3 tools/quality_gate.py quality
+```
 
 ## Live Execution Status
 
-Live execution has not started. Workflow execution must complete Slices 01
-through 07 and obtain explicit live-run approval before Slice 08 can run.
+Live execution has not started. Workflow execution must not run live
+infrastructure commands unless the user explicitly approves live infrastructure
+work in a later turn.
 
 ## Blockers
 
-No blockers remain for workflow creation.
+No blocker remains for workflow creation.
 
-Potential blockers for future execution:
+Execution blockers for implementation:
 
-- missing Multipass or Docker on the host;
-- insufficient CPU, memory or disk for all services;
-- missing secrets or unsafe default credentials;
-- ambiguous mandatory service scope under constrained host resources;
-- non-idempotent VM, Swarm or stack behavior discovered during implementation.
+- reset/destroy confirmation and retention semantics must be finalized in
+  Slice 01;
+- the Platform/Artifacts/Deployment ADR must be accepted or superseded before
+  boundary-moving source changes;
+- current source/preflight worktree changes need ownership review before slices
+  touch overlapping paths;
+- no implementation slice may run live infrastructure as a default quality
+  check.
 
-If a future blocker cannot be solved with at least 90 percent confidence, the
-executor must stop and record Three Amigos questions in this report before
-continuing.
-
-## Slice 01: Integration Test Contract
-
-Status: `completed`
-
-Responsible role:
-
-- Senior Requirement Engineer
-
-Subagent reviews:
-
-- Senior Swarm Orchestrator: S3D returned `EXECUTION_PLAN`; Slice 01 is first
-  executable slice, dependency-free, with no lock conflict.
-- Senior Requirement Engineer: follow-up review returned `READY` after the
-  temporary requirement baseline, resource-gated semantics, consent contract,
-  evidence bundle and checklist alignment were documented.
-- Senior System Architect: follow-up review returned `READY`; changes remain
-  inside `documentation/workflow/**` and `OPERATIONAL_READINESS_CHECKLIST.md`.
-- Senior Security Sandbox Engineer: follow-up review returned `READY`; live
-  consent, refusal, redaction, evidence and credential-source rules are
-  concrete.
-- Senior Tester: review returned `READY`; documentation-only gate is sufficient
-  for Slice 01 and the full Python gate is not claimed.
-
-Changed files:
-
-- `OPERATIONAL_READINESS_CHECKLIST.md`
-- `documentation/workflow/context-pack.json`
-- `documentation/workflow/context-pack.md`
-- `documentation/workflow/execution-report.md`
-- `documentation/workflow/workflow.md`
-
-Quality-gate commands:
-
-- `git diff --check`: pass
-- `python3 -m json.tool documentation/workflow/context-pack.json`: pass
-
-Quality-gate result: `pass`
-
-Skipped checks:
-
-- `python3 tools/quality_gate.py quality`: skipped because Slice 01 is
-  documentation/readiness-only and the slice-required D8 gate is
-  `git diff --check`.
-
-Live infrastructure:
-
-- Not run. No Multipass, Docker Swarm, netplan, socat, compose/stack or
-  service bootstrap command was executed.
-
-Rollback reference:
-
-- Previous checkpoint before Slice 01: `2b14c5c`
-
-Checkpoint commit:
-
-- `31f6e12`
-
-arc42 update status:
+## arc42 Update Status
 
 - `checked, not changed`
-- Rationale: Slice 01 clarifies integration-test contracts and live-safety
-  semantics. It does not change runtime topology or architecture decisions.
-
-ADR update status:
-
-- `checked, not changed`
-- Rationale: The existing platform/artifacts/deployment responsibility ADR
-  remains compatible with the Slice 01 contract.
-
-Push result:
-
-- `git push origin HEAD:docs/workflow-installation-integration-test-20260523`:
-  pass
+- Rationale: workflow creation changes planning artifacts only. Slice 02 owns
+  arc42 and ADR synchronization before implementation changes alter runtime or
+  responsibility behavior.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,54 +1,82 @@
-# Workflow: Tasklist Remediation Conversion
+# Workflow: Full Installation Integration Verification
 
 ## Executive Summary
 
-This workflow converts `TASKLIST.md` into the active governed remediation
-workflow for Tiny Swarm World. The original task list was derived from
-`AUDIT_REPORT.md`, but it contained stale `docker/` path assumptions,
-duplicated findings and obsolete `pytest -q` verification commands. This
-workflow preserves the useful audit intent, normalizes it to the current
-repository shape and removes `TASKLIST.md` after successful conversion.
+This workflow defines the governed path for creating and running an opt-in
+integration test that proves Tiny Swarm World can perform a complete local
+installation and verify full operational functionality.
 
-The active implementation baseline is Python automation under
-`src/tiny_swarm_world`, infrastructure assets under `infra`, tests under
-`tests`, documentation under `documentation` and quality gates from
-`QUALITY.md`.
+The target proof is not a mock-only quality gate. It must verify, with recorded
+evidence, that a Linux/WSL host can bootstrap Multipass VMs, configure
+networking, install Docker, initialize Docker Swarm, join workers, deploy the
+service stacks, and reach the expected services from the host.
 
-## Conversion Status
+The workflow does not execute live infrastructure during workflow creation.
+Live Multipass, Docker Swarm, netplan, socat and stack deployment commands stay
+behind an explicit opt-in gate during workflow execution.
 
-`TASKLIST.md` was successfully converted into this workflow and then removed
-from the repository so stale task planning does not compete with
-`documentation/workflow/**`.
+## Target Picture
 
-Original source hash:
+### Verified Baseline
 
-```text
-TASKLIST.md sha256=96295c760ceaee6217e7987ff0b7bbd034479332d3f3d8341d2bcc4e55df9f48
-AUDIT_REPORT.md sha256=b6714f0898a5ae2eca750516e920a1f412584f43ebc6e195b5d5d61c741c0816
-```
+- The repository default quality gate is `python3 tools/quality_gate.py quality`.
+- The default quality gate must not create VMs, change networking, deploy
+  Docker stacks or bootstrap local services.
+- `AUDIT_REPORT.md` records that full end-to-end operational readiness was not
+  verified and that live Multipass/Docker/Swarm evidence is missing.
+- `OPERATIONAL_READINESS_CHECKLIST.md` records open readiness items for host,
+  VM, network, Docker, Swarm, stack deployment, services, smoke tests,
+  observability and documentation.
+- The current package entrypoint exposes explicit service choices only:
+  `multipass-init-vms`, `network-prepare-netplan`, `network-setup-netplan`,
+  `multipass-restart-vms`, `multipass-docker-install`,
+  `multipass-docker-swarm-init` and `vm-ip-list`.
+- Service stack deployment exists as separate preparation or compose scripts,
+  not as a single verified canonical full-install command.
+
+### Target Outcome
+
+The completed workflow must produce:
+
+- a non-destructive live-test contract and preflight gate;
+- a canonical full-installation verification path;
+- deterministic evidence for every installation phase;
+- automated health checks for Docker Swarm and deployed services;
+- explicit remediation loops for blockers that can be solved with at least
+  90 percent confidence;
+- a Three Amigos question-answer escalation path for blockers that require
+  product, architecture or test clarification;
+- documentation that tells an operator how to run the full integration test and
+  interpret failures.
 
 ## Requirement Clarification Record
 
 Original request:
 
 ```text
-workflow create with subagents
-nachdem die Tasklist.md erfolgreich in einen workflow umgewandelt wurde, datei loeschen
+Erstelle einen workflow fuer einen Integrationstest, der eine vollstaendige
+Installations prueft, vollstaendige funktionsfaehigkeit. Falls blocker
+entstehen, diese vollstaendig selbst loesen wenn dies zu 90% moeglich ist,
+ansonsten rueckfragen stellen, damit ein 3 Amigo Frage Antwort prozess
+gestartet werden kann.
 ```
 
 Interpreted intent:
 
-- Convert `TASKLIST.md` into a complete executable workflow.
-- Preserve audit finding traceability from `AUDIT_REPORT.md`.
-- Normalize stale task assumptions before workflow execution.
-- Delete `TASKLIST.md` after successful conversion.
-- Use subagents for requirement, architecture, Python, testing, frontend and
-  DevOps review.
+- Create a repository workflow for an opt-in integration test that proves the
+  full installation and functional readiness of Tiny Swarm World.
+- Include all major operational phases from host readiness through service
+  reachability.
+- Make blocker handling explicit: self-remediate when confidence is at least
+  90 percent, otherwise stop and ask Three Amigos clarification questions.
+- Preserve root `AGENTS.md`, `QUALITY.md`, hexagonal architecture and live
+  infrastructure safety constraints.
 
 Change type:
 
-- Workflow creation and documentation governance.
-- Source planning artifact deletion after conversion.
+- Workflow creation and verification-governance planning.
+- Future implementation of integration-test harness, preflight checks,
+  live-test evidence capture and documentation.
 
 Affected process strand:
 
@@ -56,203 +84,234 @@ Affected process strand:
 
 Affected architecture area:
 
-- Python hexagonal automation governance.
-- Platform, networking, Docker, Swarm and deployment remediation planning.
-- Documentation and quality-gate governance.
+- Platform automation: Multipass, VM lifecycle, network, netplan, socat,
+  Docker install, Docker Swarm init and worker join.
+- Deployment automation: Portainer, compose stack deployment and service
+  reachability.
+- Shared automation: command workflow, YAML handling, logging, failure
+  propagation and evidence capture.
+- Documentation and operational readiness.
 
 Explicit requirements:
 
-- Use subagents.
-- Convert `TASKLIST.md` into a workflow.
-- Delete `TASKLIST.md` only after the conversion succeeds.
+- Create a workflow for a full installation integration test.
+- Verify complete functionality, not only command construction.
+- Resolve blockers completely when the solution path is at least 90 percent
+  clear.
+- Ask clarifying questions and start a Three Amigos Q&A process when blockers
+  cannot be solved confidently.
 
 Implicit requirements:
 
-- Preserve `AGENTS.md` and `QUALITY.md` authority.
-- Do not copy stale `docker/` and `pytest -q` assumptions into the active
-  workflow.
-- Collapse duplicated task-list entries into executable slices.
-- Keep live infrastructure commands disabled unless explicitly requested.
-- Keep Java deployment-example files out of this workflow unless a slice
-  explicitly targets them.
+- Do not run live infrastructure commands during normal development gates.
+- Make the integration test opt-in and visibly live/destructive-risk aware.
+- Separate preflight, dry-run/static checks and live execution.
+- Collect logs, command results and endpoint health evidence.
+- Keep the Python automation architecture hexagonal.
+- Keep `src/main/java` out of scope unless service reachability requires a
+  deployed example application in a later clarified workflow.
 
 Assumptions:
 
-- `AUDIT_REPORT.md` and the removed `TASKLIST.md` are intake evidence, not
-  verified current implementation truth.
-- No `documentation/epics` source exists. EPIC traceability is recorded as a
-  gap and does not block this workflow creation.
-- `docker/` is legacy audit context. Active remediation must verify current
-  paths before changing code.
-- The default quality gate is `python3 tools/quality_gate.py quality`.
+- "Complete installation" means the product scope described by the repository:
+  Multipass VMs, Docker Swarm and the supported service stacks.
+- "Complete functionality" means host reachability and runtime health for the
+  deployed local infrastructure services listed in README and AGENTS.md.
+- The integration test may add new opt-in tooling, but must not weaken the
+  default quality gate.
+- Live execution requires an explicit workflow-execution approval before any
+  Multipass, Docker Swarm, netplan, socat or stack deployment command runs.
 
 Non-goals:
 
-- No runtime implementation during workflow creation.
-- No live Multipass, Docker Swarm, compose deployment, netplan, `socat`,
-  Portainer, Nexus, Jenkins, RabbitMQ, SonarQube or Swagger/NGINX execution.
-- No direct preservation of duplicated task entries.
-- No required use of `pytest`.
-- No cleanup of legacy files before workflow execution proves references and
-  replacement paths.
+- No live infrastructure execution during workflow creation.
+- No Java deployment-example changes.
+- No cloud provider support.
+- No Windows-native PowerShell or backslash-path runtime model.
+- No default CI job that runs live Multipass or Docker Swarm.
+- No secret defaults committed to the repository.
 
 Risks:
 
-- The audit was written against an older repository shape.
-- Several original tasks referenced findings instead of concrete task or slice
-  IDs.
-- Placeholder commands such as `<canonical_entrypoint>` are not executable
-  acceptance criteria.
-- Live infrastructure behavior cannot be proven without explicit live-run
-  authorization.
-- arc42 runtime, deployment and risk sections remain placeholder-level.
+- Current orchestration is not proven end-to-end.
+- Some existing setup behavior may be destructive or not idempotent.
+- Stack deployment may require secret handling and Portainer initialization.
+- Network and port-forwarding behavior differs between native Linux and WSL.
+- Full live validation can be slow and host-dependent.
 
 Open questions:
 
-- Which future EPIC should own long-term operational-readiness remediation?
-- Which live infrastructure smoke tests should be authorized after mocked and
-  static gates pass?
+- Which services are mandatory for the first "full functionality" proof if a
+  host lacks resources for all stacks?
+- Should the live test require a clean host, or may it reconcile an existing
+  Tiny Swarm World environment?
+- Which cleanup mode is acceptable after a successful live run: preserve,
+  stop-only, or destroy?
 
 Blocking questions:
 
-- None for workflow creation. The open questions are recorded as traceability
-  and live-validation gaps for later workflow execution.
+- None for workflow creation. The open questions become live-execution gates
+  and are handled through the Three Amigos escalation path when they affect a
+  concrete run.
 
 Confidence level:
 
-- 84 percent.
+- 92 percent for workflow creation.
+- Less than 90 percent for immediate live execution without additional operator
+  approval and environment facts.
 
 Decision:
 
 ```text
-PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+READY_FOR_WORKFLOW
 ```
 
-## Verified Baseline
+EPIC traceability:
 
-- Branch:
-  `architecture/workflow-tasklist-remediation-20260523`
-- Repository root:
-  `D:/Projects/Tiny-Swarm-World`
-- Current Python source root:
-  `src/tiny_swarm_world`
-- Current infrastructure asset root:
-  `infra`
-- Current quality gate:
-  `python3 tools/quality_gate.py quality`
-- Current full gate order:
-  `lint`, `arch-lint`, `arch-tests`, `typecheck`, `test`
-- Architecture checks:
-  `.importlinter` and `tests.architecture.test_hexagonal_imports`
-- Frontend package tooling:
-  not present
-- EPIC source:
-  not present
-- Tasklist source:
-  converted and deleted
+- No `documentation/epics` directory exists in the repository.
+- Answer to "Does the implementation still match the EPIC?": no EPIC source is
+  available; this is recorded as a traceability gap, not a workflow-creation
+  blocker.
 
-## Target Picture
+## Three Amigos Review
 
-After workflow execution, Tiny Swarm World should have:
+### Senior Requirement Engineer
 
-- one current, supported Python entrypoint and composition root;
-- no stale task-list file outside the governed workflow;
-- safe, non-destructive platform lifecycle behavior;
-- deterministic network and netplan handling;
-- Docker readiness checks before Swarm operations;
-- idempotent Swarm bootstrap and validated parsing;
-- an explicit deployment/compose flow with VM/Swarm-compatible assets;
-- validated configuration and secret handling;
-- reliable tests and architecture gates;
-- operational documentation that distinguishes safe local checks from live
-  infrastructure commands.
+- The requirement is testable when "complete installation" is decomposed into
+  host, Python, VM, network, Docker, Swarm, deployment, service reachability,
+  evidence and rerun checks.
+- The workflow must define mandatory and optional functionality explicitly.
+- Open live-run policy questions are non-blocking for workflow authoring.
+
+### Senior System Architect
+
+- The integration test must exercise platform and deployment behavior without
+  moving concrete adapter construction out of `infrastructure/composition.py`.
+- Live-test tooling must remain outside domain code.
+- Stack deployment verification belongs to the Deployment responsibility.
+- VM, network, Docker and Swarm verification belongs to the Platform
+  responsibility.
+
+### Senior Python Automation Developer
+
+- Preflight, orchestration and probes should be implemented as small
+  application use cases behind ports where behavior becomes reusable.
+- The live runner can live under `tools/` as an operator entrypoint while using
+  application services through composition.
+- Constructors must not execute external commands.
+- Command results must preserve exit code, stdout, stderr, node identity and
+  phase identity.
+
+### Senior React Frontend Developer
+
+- No frontend module exists and this workflow does not introduce one.
+- UI verification is endpoint reachability and HTTP/API readiness only.
+- If later evidence dashboards are requested, that requires a separate
+  frontend workflow.
+
+### Senior Tester
+
+- Default tests must remain mock-based and deterministic.
+- Live integration checks must be skipped unless an explicit environment
+  variable and command-line confirmation are both present.
+- The live test must fail on partial installation, hidden command failure,
+  missing health evidence or unreachable mandatory services.
+- The workflow needs a dry-run mode before live execution.
+
+### Dependency And Deadlock Validator
+
+- The workflow has one critical chain: preflight -> orchestration contract ->
+  platform readiness -> deployment readiness -> live runner -> docs.
+- Documentation updates can happen late, but must consume actual command names
+  and evidence paths produced by the implementation slices.
+- Live execution is gated after implementation and quality gates, so it does
+  not deadlock default development verification.
+
+## Complete Functionality Definition
+
+The integration test proves complete functionality only when all mandatory
+checks pass:
+
+- Host environment: Linux or WSL detected, Python version supported,
+  dependencies installed, Multipass available, Docker CLI available where
+  required, and required ports not occupied.
+- Python entrypoint: canonical commands are discoverable from repository root.
+- VM lifecycle: manager and worker VMs exist or are created according to the
+  selected mode, and VM state is verified.
+- Network: manager IP, worker IPs, gateway, netplan transfer/application and
+  WSL/Linux forwarding checks are verified.
+- Docker: Docker daemon is installed and healthy on every node.
+- Swarm: manager is active, worker token retrieval succeeds, workers are joined
+  and visible through `docker node ls`.
+- Deployment: Portainer stack deploys and at least Nexus, Jenkins, RabbitMQ,
+  SonarQube and Swagger/NGINX stacks are deployed or explicitly classified as
+  resource-gated with Three Amigos approval.
+- Reachability: mandatory service endpoints respond from the host or produce
+  actionable failure evidence.
+- Rerun safety: a second verification run detects existing state and does not
+  perform an implicit destructive reset.
+- Evidence: logs, command results, endpoint probe results and readiness summary
+  are stored under a deterministic ignored artifact directory.
 
 ## Scope
 
-In scope for workflow execution:
+In scope:
 
-- `src/tiny_swarm_world/**`
-- `infra/config/**`
-- `infra/compose/**`
-- `infra/prepare/**`
-- `infra/swarm/**`
-- `tests/**`
-- `.importlinter`
-- `tools/quality_gate.py` only when a slice explicitly changes gate behavior
-- `QUALITY.md` only when a slice explicitly changes quality policy
-- `README.md`
-- `documentation/**`
+- Workflow and context documentation.
+- Future opt-in live integration test harness.
+- Preflight checks for host, Python, Multipass, Docker, ports, secrets and
+  resource availability.
+- Dry-run command plan verification.
+- Full live install sequence verification.
+- Health probes for platform and service endpoints.
+- Evidence capture and failure reporting.
+- Documentation updates and readiness checklist synchronization.
 
-Out of scope unless a slice is refined:
+Out of scope:
 
-- `src/main/java/**`
-- live infrastructure execution
-- new frontend package tooling
-- speculative microservice extraction
-- direct restoration of `TASKLIST.md`
-
-## Converted Task Traceability
-
-| Finding | Original task IDs | Workflow slice |
-|---|---|---|
-| F-001 Python package/import model | T-001, T-004, T-007 | Slice 01 |
-| F-003 active/dead orchestration mix | T-002, T-011 | Slice 01 and Slice 08 |
-| F-014 hidden command failures | T-009, T-021 | Slice 01 and Slice 05 |
-| F-012 test suite readiness | T-005, T-020 | Slice 01 and Slice 08 |
-| F-013 config contracts | T-006, T-019 | Slice 02 and Slice 07 |
-| F-002 destructive VM lifecycle | T-010 | Slice 03 |
-| F-004 netplan path assumptions | T-012 | Slice 04 |
-| F-005 WSL/Linux networking lifecycle | T-013 | Slice 04 |
-| F-006 Docker readiness | T-014 | Slice 05 |
-| F-007 Swarm bootstrap | T-015 | Slice 05 |
-| F-008 missing stack deployment | T-008, T-016 | Slice 06 |
-| F-010 compose/VM context mismatch | T-017 | Slice 06 |
-| F-009 hardcoded credentials | T-018 | Slice 07 |
-| F-011 outdated documentation | T-003, T-022 | Slice 08 |
-| F-015 non-production leftovers | T-023 | Slice 08 |
+- Executing live infrastructure during workflow creation.
+- Running live infrastructure in default CI.
+- Expanding Windows-native support.
+- Refactoring unrelated legacy modules.
+- Changing Java example application behavior.
 
 ## Architecture Constraints
 
-- Preserve the Python hexagonal architecture.
-- Domain code must remain independent from application and infrastructure.
+- Preserve hexagonal architecture.
+- Domain code must not import application or infrastructure.
 - Application services depend on ports and domain objects, not concrete
   adapters.
-- Infrastructure adapters own command execution, YAML parsing, filesystem
-  access, HTTP clients, Docker, Multipass and shell details.
-- Runtime wiring stays in
-  `src/tiny_swarm_world/infrastructure/composition.py`.
-- Entry-point code stays thin.
-- Use structured YAML handling or existing YAML adapters.
-- Do not expand Windows-native behavior.
-- Do not run live infrastructure commands without explicit user approval.
+- Infrastructure adapters implement ports and own technology-specific behavior.
+- Standard runtime wiring remains in `src/tiny_swarm_world/infrastructure/composition.py`.
+- `src/tiny_swarm_world/__main__.py` stays thin.
+- Live-test tooling must make live side effects explicit.
+- Secrets must come from environment or ignored local files, never committed
+  defaults.
+- Linux/WSL and POSIX paths are the only supported runtime model.
 
 ## Python Automation Assessment
 
-The remediation is Python-first. Implementation slices must use current package
-imports under `tiny_swarm_world`, not legacy top-level `application`,
-`domain` or `infrastructure` imports from the old audit baseline.
+Expected implementation direction:
 
-Command orchestration and failure propagation must be modeled through domain
-objects, application ports and infrastructure adapters. Tests must mock external
-commands, VM operations, network mutation, Docker operations and service
-bootstrap calls by default.
+- Add a preflight model that validates host/runtime readiness before any live
+  command runs.
+- Add or expose a canonical full-install command sequence without hiding
+  external execution in constructors.
+- Add structured phase results for VM, network, Docker, Swarm, deployment and
+  service probes.
+- Keep command construction deterministic and testable with mocks.
+- Preserve `PYTHONPATH=src` or package execution behavior documented by the
+  repository until packaging is explicitly changed.
 
 ## Frontend Assessment
 
-Status: not applicable for implementation.
-
-No frontend module or package tooling is present. The Senior React Frontend
-Developer role is included for mandatory workflow-create coverage only and
-records no implementation impact. Do not add React, TypeScript,
-`package.json`, frontend build tooling, UI components, API client layers or
-frontend tests unless a future requirement introduces a verified frontend
-module and tooling conventions.
-
-Python UI adapters remain Python automation and infrastructure adapter scope.
+No frontend changes are planned. The integration test checks operational
+endpoints, not browser UX. Any future dashboard, replay UI or evidence viewer
+requires a separate frontend workflow and Three Amigos review.
 
 ## Test Strategy
 
-Use `QUALITY.md` as the source of truth:
+Default verification:
 
 ```bash
 python3 tools/quality_gate.py lint
@@ -263,282 +322,253 @@ python3 tools/quality_gate.py test
 python3 tools/quality_gate.py quality
 ```
 
-For documentation-only changes:
+Targeted development checks should use the nearest relevant existing gate from
+`QUALITY.md`. New live integration tooling must also include deterministic unit
+tests with mocked command execution and mocked endpoint probes.
 
-```bash
-git diff --check
-```
+Live verification:
 
-Focused Python tests may use `unittest` with `PYTHONPATH=src`, for example:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition
-```
-
-Do not use `pytest -q` as the default gate.
+- introduced by a later implementation slice;
+- never included in the default quality gate;
+- requires explicit operator confirmation;
+- refuses to run without a successful preflight;
+- stores evidence in an ignored artifact directory;
+- reports every failed phase with owner, command, exit status and remediation
+  classification.
 
 ## Resilience Requirements
 
-- Destructive VM reset must be explicit, never default.
-- Docker and Swarm flows need readiness checks, retry limits, timeout policy
-  and clear diagnostics.
-- Command failures must fail critical workflows instead of being hidden behind
-  progress UI.
-- Network setup must be idempotent and have cleanup semantics.
-- Deployment checks must distinguish mocked/static verification from live smoke
-  tests.
-- Secret and config validation must fail fast with actionable errors.
+- Every external command must have a timeout.
+- Retriable readiness checks must have bounded retries and diagnostics.
+- Non-retriable critical failures must abort the live run.
+- Cleanup must be explicit and never implicit after failure.
+- Reruns must detect existing VMs, Docker state, Swarm state and stacks.
+- A failure report must separate host blockers, product defects, configuration
+  gaps, secret gaps and resource limits.
 
-## Execution Profile
+## Blocker Remediation And Three Amigos Q&A
 
-```text
-executionProfile=FULL_PATH
-reason=The workflow governs product remediation across Python source, infrastructure assets, tests, documentation, quality gates and live-infrastructure safety.
-requiredFullReviews=Senior Requirement Engineer, Senior System Architect, Senior Python Automation Developer, Senior React Frontend Developer, Senior Tester, Senior DevOps Engineer, Senior Documentation Engineer
-allowedImpactChecks=Senior React Frontend Developer may record N/A implementation impact because no frontend module exists
-requiredQualityChecks=git diff --check; python3 tools/quality_gate.py arch-lint; python3 tools/quality_gate.py arch-tests; python3 tools/quality_gate.py quality when practical
-stopConditions=stale docker paths copied without verification, pytest used as default gate, live infrastructure command executed without approval, slice dependencies unclear
-```
+When a blocker appears during workflow execution, use this decision path:
+
+1. Capture evidence: phase, command or probe, expected result, actual result,
+   logs, exit code, stdout, stderr and affected files.
+2. Classify the blocker:
+   - host prerequisite missing;
+   - configuration or secret missing;
+   - deterministic implementation defect;
+   - flaky runtime readiness;
+   - architecture ambiguity;
+   - product-scope ambiguity;
+   - resource limitation.
+3. Self-remediate only when all are true:
+   - root cause confidence is at least 90 percent;
+   - the fix stays inside the active slice write scope;
+   - the fix does not require new product policy;
+   - the fix preserves architecture and safety rules;
+   - verification can prove the fix in the current environment.
+4. Retry at most three targeted remediation loops for the same blocker.
+5. Stop and start Three Amigos Q&A when confidence is below 90 percent, the
+   fix requires scope clarification, the environment decision belongs to the
+   operator, or the third retry fails.
+
+Three Amigos Q&A must ask concise blocking questions with these roles:
+
+- Requirement: what result must count as successful functionality?
+- Architecture: which boundary or runtime behavior is authoritative?
+- Testing: what evidence proves the run is acceptable?
+- Python automation: which command, adapter or workflow owns the fix?
+- Operations: which host, secret, resource or cleanup decision is allowed?
 
 ## Ordered Slices
 
-### Slice 01: Baseline, Entrypoint And Failure Semantics
+### Slice 01 - Integration Test Contract
 
 Purpose:
 
-Verify or repair the current Python entrypoint, package/import readiness,
-composition root, dead orchestration classification and command failure
-semantics. This slice also establishes the minimum test baseline used by later
-infrastructure slices.
+- Convert this workflow into a concrete integration-test contract with
+  mandatory checks, optional checks, live-run consent and evidence semantics.
 
 ```yaml
 slice_id: "01"
 profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
+owner: "Senior Requirement Engineer"
 secondary_reviewers:
-  - "Senior System Architect"
   - "Senior Tester"
+  - "Senior System Architect"
 affected_files:
-  - "src/tiny_swarm_world/__main__.py"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "src/tiny_swarm_world/domain/command/**"
-  - "src/tiny_swarm_world/application/ports/commands/**"
-  - "src/tiny_swarm_world/application/services/commands/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
-  - "tests/application/**"
-  - "tests/infrastructure/**"
-  - "tests/architecture/**"
-  - "README.md"
-  - "documentation/**"
-affected_modules:
-  - "src/tiny_swarm_world"
-  - "tests"
-  - "documentation"
-affected_contracts: []
+  - "documentation/workflow/workflow.md"
+  - "documentation/workflow/context-pack.md"
+  - "documentation/workflow/context-pack.json"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
+affected_modules: []
+affected_contracts:
+  - "full-installation-integration-test-contract"
 dependencies: []
 parallel_group: "A"
 file_locks:
-  - "src/tiny_swarm_world/__main__.py"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "src/tiny_swarm_world/domain/command/**"
-  - "src/tiny_swarm_world/application/ports/commands/**"
-  - "src/tiny_swarm_world/application/services/commands/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
+  - "documentation/workflow/**"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
+contract_locks:
+  - "integration-test-success-criteria"
 architecture_locks:
-  - "python-hexagonal-boundaries"
-contract_locks: []
+  - "live-infrastructure-safety"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "git diff --check"
   required:
     - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "check building blocks and runtime view"
-  adr: "not required unless entrypoint strategy changes materially"
+  arc42: "check only"
+  adr: "check ADR platform/artifacts/deployment split"
 stop_conditions:
-  - "canonical entrypoint cannot be verified"
-  - "application imports infrastructure"
-  - "command failures would be hidden"
-  - "legacy docker path is treated as current source root without verification"
+  - "mandatory functionality cannot be defined without product clarification"
+  - "live-run consent semantics are unclear"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-001: T-001, T-004, T-007
-- F-003: T-002, T-011
-- F-014: T-009, T-021
-- F-012: T-005, T-020
+- Workflow and readiness documentation only.
 
 Done criteria:
 
-- `PYTHONPATH=src python3 -m tiny_swarm_world` is either verified or repaired.
-- `__main__.py` remains thin.
-- Critical command failure policy is explicit and tested.
-- Dead or legacy orchestration surfaces are classified, not silently expanded.
+- Mandatory, optional and resource-gated checks are explicit.
+- Live side effects require opt-in consent.
+- Evidence semantics are documented.
 
-### Slice 02: Configuration Contract Foundation
+### Slice 02 - Preflight And Configuration Validation
 
 Purpose:
 
-Create or verify typed configuration contracts, deterministic repository-root
-path handling, YAML validation boundaries and environment override
-expectations before live-infrastructure-facing slices depend on configuration.
+- Add deterministic preflight checks that fail before live side effects when
+  host, dependencies, secrets, ports or resource limits are not ready.
 
 ```yaml
 slice_id: "02"
 profile: "FULL_PATH"
 owner: "Senior Python Automation Developer"
 secondary_reviewers:
-  - "Senior System Architect"
   - "Senior Tester"
   - "Senior DevOps Engineer"
+  - "Senior Security Sandbox Engineer"
 affected_files:
+  - "src/tiny_swarm_world/application/**"
   - "src/tiny_swarm_world/domain/**"
-  - "src/tiny_swarm_world/application/ports/repositories/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/yaml/**"
-  - "src/tiny_swarm_world/infrastructure/project_paths.py"
-  - "infra/config/**"
+  - "src/tiny_swarm_world/infrastructure/**"
   - "tests/**"
-  - "documentation/**"
+  - "tools/**"
 affected_modules:
-  - "src/tiny_swarm_world/domain"
-  - "src/tiny_swarm_world/application"
-  - "src/tiny_swarm_world/infrastructure"
-  - "infra/config"
+  - "tiny_swarm_world.application"
+  - "tiny_swarm_world.domain"
+  - "tiny_swarm_world.infrastructure"
 affected_contracts:
-  - "configuration schema and override behavior"
+  - "preflight-result"
+  - "live-run-consent"
 dependencies:
   - "01"
 parallel_group: "B"
 file_locks:
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/yaml/**"
-  - "infra/config/**"
-architecture_locks:
-  - "configuration-boundary"
+  - "src/tiny_swarm_world/**"
+  - "tests/**"
+  - "tools/**"
 contract_locks:
-  - "configuration-contract"
+  - "preflight-result"
+architecture_locks:
+  - "hexagonal-import-boundaries"
+  - "external-command-safety"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
+    - "python3 tools/quality_gate.py test"
     - "python3 tools/quality_gate.py typecheck"
   required:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "check constraints and concepts"
-  adr: "required only if config authority changes"
+  arc42: "update if a new preflight concept is introduced"
+  adr: "not required unless responsibility boundaries change"
 stop_conditions:
-  - "configuration keys cannot be verified"
-  - "host-specific paths or secrets would be committed"
-  - "YAML is modified by ad hoc string manipulation"
+  - "preflight would need to execute live infrastructure commands"
+  - "secret handling cannot be made explicit"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-013: T-006, T-019
+- Python preflight code, tests and tool entrypoints needed for preflight only.
 
 Done criteria:
 
-- Required configuration contracts are explicit and testable.
-- Path resolution is repository-root aware where needed.
-- Overrides and examples are documented without secrets.
+- Preflight can run without creating VMs or changing networking.
+- Missing prerequisites produce actionable failures.
+- Unit tests cover each preflight outcome.
 
-### Slice 03: Multipass Lifecycle Safety
+### Slice 03 - Canonical Full-Installation Plan
 
 Purpose:
 
-Make VM lifecycle behavior state-aware and non-destructive by default. Any
-reset path must be explicit and separately validated.
+- Define a canonical full-installation plan that sequences existing platform
+  services and identifies missing deployment steps before live execution.
 
 ```yaml
 slice_id: "03"
 profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
+owner: "Senior System Architect"
 secondary_reviewers:
-  - "Senior DevOps Engineer"
+  - "Senior Python Automation Developer"
   - "Senior Tester"
-  - "Senior Security Sandbox Engineer"
 affected_files:
-  - "src/tiny_swarm_world/domain/multipass/**"
-  - "src/tiny_swarm_world/application/services/multipass/**"
-  - "src/tiny_swarm_world/application/services/vm/**"
-  - "src/tiny_swarm_world/application/services/platform/**"
-  - "src/tiny_swarm_world/application/ports/repositories/port_vm_repository.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/vm_repository_yaml.py"
-  - "infra/config/multipass/**"
-  - "infra/config/vm/**"
-  - "tests/application/services/multipass/**"
-  - "tests/domain/**"
+  - "src/tiny_swarm_world/application/**"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/__main__.py"
+  - "tests/**"
   - "documentation/**"
 affected_modules:
-  - "multipass"
-  - "vm"
-  - "platform"
+  - "tiny_swarm_world.application.services.platform"
+  - "tiny_swarm_world.infrastructure.composition"
 affected_contracts:
-  - "VM lifecycle command contract"
+  - "full-installation-plan"
 dependencies:
   - "01"
   - "02"
 parallel_group: "C"
 file_locks:
-  - "src/tiny_swarm_world/domain/multipass/**"
-  - "src/tiny_swarm_world/application/services/multipass/**"
-  - "src/tiny_swarm_world/application/services/vm/**"
-  - "infra/config/multipass/**"
-  - "infra/config/vm/**"
-architecture_locks:
-  - "live-infrastructure-safety"
+  - "src/tiny_swarm_world/application/**"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/__main__.py"
+  - "tests/**"
 contract_locks:
-  - "multipass-command-contract"
+  - "full-installation-plan"
+architecture_locks:
+  - "thin-entrypoint"
+  - "composition-root-wiring"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.application.services.multipass.test_multipass_init_vms"
-    - "python3 tools/quality_gate.py arch-lint"
     - "python3 tools/quality_gate.py arch-tests"
     - "python3 tools/quality_gate.py test"
   required:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update runtime and risks when lifecycle behavior changes"
-  adr: "consider if default reset behavior changes"
+  arc42: "runtime and deployment view check"
+  adr: "check ADR platform/artifacts/deployment split"
 stop_conditions:
-  - "multipass command would run live"
-  - "default path still deletes or purges VMs"
-  - "reset behavior lacks explicit user intent"
+  - "canonical sequence cannot be defined from current services"
+  - "entrypoint would need low-level infrastructure imports"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-002: T-010
+- Full-installation planning use case, composition wiring, thin CLI exposure
+  and matching tests.
 
 Done criteria:
 
-- Default lifecycle behavior does not destroy VMs.
-- Explicit reset path is separated from reconcile/bootstrap behavior.
-- Tests use mocked command execution.
+- A dry-run plan lists every phase in order.
+- The plan has no hidden live execution.
+- Tests prove the order and failure propagation.
 
-### Slice 04: Networking, WSL2 And Netplan
+### Slice 04 - Platform Runtime Readiness Probes
 
 Purpose:
 
-Make netplan generation, transfer path handling and WSL/Linux networking
-procedures deterministic, idempotent and safe to validate without live network
-mutation.
+- Implement platform probes for VM state, network readiness, Docker daemon
+  health, Swarm manager state, worker join status and rerun safety.
 
 ```yaml
 slice_id: "04"
@@ -547,76 +577,61 @@ owner: "Senior Python Automation Developer"
 secondary_reviewers:
   - "Senior DevOps Engineer"
   - "Senior Tester"
-  - "Senior Security Sandbox Engineer"
+  - "Senior System Architect"
 affected_files:
-  - "src/tiny_swarm_world/domain/network/**"
-  - "src/tiny_swarm_world/application/services/network/**"
-  - "src/tiny_swarm_world/application/services/vm/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/netplan_repository.py"
-  - "infra/config/network/**"
-  - "infra/swarm/**"
-  - "tests/application/services/network/**"
-  - "tests/domain/network/**"
-  - "documentation/system/network.adoc"
-  - "documentation/user_guide/troubleshooting.adoc"
+  - "src/tiny_swarm_world/application/**"
+  - "src/tiny_swarm_world/domain/**"
+  - "src/tiny_swarm_world/infrastructure/**"
+  - "infra/config/**"
+  - "tests/**"
 affected_modules:
-  - "network"
-  - "vm"
-  - "infra/config/network"
+  - "tiny_swarm_world.application.services.platform"
+  - "tiny_swarm_world.infrastructure.adapters"
 affected_contracts:
-  - "netplan artifact and transfer path contract"
+  - "platform-readiness-result"
 dependencies:
-  - "02"
   - "03"
 parallel_group: "D"
 file_locks:
-  - "src/tiny_swarm_world/domain/network/**"
-  - "src/tiny_swarm_world/application/services/network/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/netplan_repository.py"
-  - "infra/config/network/**"
-  - "infra/swarm/**"
-architecture_locks:
-  - "network-live-safety"
+  - "src/tiny_swarm_world/**"
+  - "infra/config/**"
+  - "tests/**"
 contract_locks:
-  - "netplan-contract"
+  - "platform-readiness-result"
+architecture_locks:
+  - "platform-responsibility-boundary"
+  - "command-result-evidence"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.application.services.network.test_network_service"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
     - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
   required:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update runtime view and deployment view when network flow changes"
-  adr: "not required unless network state model changes materially"
+  arc42: "runtime view update if probes become product behavior"
+  adr: "not required unless ownership changes"
 stop_conditions:
-  - "netplan changes would be applied live"
-  - "socat or iptables command would run live"
-  - "generated file path cannot be verified"
+  - "probe requires destructive reset as default behavior"
+  - "Docker or Swarm output parsing is ambiguous"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-004: T-012
-- F-005: T-013
+- Platform readiness code, command result parsing, tests and relevant config
+  validation.
 
 Done criteria:
 
-- Netplan save and transfer paths resolve to the same deterministic artifact.
-- WSL/Linux networking setup has prepare, verify and cleanup semantics.
-- Live mutation remains opt-in only.
+- Probes are mock-testable.
+- Live probe failures contain node, command and expected state.
+- Rerun safety is explicitly checked.
 
-### Slice 05: Docker Readiness And Swarm Bootstrap
+### Slice 05 - Deployment And Service Readiness Probes
 
 Purpose:
 
-Add Docker daemon readiness semantics, robust retry/timeout behavior, state-aware
-Swarm init/join and validated parsing without running Docker or Swarm live by
-default.
+- Implement deployment probes that verify Portainer, stack lifecycle and service
+  endpoint health for the supported service set.
 
 ```yaml
 slice_id: "05"
@@ -624,473 +639,372 @@ profile: "FULL_PATH"
 owner: "Senior Python Automation Developer"
 secondary_reviewers:
   - "Senior DevOps Engineer"
+  - "Senior Security Sandbox Engineer"
   - "Senior Tester"
 affected_files:
-  - "src/tiny_swarm_world/domain/command/**"
-  - "src/tiny_swarm_world/application/services/multipass/**"
-  - "src/tiny_swarm_world/application/services/platform/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
-  - "infra/config/docker/**"
-  - "infra/config/multipass/**"
-  - "tests/application/services/multipass/**"
-  - "tests/infrastructure/adapters/command_runner/**"
-  - "documentation/**"
+  - "src/tiny_swarm_world/application/**"
+  - "src/tiny_swarm_world/domain/**"
+  - "src/tiny_swarm_world/infrastructure/**"
+  - "infra/config/compose/**"
+  - "infra/compose/**"
+  - "tests/**"
 affected_modules:
-  - "docker-readiness"
-  - "swarm-bootstrap"
-  - "command-runner"
+  - "tiny_swarm_world.application.services.deployment"
+  - "tiny_swarm_world.infrastructure.adapters"
 affected_contracts:
-  - "Docker readiness command contract"
-  - "Swarm token and node verification contract"
+  - "deployment-readiness-result"
+  - "service-health-probe"
 dependencies:
   - "03"
-  - "04"
-parallel_group: "E"
+parallel_group: "D"
 file_locks:
-  - "src/tiny_swarm_world/application/services/multipass/**"
-  - "src/tiny_swarm_world/application/services/platform/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
-  - "infra/config/docker/**"
-architecture_locks:
-  - "docker-swarm-live-safety"
+  - "src/tiny_swarm_world/**"
+  - "infra/config/compose/**"
+  - "infra/compose/**"
+  - "tests/**"
 contract_locks:
-  - "swarm-command-contract"
+  - "deployment-readiness-result"
+  - "service-health-probe"
+architecture_locks:
+  - "deployment-responsibility-boundary"
+  - "secret-handling"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_workflow_configuration"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
     - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
   required:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update runtime and risks for readiness and bootstrap behavior"
-  adr: "consider if retry/failure policy becomes cross-cutting"
+  arc42: "deployment view update if deployment behavior changes"
+  adr: "not required unless service ownership changes"
 stop_conditions:
-  - "docker or docker swarm command would run live"
-  - "token parsing remains positional and unvalidated"
-  - "critical command failure still reports success"
+  - "hardcoded credentials would be required"
+  - "stack manifests are not safe for Swarm validation"
+  - "mandatory service list cannot be satisfied on target resources"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-006: T-014
-- F-007: T-015
-- F-014: T-009, T-021
+- Deployment readiness code, service health probes, tests and stack validation
+  support.
 
 Done criteria:
 
-- Docker install blocks on daemon readiness in mocked tests.
-- Swarm init/join handles already-active states.
-- Token/IP parsing is explicit and validated.
-- Critical failures propagate.
+- Service probes are explicit and timeout-bounded.
+- Missing secrets fail before stack deployment.
+- Portainer and service endpoint failures produce actionable evidence.
 
-### Slice 06: Deployment Stack And Compose Flow
+### Slice 06 - Live Integration Runner And Evidence Bundle
 
 Purpose:
 
-Separate platform provisioning from stack deployment, integrate deployment into
-the canonical flow or document the handoff, and fix compose assumptions that
-conflict with VM/Swarm execution.
+- Add the opt-in live runner that executes preflight, dry-run plan,
+  full-installation phases, probes and evidence collection.
 
 ```yaml
 slice_id: "06"
 profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
+owner: "Senior DevOps Engineer"
 secondary_reviewers:
-  - "Senior DevOps Engineer"
+  - "Senior Python Automation Developer"
   - "Senior Tester"
-  - "Senior System Architect"
+  - "Senior Security Sandbox Engineer"
 affected_files:
-  - "src/tiny_swarm_world/domain/deployment/**"
-  - "src/tiny_swarm_world/application/services/deployment/**"
-  - "src/tiny_swarm_world/application/ports/clients/port_portainer_client.py"
-  - "src/tiny_swarm_world/application/ports/repositories/port_compose_file_repository.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/clients/portainer_http_client.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
-  - "infra/config/compose/**"
-  - "infra/compose/**"
-  - "tests/application/services/deployment/**"
-  - "tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py"
-  - "documentation/**"
+  - "tools/**"
+  - "src/tiny_swarm_world/**"
+  - "tests/**"
+  - ".gitignore"
 affected_modules:
-  - "deployment"
-  - "compose"
-  - "portainer-client"
+  - "tiny_swarm_world.application"
+  - "tiny_swarm_world.infrastructure"
 affected_contracts:
-  - "deployment stack contract"
+  - "live-integration-runner"
+  - "evidence-bundle"
 dependencies:
+  - "04"
   - "05"
-parallel_group: "F"
+parallel_group: "E"
 file_locks:
-  - "src/tiny_swarm_world/domain/deployment/**"
-  - "src/tiny_swarm_world/application/services/deployment/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/clients/portainer_http_client.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
-  - "infra/config/compose/**"
-  - "infra/compose/**"
-architecture_locks:
-  - "deployment-boundary"
+  - "tools/**"
+  - "src/tiny_swarm_world/**"
+  - "tests/**"
+  - ".gitignore"
 contract_locks:
-  - "compose-stack-contract"
+  - "live-integration-runner"
+  - "evidence-bundle"
+architecture_locks:
+  - "live-infrastructure-safety"
+  - "failure-propagation"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
     - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
   required:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update deployment view"
-  adr: "consider if canonical deployment strategy changes"
+  arc42: "runtime view and quality requirements check"
+  adr: "not required unless live-test policy changes"
 stop_conditions:
-  - "compose deployment would run live"
-  - "stack deploy command lacks dry-run or mocked verification"
-  - "host-local compose assumptions remain unclassified"
+  - "runner can execute live commands without explicit confirmation"
+  - "evidence artifacts would be committed"
+  - "critical command failures can be hidden"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-008: T-008, T-016
-- F-010: T-017
+- Live runner, evidence paths, ignored artifact directories and tests.
 
 Done criteria:
 
-- Deployment is a deliberate stage with verification.
-- Compose assets are classified as VM/Swarm-compatible or explicitly legacy.
-- No live deployment runs without approval.
+- The live runner refuses to run without explicit confirmation.
+- Dry-run mode is available.
+- Evidence output is deterministic and ignored by Git.
+- Critical failures produce non-zero exit status.
 
-### Slice 07: Secrets, Nexus And Configuration Contracts
+### Slice 07 - Documentation And Readiness Synchronization
 
 Purpose:
 
-Remove hardcoded credentials from active automation paths, define secret/config
-inputs and validate Nexus/Portainer/bootstrap configuration without committing
-real secrets.
+- Update operator documentation, troubleshooting and readiness checklist from
+  the implemented integration-test behavior.
 
 ```yaml
 slice_id: "07"
 profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
+owner: "Senior Documentation Engineer"
 secondary_reviewers:
-  - "Senior DevOps Engineer"
-  - "Senior Security Sandbox Engineer"
   - "Senior Tester"
+  - "Senior DevOps Engineer"
+  - "Senior System Architect"
 affected_files:
-  - "src/tiny_swarm_world/domain/nexus/**"
-  - "src/tiny_swarm_world/application/services/nexus/**"
-  - "src/tiny_swarm_world/application/services/artifacts/**"
-  - "src/tiny_swarm_world/application/ports/clients/port_nexus_client.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/clients/nexus_http_client.py"
-  - "infra/prepare/nexus/**"
-  - "infra/prepare/portainer/**"
-  - "infra/config/**"
-  - "tests/application/services/nexus/**"
+  - "README.md"
   - "documentation/**"
-affected_modules:
-  - "nexus"
-  - "artifacts"
-  - "secrets"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
+affected_modules: []
 affected_contracts:
-  - "secret and environment input contract"
+  - "operator-runbook"
 dependencies:
-  - "02"
   - "06"
-parallel_group: "G"
+parallel_group: "F"
 file_locks:
-  - "src/tiny_swarm_world/domain/nexus/**"
-  - "src/tiny_swarm_world/application/services/nexus/**"
-  - "src/tiny_swarm_world/application/services/artifacts/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/clients/nexus_http_client.py"
-  - "infra/prepare/nexus/**"
-  - "infra/prepare/portainer/**"
-  - "infra/config/**"
-architecture_locks:
-  - "secret-safety"
+  - "README.md"
+  - "documentation/**"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
 contract_locks:
-  - "secret-input-contract"
+  - "operator-runbook"
+architecture_locks:
+  - "documentation-authority"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.application.services.nexus.test_bootstrap_nexus"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "git diff --check"
   required:
     - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "update concepts and risks for secret handling"
-  adr: "required if secret ownership model changes materially"
+  arc42: "update runtime, deployment, quality and risk sections as needed"
+  adr: "not required unless policy changes"
 stop_conditions:
-  - "real credential would be committed"
-  - "script defaults to insecure admin credentials"
-  - "bootstrap endpoint is called live"
+  - "documentation would claim live validation without evidence"
+  - "runbook contains host-specific secrets or absolute paths"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-009: T-018
-- F-013: T-006, T-019
+- README, documentation and readiness checklist only.
 
 Done criteria:
 
-- No tracked active automation path embeds real credentials.
-- Missing secrets fail fast.
-- Example templates contain placeholders only.
+- Runbook has exact commands and prerequisites.
+- Troubleshooting maps common failures to remediation.
+- Readiness checklist reflects implemented and verified behavior.
 
-### Slice 08: Test Gate Cleanup And Operational Documentation
+### Slice 08 - Controlled Live Verification
 
 Purpose:
 
-Complete test curation, architecture-gate alignment, operational documentation
-and legacy surface cleanup. This slice updates docs and arc42 after the
-implementation slices establish verified behavior.
+- Run the implemented opt-in integration test in a suitable Linux/WSL
+  environment and record the result without weakening default quality gates.
 
 ```yaml
 slice_id: "08"
 profile: "FULL_PATH"
-owner: "Senior Documentation Engineer"
+owner: "Senior Tester"
 secondary_reviewers:
-  - "Senior Tester"
-  - "Senior System Architect"
-  - "Senior Python Automation Developer"
   - "Senior DevOps Engineer"
+  - "Senior Security Sandbox Engineer"
+  - "Senior Requirement Engineer"
 affected_files:
-  - "tests/**"
-  - ".importlinter"
-  - "tools/quality_gate.py"
-  - "QUALITY.md"
-  - "README.md"
-  - "documentation/arc42/**"
-  - "documentation/user_guide/**"
-  - "documentation/system/**"
-  - "documentation/deployment/**"
-  - "documentation/process/**"
-  - "infra/swarm/**"
-  - "infra/prepare/**/README.md"
-affected_modules:
-  - "tests"
-  - "documentation"
-  - "quality-gate"
-  - "legacy-surface"
+  - "documentation/workflow/execution-report.md"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
+affected_modules: []
 affected_contracts:
-  - "quality-gate policy when changed"
+  - "live-verification-evidence"
 dependencies:
-  - "01"
-  - "02"
-  - "03"
-  - "04"
-  - "05"
-  - "06"
   - "07"
-parallel_group: "H"
+parallel_group: "G"
 file_locks:
-  - "tests/**"
-  - ".importlinter"
-  - "tools/quality_gate.py"
-  - "QUALITY.md"
-  - "README.md"
-  - "documentation/**"
-  - "infra/swarm/**"
-architecture_locks:
-  - "documentation-governance"
-  - "quality-gate-authority"
+  - "documentation/workflow/execution-report.md"
+  - "OPERATIONAL_READINESS_CHECKLIST.md"
 contract_locks:
-  - "quality-gate-contract"
+  - "live-verification-evidence"
+architecture_locks:
+  - "live-infrastructure-safety"
 quality_gates:
   targeted:
-    - "git diff --check"
-    - "python3 tools/quality_gate.py arch-lint"
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py quality"
   required:
-    - "git diff --check"
     - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update constraints, runtime view, deployment view, quality requirements and risks"
-  adr: "required if quality policy or runtime strategy changes materially"
+  arc42: "check after live evidence"
+  adr: "not required unless live policy changes"
 stop_conditions:
-  - "quality gate is weakened"
-  - "documentation claims live behavior that was not verified"
-  - "legacy script is removed before references are checked"
+  - "operator has not explicitly approved live infrastructure execution"
+  - "preflight fails"
+  - "same blocker has failed three targeted remediation attempts"
+  - "confidence is below 90 percent and Three Amigos questions are unresolved"
 ```
 
-Task traceability:
+Allowed write scope:
 
-- F-011: T-003, T-022
-- F-012: T-005, T-020
-- F-015: T-023
-- F-003: T-002, T-011
+- Execution report and readiness evidence updates only, unless a blocker is
+  self-remediated with at least 90 percent confidence inside the owning slice.
 
 Done criteria:
 
-- `pytest` references are no longer described as the default gate.
-- Documentation provides current safe checks and explicitly marks live
-  infrastructure commands as opt-in.
-- arc42 placeholder sections touched by remediation are updated or have
-  documented no-change rationale.
-- Legacy surfaces are removed only after reference checks or are clearly
-  documented as unsupported.
+- Live test either passes with evidence or stops with a classified blocker.
+- Any self-remediation has targeted verification.
+- Any unresolved blocker has Three Amigos questions recorded.
 
 ## Slice Dependency Graph
 
 ```text
-01 -> 02 -> 03 -> 04 -> 05 -> 06 -> 07 -> 08
+01
+  -> 02
+      -> 03
+          -> 04
+          -> 05
+              -> 06
+                  -> 07
+                      -> 08
 ```
 
 Parallelization:
 
-- This workflow is intentionally sequential. The original task list contained
-  cross-phase duplicate findings and finding-ID dependencies. Sequential
-  execution keeps ownership, evidence and rollback clear.
+- Slice 04 and Slice 05 may be implemented in parallel only after Slice 03
+  stabilizes shared result contracts.
+- Slice 07 documentation can draft structure early, but final content depends
+  on Slice 06 command names and evidence paths.
+- Slice 08 is always sequential and gated by live-run approval.
 
-## Role And Subagent Ownership Map
+## Role Ownership Map
 
-| Area | Owner | Supporting roles |
-|---|---|---|
-| Workflow conversion | Senior Workflow Architect | Senior Requirement Engineer |
-| Python implementation | Senior Python Automation Developer | Senior System Architect, Senior Tester |
-| Architecture boundaries | Senior System Architect | quality architecture validation |
-| Quality gates | Senior Tester | quality-gate skill |
-| Multipass, Docker, Swarm and shell assets | Senior DevOps Engineer | Security Sandbox Engineer |
-| Secret handling | Senior Security Sandbox Engineer | Senior DevOps, Senior Tester |
-| Documentation and arc42 | Senior Documentation Engineer | Senior System Architect |
-| Frontend assessment | Senior React Frontend Developer | N/A implementation impact |
+- Senior Requirement Engineer: requirement contract, acceptance criteria,
+  Three Amigos Q&A and resource-gated service decisions.
+- Senior System Architect: architecture boundaries, responsibility ownership,
+  composition root and arc42 alignment.
+- Senior Python Automation Developer: preflight, command orchestration,
+  readiness probes and testable implementation.
+- Senior DevOps Engineer: live runner, host prerequisites, evidence layout,
+  runtime diagnostics and shell/script interaction.
+- Senior Security Sandbox Engineer: secret handling, destructive command
+  controls and live-run consent.
+- Senior Tester: unit coverage, live verification strategy, failure evidence
+  and final test report.
+- Senior Documentation Engineer: runbook, troubleshooting and readiness
+  checklist synchronization.
 
 ## Quality-Gate Expectations
 
-All slices:
-
-```bash
-git diff --check
-```
-
-Architecture-sensitive slices:
-
-```bash
-python3 tools/quality_gate.py arch-lint
-python3 tools/quality_gate.py arch-tests
-```
-
-Implementation slices:
-
-```bash
-python3 tools/quality_gate.py test
-```
-
-Final readiness when practical:
+Required default gate for implementation slices:
 
 ```bash
 python3 tools/quality_gate.py quality
 ```
 
-Optional static Bash syntax check for shell slices:
+Targeted gates during development:
 
 ```bash
-find infra -name '*.sh' -print0 | xargs -0 bash -n
+python3 tools/quality_gate.py lint
+python3 tools/quality_gate.py arch-lint
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py typecheck
+python3 tools/quality_gate.py test
 ```
 
-Do not run `multipass`, `docker swarm`, compose deployments, netplan changes,
-`socat` forwarding or service bootstrap scripts unless the user explicitly
-authorizes live infrastructure execution.
+Documentation-only gate:
+
+```bash
+git diff --check
+```
+
+Live integration commands introduced by this workflow are not replacements for
+the default quality gate. They are additional opt-in evidence commands after
+the implementation slices define them.
 
 ## Documentation Synchronization Points
 
-- Update `documentation/arc42/02_constraints.adoc` when constraints change.
-- Update `documentation/arc42/06_runtime_view.adoc` when runtime flow changes.
-- Update `documentation/arc42/07_deployment_view.adoc` when deployment flow
-  changes.
-- Update `documentation/arc42/10_quality_requirements.adoc` when quality gates
-  or verification expectations change.
-- Update `documentation/arc42/11_risks_and_debt.adoc` when operational risks
-  change.
-- Update README and user guides only with verified commands and explicit live
-  run caveats.
+- After Slice 01: readiness checklist aligns with success criteria.
+- After Slice 03: README and runtime docs know the canonical plan name.
+- After Slice 06: runbook records exact live runner command, preflight command,
+  dry-run command and evidence path.
+- After Slice 08: execution report records pass/fail evidence and unresolved
+  blockers.
 
 ## Stop Conditions
 
-Stop workflow execution if:
+Stop workflow execution when:
 
-- active branch is not
-  `architecture/workflow-tasklist-remediation-20260523`;
-- a deleted `TASKLIST.md` entry cannot be traced through this workflow;
-- a slice copies stale `docker/` source assumptions without verifying current
-  paths;
-- `pytest` is used as the default gate instead of `tools/quality_gate.py`;
-- live infrastructure commands would run without explicit user approval;
-- quality gates fail or would need to be weakened;
-- architecture boundaries are unclear;
-- a slice cannot map affected files to a single owner;
-- secrets would be committed;
-- documentation claims verified live behavior without live-run evidence.
-
-## Uncertainty Escalation Rules
-
-- Missing EPIC ownership routes to Senior Requirement Engineer.
-- Architecture ambiguity routes to Senior System Architect.
-- Quality command ambiguity routes to Senior Tester and `quality-gate`.
-- Live-infrastructure ambiguity routes to Senior DevOps and Security Sandbox
-  Engineer.
-- Secret-handling ambiguity routes to Security Sandbox Engineer.
-- Any unclassified slice routes to Root Architect through Senior System
-  Architect.
+- the active branch is not the workflow branch;
+- unrelated worktree changes conflict with the slice write scope;
+- a required quality gate fails;
+- a live command would run without explicit approval;
+- a command failure is not propagated;
+- hardcoded secrets would be committed;
+- default behavior would delete VMs or stacks implicitly;
+- a service success criterion is ambiguous;
+- a blocker cannot be solved with at least 90 percent confidence;
+- Three Amigos questions are unresolved.
 
 ## Commit And Push Plan
 
-Workflow creation may be committed and pushed when requested. Workflow execute
-must create slice-scoped commits only after required gates pass or documented
-skip reasons are accepted by the active workflow.
-
-Do not combine implementation slices in one commit. Do not push directly to
-`main`. Do not run `push auto` unless explicitly requested and allowed by the
-repository governance.
+- Commit only after the relevant required gates pass.
+- Keep workflow creation documentation separate from implementation slices.
+- Do not include generated evidence artifacts, logs, local env files or secrets.
+- Use git commit preparation before committing or pushing.
+- Do not push or open a PR unless explicitly requested.
 
 ## Definition Of Done
 
-- `TASKLIST.md` is deleted after conversion.
-- This workflow and context pack are present.
-- Every original task ID has traceability to a slice.
-- Stale task-list commands and paths are normalized.
-- Required roles and stop conditions are explicit.
-- The workflow can be consumed by `workflow execute`.
-- Documentation and arc42 impact are checked.
-- Required validation for this workflow creation passes.
+This workflow is done when:
+
+- the live integration test contract is documented;
+- preflight and dry-run modes exist;
+- full live install verification is opt-in and safety-gated;
+- platform, deployment and service health probes are implemented;
+- evidence is deterministic and ignored by Git;
+- default quality gate passes;
+- live verification either passes or stops with classified blockers and Three
+  Amigos questions;
+- README, documentation and readiness checklist match the implemented behavior.
 
 ## Handoff To Workflow Execute
 
-`workflow execute` may start after:
-
-- `documentation/workflow/workflow.md` and `context-pack.*` are present;
-- `TASKLIST.md` deletion is visible in git diff;
-- the active branch is verified;
-- S3/S3D validates slice metadata and dependencies;
-- the executor accepts the EPIC traceability gap and stale audit baseline as
-  documented assumptions.
-
-Use `.agents/skills/workflow-executor/SKILL.md` as the active executor.
+Workflow execute must begin with Slice 01. It must not skip directly to live
+execution. Slice 08 requires explicit live infrastructure approval after
+Slices 01 through 07 have passed their required gates.
 
 ## arc42 Check Status
 
-arc42 was checked during workflow creation.
+Checked files:
 
-Current findings:
+- `documentation/arc42/05_building_blocks.adoc`
+- `documentation/arc42/06_runtime_view.adoc`
+- `documentation/arc42/07_deployment_view.adoc`
+- `documentation/arc42/10_quality_requirements.adoc`
+- `documentation/arc42/11_risks_and_debt.adoc`
+- `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`
 
-- `documentation/arc42/05_building_blocks.adoc` already records the current
-  Python automation, infrastructure asset and deployment-example split.
-- `documentation/arc42/06_runtime_view.adoc`,
-  `documentation/arc42/07_deployment_view.adoc`,
-  `documentation/arc42/10_quality_requirements.adoc` and
-  `documentation/arc42/11_risks_and_debt.adoc` remain placeholder-level for
-  this remediation scope.
+Current status:
 
-Slice 08 must update those sections or record explicit no-change rationale
-after implementation evidence exists.
+- No arc42 content was changed during workflow creation.
+- Future slices must update runtime, deployment, quality and risk sections if
+  integration-test behavior becomes product behavior.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -172,6 +172,12 @@ EPIC traceability:
 - Answer to "Does the implementation still match the EPIC?": no EPIC source is
   available; this is recorded as a traceability gap, not a workflow-creation
   blocker.
+- Temporary requirement baseline for this workflow: the original user request,
+  root `AGENTS.md`, root `QUALITY.md`, `AUDIT_REPORT.md`,
+  `OPERATIONAL_READINESS_CHECKLIST.md`, this Requirement Clarification Record
+  and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`.
+  The user request `workflow execute with subagents` on 2026-05-23 accepts this
+  workflow as the execution target until a dedicated EPIC is added.
 
 ## Three Amigos Review
 
@@ -252,6 +258,151 @@ checks pass:
   perform an implicit destructive reset.
 - Evidence: logs, command results, endpoint probe results and readiness summary
   are stored under a deterministic ignored artifact directory.
+
+Run result states:
+
+- `PASS`: all mandatory checks pass, no resource-gated mandatory service is
+  omitted, no live safety refusal occurred and evidence is complete.
+- `PASS_WITH_RESOURCE_GATES`: all non-gated mandatory checks pass, one or more
+  resource-gated services are omitted with recorded Three Amigos approval and
+  evidence is complete. This is not a full-functionality pass.
+- `REFUSED`: the runner stopped before any live command because live consent was
+  missing or invalid.
+- `BLOCKED`: preflight or requirement scope prevents a valid run.
+- `FAIL`: a mandatory check ran and failed.
+
+## Integration Test Contract
+
+Check categories:
+
+- `MANDATORY`: required for `PASS`; failure or missing evidence blocks the run.
+- `RESOURCE_GATED`: normally mandatory, but may be omitted only when host
+  resources are below the full-run threshold and Three Amigos approval records
+  the reduced scope. The best possible result is `PASS_WITH_RESOURCE_GATES`.
+- `OPTIONAL`: diagnostic only; omission must be recorded as `NOT_APPLICABLE`
+  and does not block `PASS`.
+
+Full-run resource threshold:
+
+- At least 4 vCPU available to the Linux/WSL environment.
+- At least 16 GiB RAM available to the Linux/WSL environment.
+- At least 60 GiB free disk in the target Multipass/Docker storage path.
+- If any threshold is not met, deploying Jenkins, SonarQube or the full
+  supporting-service set requires Three Amigos approval before it can be
+  resource-gated.
+
+Contract table:
+
+| Check ID | Phase | Category | Owner | Evidence Required | Failure Classification | Remediation Policy | Pass Condition |
+|---|---|---|---|---|---|---|---|
+| `REQ-BASELINE` | requirement | `MANDATORY` | Senior Requirement Engineer | requirement baseline entry in execution report | product-scope ambiguity | stop for Three Amigos if baseline is disputed | active workflow baseline is accepted or EPIC is added |
+| `LIVE-CONSENT` | safety | `MANDATORY` | Senior Security Sandbox Engineer | consent or refusal JSON | missing live consent | refuse before live command execution | live mode has valid consent, or dry-run mode avoids live commands |
+| `PREFLIGHT` | preflight | `MANDATORY` | Senior DevOps Engineer | `preflight.json` | host prerequisite missing | self-remediate only for deterministic local checks; otherwise ask operator | all mandatory prerequisites pass |
+| `HOST` | preflight | `MANDATORY` | Senior DevOps Engineer | OS, WSL/Linux, Python, Multipass, Docker CLI and port checks | host prerequisite missing | stop with actionable host remediation | host satisfies runtime prerequisites |
+| `PYTHON-ENTRYPOINT` | preflight | `MANDATORY` | Senior Python Automation Developer | command output for service discovery | implementation defect | self-remediate in owning slice when 90 percent clear | canonical entrypoint is discoverable from repo root |
+| `VM-LIFECYCLE` | platform | `MANDATORY` | Senior Python Automation Developer | manager and worker VM state results | runtime/platform failure | retry bounded readiness checks, then classify | expected VMs exist or are created and verified |
+| `NETWORK` | platform | `MANDATORY` | Senior Python Automation Developer | IP, gateway, netplan and forwarding probe results | runtime/platform failure | self-remediate deterministic path/config defects only | network state required for service reachability is verified |
+| `DOCKER` | platform | `MANDATORY` | Senior Python Automation Developer | per-node Docker daemon health results | runtime/platform failure | retry bounded daemon readiness, then fail | Docker daemon is healthy on every node |
+| `SWARM` | platform | `MANDATORY` | Senior Python Automation Developer | manager state, join token and `docker node ls` results | runtime/platform failure | self-remediate idempotency/parsing defects when 90 percent clear | manager active and workers joined |
+| `STACK-PORTAINER` | deployment | `MANDATORY` | Senior Python Automation Developer | stack status and endpoint probe | deployment failure | stop if secrets or stack contract are missing | Portainer stack is deployed and reachable |
+| `STACK-SUPPORTING` | deployment | `RESOURCE_GATED` | Senior Requirement Engineer | stack status for Nexus, Jenkins, RabbitMQ, SonarQube and Swagger/NGINX, plus any gate approval | resource limitation or deployment failure | Three Amigos approval required to omit any service | all services deploy for `PASS`; approved omissions produce `PASS_WITH_RESOURCE_GATES` |
+| `REACHABILITY` | verification | `MANDATORY` | Senior Tester | host endpoint probe results | service reachability failure | retry bounded readiness checks, then fail | mandatory endpoints respond from host |
+| `RERUN-SAFETY` | verification | `MANDATORY` | Senior Tester | second-run state-detection summary | destructive behavior risk | stop on implicit destructive behavior | rerun detects existing state without implicit reset |
+| `EVIDENCE` | evidence | `MANDATORY` | Senior Tester | complete redacted evidence bundle | missing evidence | block until evidence is complete | manifest, summary, phase results, probes, checksums and redaction report exist |
+| `EXTENDED-DIAGNOSTICS` | diagnostics | `OPTIONAL` | Senior DevOps Engineer | optional log tails, timing report or extra probes | diagnostic unavailable | record `NOT_APPLICABLE` | optional evidence is either present or explicitly skipped |
+
+Resource-gated approval record:
+
+- Must be written to the execution report before live deployment begins.
+- Must name the omitted service, measured host resource value, approving roles,
+  reason the service is gated and the resulting maximum status
+  `PASS_WITH_RESOURCE_GATES`.
+- Must not be used when the user requires a strict full-functionality `PASS`.
+
+## Live-Run Consent Contract
+
+Live commands are any commands that can create or delete VMs, change networking,
+install Docker, initialize or mutate Docker Swarm, deploy compose stacks, start
+port forwarding or bootstrap services.
+
+The live runner must require all of the following before any live command is
+handed to a command runner:
+
+- CLI flag: `--live`.
+- Environment variable:
+  `TSW_LIVE_INFRASTRUCTURE_CONSENT=I_UNDERSTAND_THIS_CHANGES_LOCAL_INFRASTRUCTURE`.
+- Interactive typed phrase:
+  `RUN TINY SWARM WORLD LIVE INSTALLATION`.
+
+Non-interactive live execution is refused by this workflow. A future workflow
+must explicitly define a separate non-interactive consent contract before CI or
+automation can run live infrastructure commands.
+
+Consent evidence must record:
+
+- UTC timestamp;
+- active git branch and commit;
+- host identifier with user-controlled names redacted when needed;
+- selected cleanup mode;
+- command categories approved for this run;
+- operator identity from the local environment when available, redacted if it
+  contains sensitive data.
+
+Refusal semantics:
+
+- Missing or invalid consent exits non-zero before live command execution.
+- The refusal phase is `REFUSED_LIVE_CONSENT_MISSING`.
+- The refusal report records only blocked command categories, not raw host
+  state or secrets.
+- Refusal must happen before any `multipass`, `docker swarm`, `netplan`,
+  `socat`, compose/stack deployment or service bootstrap command is executed.
+
+## Evidence Bundle Contract
+
+Evidence path:
+
+```text
+.tiny-swarm-world/evidence/live-installation/<run-id>/
+```
+
+`<run-id>` format:
+
+```text
+YYYYMMDDTHHMMSSZ-<short-git-sha>-<mode>
+```
+
+The implementation slice that creates the live runner must also add the
+evidence root to `.gitignore` before any evidence is written.
+
+Required files:
+
+- `manifest.json`: run id, workflow version, branch, commit, host class,
+  started/finished timestamps and command categories.
+- `summary.json`: final status, failed checks, resource-gated checks and next
+  action.
+- `preflight.json`: host, resource, secret-source and port validation.
+- `consent.json` or `refusal.json`: live consent result without secrets.
+- `phases/<phase-id>.json`: per-phase status, owner, timings and retries.
+- `commands/<phase-id>/<ordinal>.json`: command category, node, timeout,
+  exit code and redacted stdout/stderr.
+- `probes/<probe-id>.json`: endpoint, expected result, actual result and
+  timing.
+- `redaction-report.json`: redaction patterns applied and fields withheld.
+- `checksums.sha256`: checksums for evidence files after redaction.
+
+Redaction rules:
+
+- Never write raw secrets, passwords, tokens, join tokens, cookies, HTTP
+  authorization headers, Portainer credentials, Nexus credentials, Jenkins
+  credentials, RabbitMQ credentials, SonarQube credentials or service bootstrap
+  credentials to logs, prompts, evidence or documentation.
+- Secrets must come from environment variables or ignored local files only.
+- Secrets must not be passed as command-line arguments when a safer environment
+  or file-based mechanism is available.
+- Missing secrets fail preflight before stack deployment.
+- Redaction must apply to stdout, stderr, command metadata, URLs, headers,
+  probe results, local env snapshots and failure reports before evidence is
+  written.
 
 ## Scope
 
@@ -399,6 +550,7 @@ affected_files:
   - "documentation/workflow/workflow.md"
   - "documentation/workflow/context-pack.md"
   - "documentation/workflow/context-pack.json"
+  - "documentation/workflow/execution-report.md"
   - "OPERATIONAL_READINESS_CHECKLIST.md"
 affected_modules: []
 affected_contracts:

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,164 +1,209 @@
-# Workflow: Full Installation Integration Verification
+# Workflow: Init Safety and Boundary Separation
 
 ## Executive Summary
 
-This workflow defines the governed path for creating and running an opt-in
-integration test that proves Tiny Swarm World can perform a complete local
-installation and verify full operational functionality.
+This workflow defines the governed implementation path for making Tiny Swarm
+World safer and more explicit at the workflow level.
 
-The target proof is not a mock-only quality gate. It must verify, with recorded
-evidence, that a Linux/WSL host can bootstrap Multipass VMs, configure
-networking, install Docker, initialize Docker Swarm, join workers, deploy the
-service stacks, and reach the expected services from the host.
+The target change removes destructive VM cleanup from normal initialization,
+introduces separate `reconcile`, `reset`, and `destroy` workflows, separates
+Platform, Artifacts, and Deployment responsibilities, moves the CLI from
+low-level service execution to workflow execution, extracts Nexus stack
+deployment into Deployment ownership, strengthens command YAML typing,
+introduces a state/inventory model, and requires verification after every
+mutating apply step.
 
-The workflow does not execute live infrastructure during workflow creation.
-Live Multipass, Docker Swarm, netplan, socat and stack deployment commands stay
-behind an explicit opt-in gate during workflow execution.
+Workflow creation does not execute live infrastructure. All Multipass, Docker
+Swarm, netplan, socat, compose, Portainer, Nexus, Jenkins, RabbitMQ, SonarQube,
+and Swagger/NGINX operations remain forbidden unless a later workflow execution
+receives explicit live infrastructure approval.
 
 ## Target Picture
 
 ### Verified Baseline
 
-- The repository default quality gate is `python3 tools/quality_gate.py quality`.
-- The default quality gate must not create VMs, change networking, deploy
-  Docker stacks or bootstrap local services.
-- `AUDIT_REPORT.md` records that full end-to-end operational readiness was not
-  verified and that live Multipass/Docker/Swarm evidence is missing.
-- `OPERATIONAL_READINESS_CHECKLIST.md` records open readiness items for host,
-  VM, network, Docker, Swarm, stack deployment, services, smoke tests,
-  observability and documentation.
-- The current package entrypoint exposes explicit service choices only:
-  `multipass-init-vms`, `network-prepare-netplan`, `network-setup-netplan`,
-  `multipass-restart-vms`, `multipass-docker-install`,
-  `multipass-docker-swarm-init` and `vm-ip-list`.
-- Service stack deployment exists as separate preparation or compose scripts,
-  not as a single verified canonical full-install command.
+- Root `AGENTS.md` defines Tiny Swarm World as a Linux/WSL-only Python
+  automation project with hexagonal architecture.
+- `QUALITY.md` defines the default quality gate as:
+
+```bash
+python3 tools/quality_gate.py quality
+```
+
+- The default quality gate must not create VMs, mutate networking, initialize
+  Docker Swarm, deploy stacks, or bootstrap services.
+- `src/tiny_swarm_world/application/services/multipass/multipass_init_vms.py`
+  currently runs `command_multipass_clean_repository_yaml.yaml` before normal
+  initialization.
+- `infra/config/multipass/command_multipass_clean_repository_yaml.yaml`
+  currently contains `multipass delete --all` and `multipass purge`.
+- `src/tiny_swarm_world/infrastructure/composition.py` currently exposes
+  `PlatformServices` and aliases `ApplicationServices = PlatformServices`.
+- `src/tiny_swarm_world/__main__.py` currently exposes low-level service names
+  through `--run`, not workflow-level commands.
+- Nexus stack deployment behavior currently lives under
+  `application/services/nexus/ensure_nexus_stack.py` while the Deployment
+  namespace re-exports it as a compatibility facade.
+- Command YAML loading validates only indirectly by constructing
+  `CommandEntity` from loose dictionary keys.
+- No durable state/inventory model currently separates desired inventory from
+  observed runtime state.
+- `infra/config/network/netplant/command_netplant_setup_yaml.yaml` ends with
+  `netplan apply` and does not require a typed verification gate afterwards.
+- `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`
+  already proposes Platform, Artifacts, Deployment, and Shared responsibility
+  boundaries.
 
 ### Target Outcome
 
 The completed workflow must produce:
 
-- a non-destructive live-test contract and preflight gate;
-- a canonical full-installation verification path;
-- deterministic evidence for every installation phase;
-- automated health checks for Docker Swarm and deployed services;
-- explicit remediation loops for blockers that can be solved with at least
-  90 percent confidence;
-- a Three Amigos question-answer escalation path for blockers that require
-  product, architecture or test clarification;
-- documentation that tells an operator how to run the full integration test and
-  interpret failures.
+- a non-destructive normal `init` path;
+- separate `reconcile`, `reset`, `destroy`, and `verify` workflows;
+- explicit destructive-operation policy and tests proving that `init` and
+  `reconcile` cannot execute delete/purge behavior;
+- real `PlatformServices`, `ArtifactServices`, and `DeploymentServices`
+  builders and dataclasses in the composition root;
+- a workflow-level CLI that remains thin and delegates to composed workflows;
+- Nexus stack deployment owned by Deployment, while Nexus repository and
+  artifact behavior stays in Artifacts;
+- typed command YAML contracts with command identity, intent, safety class,
+  parameters, effects, allowed workflows, and verification specs;
+- a state/inventory model that separates desired configuration from observed
+  runtime facts;
+- mandatory verify-after-apply behavior for platform and deployment changes;
+- architecture tests and documentation that protect the new boundaries.
 
 ## Requirement Clarification Record
 
 Original request:
 
 ```text
-Erstelle einen workflow fuer einen Integrationstest, der eine vollstaendige
-Installations prueft, vollstaendige funktionsfaehigkeit. Falls blocker
-entstehen, diese vollstaendig selbst loesen wenn dies zu 90% moeglich ist,
-ansonsten rueckfragen stellen, damit ein 3 Amigo Frage Antwort prozess
-gestartet werden kann.
+Workflow create with subagents:
+1. Destruktive VM-Cleanup-Schritte aus dem normalen Init entfernen
+2. reconcile/reset/destroy als getrennte Workflows einfuehren
+3. PlatformServices, ArtifactServices und DeploymentServices wirklich trennen
+4. CLI auf Workflow-Ebene umbauen
+5. Nexus Stack Deployment aus Artifacts/Nexus herausloesen
+6. Command-YAMLs staerker typisieren
+7. State-/Inventory-Modell einfuehren
+8. Verify-Schritte nach jedem Apply erzwingen
 ```
 
 Interpreted intent:
 
-- Create a repository workflow for an opt-in integration test that proves the
-  full installation and functional readiness of Tiny Swarm World.
-- Include all major operational phases from host readiness through service
-  reachability.
-- Make blocker handling explicit: self-remediate when confidence is at least
-  90 percent, otherwise stop and ask Three Amigos clarification questions.
-- Preserve root `AGENTS.md`, `QUALITY.md`, hexagonal architecture and live
-  infrastructure safety constraints.
+- Create a repository workflow, using subagent review, for an architecture and
+  automation refactoring that makes normal initialization safe, separates
+  explicit workflow intent, and enforces state verification.
+- Treat Platform, Artifacts, and Deployment as responsibility boundaries inside
+  the existing Python automation architecture. This workflow does not claim
+  they are independently deployable microservices.
+- Preserve root `AGENTS.md`, `QUALITY.md`, hexagonal imports, live
+  infrastructure safety, and the Linux/WSL-only operating model.
 
 Change type:
 
-- Workflow creation and verification-governance planning.
-- Future implementation of integration-test harness, preflight checks,
-  live-test evidence capture and documentation.
+- Workflow creation and future implementation planning.
+- Future production-code changes to application services, domain models,
+  ports, infrastructure adapters, command YAMLs, CLI and tests.
+- Future documentation synchronization for arc42, README and user/operator
+  documentation.
 
 Affected process strand:
 
 - `workflow create`.
 
-Affected architecture area:
+Affected architecture areas:
 
-- Platform automation: Multipass, VM lifecycle, network, netplan, socat,
-  Docker install, Docker Swarm init and worker join.
-- Deployment automation: Portainer, compose stack deployment and service
-  reachability.
-- Shared automation: command workflow, YAML handling, logging, failure
-  propagation and evidence capture.
-- Documentation and operational readiness.
+- Platform automation: VM lifecycle, network, Docker install, Swarm init/join,
+  runtime probes and inventory facts.
+- Artifact automation: Nexus repository/user/readiness behavior, Docker/Maven
+  publishing contracts, image build/push contracts.
+- Deployment automation: compose stacks, Portainer stack create/update/upload,
+  Nexus stack deployment and service lifecycle.
+- Shared automation: command catalog, YAML handling, command result evidence,
+  composition root, CLI dispatch and quality gates.
 
 Explicit requirements:
 
-- Create a workflow for a full installation integration test.
-- Verify complete functionality, not only command construction.
-- Resolve blockers completely when the solution path is at least 90 percent
-  clear.
-- Ask clarifying questions and start a Three Amigos Q&A process when blockers
-  cannot be solved confidently.
+- Remove destructive VM cleanup from normal init.
+- Introduce `reconcile`, `reset`, and `destroy` as separate workflows.
+- Truly separate PlatformServices, ArtifactServices and DeploymentServices.
+- Rebuild CLI around workflow-level commands.
+- Extract Nexus stack deployment from Artifacts/Nexus ownership.
+- Strongly type command YAMLs.
+- Introduce a state/inventory model.
+- Force verification steps after every apply.
 
 Implicit requirements:
 
-- Do not run live infrastructure commands during normal development gates.
-- Make the integration test opt-in and visibly live/destructive-risk aware.
-- Separate preflight, dry-run/static checks and live execution.
-- Collect logs, command results and endpoint health evidence.
-- Keep the Python automation architecture hexagonal.
-- Keep `src/main/java` out of scope unless service reachability requires a
-  deployed example application in a later clarified workflow.
+- Keep `__main__.py` thin.
+- Keep concrete adapter construction in `infrastructure/composition.py`.
+- Do not weaken `.importlinter`, architecture tests or quality gates.
+- Do not run live infrastructure during normal development or workflow
+  creation.
+- Keep tests mock-based and deterministic unless a later live workflow
+  explicitly allows integration execution.
+- Update arc42 and user/operator documentation when behavior changes.
 
-Assumptions:
+Assumptions accepted for workflow creation:
 
-- "Complete installation" means the product scope described by the repository:
-  Multipass VMs, Docker Swarm and the supported service stacks.
-- "Complete functionality" means host reachability and runtime health for the
-  deployed local infrastructure services listed in README and AGENTS.md.
-- The integration test may add new opt-in tooling, but must not weaken the
-  default quality gate.
-- Live execution requires an explicit workflow-execution approval before any
-  Multipass, Docker Swarm, netplan, socat or stack deployment command runs.
+- `init` means create or prepare missing managed resources without deletion.
+- `reconcile` means converge existing managed state non-destructively.
+- `reset` means explicit reinitialization of managed runtime resources and may
+  run destructive commands only after a dedicated reset confirmation contract.
+- `destroy` means explicit teardown of managed runtime resources and may run
+  destructive commands only after a dedicated destroy confirmation contract.
+- `verify` means inspect and report current state without mutating resources.
+- Desired inventory is product configuration and may live under committed
+  `infra/config` files.
+- Observed runtime inventory and command evidence must live under an ignored
+  local state/evidence root such as `.tiny-swarm-world/`.
+- Exact reset/destroy retention rules are implementation acceptance criteria in
+  Slice 01 and must be documented before destructive code is changed.
 
 Non-goals:
 
 - No live infrastructure execution during workflow creation.
-- No Java deployment-example changes.
-- No cloud provider support.
-- No Windows-native PowerShell or backslash-path runtime model.
+- No Java example application changes.
+- No Windows-native runtime expansion.
+- No big-bang source tree move.
 - No default CI job that runs live Multipass or Docker Swarm.
-- No secret defaults committed to the repository.
+- No conversion of Platform, Artifacts and Deployment into microservices.
+- No committed secrets, host-specific absolute paths or local state snapshots.
 
 Risks:
 
-- Current orchestration is not proven end-to-end.
-- Some existing setup behavior may be destructive or not idempotent.
-- Stack deployment may require secret handling and Portainer initialization.
-- Network and port-forwarding behavior differs between native Linux and WSL.
-- Full live validation can be slow and host-dependent.
+- Current normal init can delete and purge all Multipass VMs.
+- Some existing tests are skipped or stale around Multipass init behavior.
+- Command workflow execution is filename-driven and currently coupled to UI
+  runner adapters.
+- Nexus bootstrap combines stack deployment, readiness, admin access and
+  anonymous access.
+- The proposed responsibility ADR is still `Status: Proposed`.
+- arc42 runtime, deployment, decision, quality and risk pages are currently
+  sparse and need synchronization when behavior changes.
+- A dirty worktree was detected during workflow creation with source/preflight
+  changes outside the workflow artifact edits. Workflow execution must resolve
+  overlap before editing those files.
 
 Open questions:
 
-- Which services are mandatory for the first "full functionality" proof if a
-  host lacks resources for all stacks?
-- Should the live test require a clean host, or may it reconcile an existing
-  Tiny Swarm World environment?
-- Which cleanup mode is acceptable after a successful live run: preserve,
-  stop-only, or destroy?
+- Which exact CLI flag names and typed phrases should be used for reset and
+  destroy confirmation?
+- Which reset mode preserves Docker images, volumes, stack data and evidence?
+- Which observed state files are retained after destroy?
 
 Blocking questions:
 
-- None for workflow creation. The open questions become live-execution gates
-  and are handled through the Three Amigos escalation path when they affect a
-  concrete run.
+- None for workflow creation. The open questions are execution gates for
+  Slice 01 and stop implementation until answered in that slice.
 
 Confidence level:
 
-- 92 percent for workflow creation.
-- Less than 90 percent for immediate live execution without additional operator
-  approval and environment facts.
+- 91 percent for workflow creation.
+- Less than 90 percent for live execution or implementation without completing
+  Slice 01.
 
 Decision:
 
@@ -168,400 +213,189 @@ READY_FOR_WORKFLOW
 
 EPIC traceability:
 
-- No `documentation/epics` directory exists in the repository.
-- Answer to "Does the implementation still match the EPIC?": no EPIC source is
-  available; this is recorded as a traceability gap, not a workflow-creation
-  blocker.
-- Temporary requirement baseline for this workflow: the original user request,
-  root `AGENTS.md`, root `QUALITY.md`, `AUDIT_REPORT.md`,
-  `OPERATIONAL_READINESS_CHECKLIST.md`, this Requirement Clarification Record
-  and `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`.
-  The user request `workflow execute with subagents` on 2026-05-23 accepts this
-  workflow as the execution target until a dedicated EPIC is added.
+- No `documentation/epics` files are present.
+- Answer to "Does the implementation still match the EPIC?": cannot verify
+  against a dedicated EPIC because no EPIC source exists.
+- Temporary requirement baseline for this workflow: the user request, root
+  `AGENTS.md`, root `QUALITY.md`, the existing architecture documentation,
+  current arc42 files, subagent reviews, and
+  `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`.
 
 ## Three Amigos Review
 
 ### Senior Requirement Engineer
 
-- The requirement is testable when "complete installation" is decomposed into
-  host, Python, VM, network, Docker, Swarm, deployment, service reachability,
-  evidence and rerun checks.
-- The workflow must define mandatory and optional functionality explicitly.
-- Open live-run policy questions are non-blocking for workflow authoring.
+- The requirement is actionable when the workflow defines operation taxonomy,
+  destructive-operation policy, acceptance criteria and stop conditions.
+- Missing EPIC traceability is recorded as a gap, not a workflow-creation
+  blocker.
+- Reset/destroy retention policy must be settled before implementation runs
+  destructive code.
 
 ### Senior System Architect
 
-- The integration test must exercise platform and deployment behavior without
-  moving concrete adapter construction out of `infrastructure/composition.py`.
-- Live-test tooling must remain outside domain code.
-- Stack deployment verification belongs to the Deployment responsibility.
-- VM, network, Docker and Swarm verification belongs to the Platform
-  responsibility.
+- Platform, Artifacts and Deployment are responsibility boundaries in the
+  Python automation, not independent runtime services.
+- `composition.py` remains the wiring root.
+- `__main__.py` remains a thin CLI entrypoint.
+- Nexus stack deployment belongs to Deployment. Nexus repository and artifact
+  behavior belongs to Artifacts.
+- Typed command YAML and state/inventory contracts must precede workflow
+  execution changes.
 
 ### Senior Python Automation Developer
 
-- Preflight, orchestration and probes should be implemented as small
-  application use cases behind ports where behavior becomes reusable.
-- The live runner can live under `tools/` as an operator entrypoint while using
-  application services through composition.
-- Constructors must not execute external commands.
-- Command results must preserve exit code, stdout, stderr, node identity and
-  phase identity.
+- Command YAML should become a typed command catalog with command identity,
+  intent, execution mode, safety class, effects and verification.
+- A state/inventory model should separate desired configuration from observed
+  facts for VMs, network, Docker, Swarm, stacks, services and artifacts.
+- Normal init must not reference the current clean command YAML.
+- Apply workflows must not return success until their verify step passes.
 
 ### Senior React Frontend Developer
 
-- No frontend module exists and this workflow does not introduce one.
-- UI verification is endpoint reachability and HTTP/API readiness only.
-- If later evidence dashboards are requested, that requires a separate
-  frontend workflow.
+- No React or browser frontend module is present.
+- This workflow has no frontend build or UI implementation impact.
+- User experience impact is CLI/operator UX: discoverable workflows, explicit
+  destructive intent, clear refusal messages and actionable verification
+  failures.
+- Future dashboards or evidence viewers require a separate frontend workflow.
 
 ### Senior Tester
 
-- Default tests must remain mock-based and deterministic.
-- Live integration checks must be skipped unless an explicit environment
-  variable and command-line confirmation are both present.
-- The live test must fail on partial installation, hidden command failure,
-  missing health evidence or unreachable mandatory services.
-- The workflow needs a dry-run mode before live execution.
+- Default tests must remain static or mock-based.
+- Required gates must come from `QUALITY.md`.
+- Tests must prove destructive cleanup is unreachable from `init` and
+  `reconcile`.
+- Tests must prove malformed command YAML fails closed.
+- Tests must prove apply/verify result states are distinct.
 
 ### Dependency And Deadlock Validator
 
-- The workflow has one critical chain: preflight -> orchestration contract ->
-  platform readiness -> deployment readiness -> live runner -> docs.
-- Documentation updates can happen late, but must consume actual command names
-  and evidence paths produced by the implementation slices.
-- Live execution is gated after implementation and quality gates, so it does
-  not deadlock default development verification.
+- Typed command YAML and state/inventory are foundational contracts and should
+  precede workflow-level mutation changes.
+- Service wiring separation and Nexus extraction can proceed after the
+  architecture baseline stabilizes.
+- CLI work depends on the workflow taxonomy and service builders.
+- Verify-after-apply depends on typed command specs, inventory state and
+  workflow dispatch.
+- Documentation and legacy cleanup are last to avoid publishing unsupported
+  behavior.
 
-## Complete Functionality Definition
+## Workflow Contracts
 
-The integration test proves complete functionality only when all mandatory
-checks pass:
+### Operation Taxonomy
 
-- Host environment: Linux or WSL detected, Python version supported,
-  dependencies installed, Multipass available, Docker CLI available where
-  required, and required ports not occupied.
-- Python entrypoint: canonical commands are discoverable from repository root.
-- VM lifecycle: manager and worker VMs exist or are created according to the
-  selected mode, and VM state is verified.
-- Network: manager IP, worker IPs, gateway, netplan transfer/application and
-  WSL/Linux forwarding checks are verified.
-- Docker: Docker daemon is installed and healthy on every node.
-- Swarm: manager is active, worker token retrieval succeeds, workers are joined
-  and visible through `docker node ls`.
-- Deployment: Portainer stack deploys and at least Nexus, Jenkins, RabbitMQ,
-  SonarQube and Swagger/NGINX stacks are deployed or explicitly classified as
-  resource-gated with Three Amigos approval.
-- Reachability: mandatory service endpoints respond from the host or produce
-  actionable failure evidence.
-- Rerun safety: a second verification run detects existing state and does not
-  perform an implicit destructive reset.
-- Evidence: logs, command results, endpoint probe results and readiness summary
-  are stored under a deterministic ignored artifact directory.
+| Workflow | Mutation | Destructive commands allowed | Purpose | Required result |
+| --- | --- | --- | --- | --- |
+| `init` | yes | no | create missing managed resources and fail on ambiguous conflicts | applied then verified |
+| `reconcile` | yes | no | converge existing managed resources without deletion | reconciled then verified |
+| `reset` | yes | yes, gated | explicitly reinitialize selected managed resources | reset then verified |
+| `destroy` | yes | yes, gated | explicitly tear down selected managed resources | destroyed then verified absent |
+| `verify` | no | no | inspect desired versus observed state | observed state report |
 
-Run result states:
+### Destructive Operation Policy
 
-- `PASS`: all mandatory checks pass, no resource-gated mandatory service is
-  omitted, no live safety refusal occurred and evidence is complete.
-- `PASS_WITH_RESOURCE_GATES`: all non-gated mandatory checks pass, one or more
-  resource-gated services are omitted with recorded Three Amigos approval and
-  evidence is complete. This is not a full-functionality pass.
-- `REFUSED`: the runner stopped before any live command because live consent was
-  missing or invalid.
-- `BLOCKED`: preflight or requirement scope prevents a valid run.
-- `FAIL`: a mandatory check ran and failed.
+- Commands containing VM deletion, purge, stack deletion, volume removal,
+  Docker prune, netplan deletion, socat teardown or credential reset must be
+  classified as destructive in the typed command catalog.
+- Destructive commands must declare `allowed_workflows` and may only be
+  selected by `reset` or `destroy`.
+- `init` and `reconcile` must fail at validation time if their command plan
+  contains destructive commands.
+- `reset` and `destroy` require explicit CLI intent and a confirmation contract
+  defined in Slice 01 before implementation.
+- Cleanup of generated evidence or local observed-state files is not implied by
+  destroy unless a separate cleanup option is explicitly defined and tested.
 
-## Integration Test Contract
+### Command YAML Contract
 
-Check categories:
+Future command YAML entries must become typed command specs with at least:
 
-- `MANDATORY`: required for `PASS`; failure or missing evidence blocks the run.
-- `RESOURCE_GATED`: normally mandatory, but may be omitted only when host
-  resources are below the full-run threshold and Three Amigos approval records
-  the reduced scope. The best possible result is `PASS_WITH_RESOURCE_GATES`.
-- `OPTIONAL`: diagnostic only; omission must be recorded as `NOT_APPLICABLE`
-  and does not block `PASS`.
+- `id`
+- `description`
+- `intent`
+- `execution_mode`
+- `safety_class`
+- `scope`
+- `allowed_workflows`
+- `parameters`
+- `effects`
+- `verify`
+- `runner`
+- `command_type`
+- `vm_type`
+- `command`
 
-Full-run resource threshold:
+Validation must reject:
 
-- At least 4 vCPU available to the Linux/WSL environment.
-- At least 16 GiB RAM available to the Linux/WSL environment.
-- At least 60 GiB free disk in the target Multipass/Docker storage path.
-- If any threshold is not met, deploying Jenkins, SonarQube or the full
-  supporting-service set requires Three Amigos approval before it can be
-  resource-gated.
+- missing required fields;
+- duplicate indexes or IDs;
+- unknown runner, command type, VM type, intent or safety class;
+- destructive shell strings without destructive classification;
+- command specs without a required verification declaration when they mutate
+  state;
+- workflow plans whose command safety class is not allowed for that workflow.
 
-Contract table:
+### State And Inventory Contract
 
-| Check ID | Phase | Category | Owner | Evidence Required | Failure Classification | Remediation Policy | Pass Condition |
-|---|---|---|---|---|---|---|---|
-| `REQ-BASELINE` | requirement | `MANDATORY` | Senior Requirement Engineer | requirement baseline entry in execution report | product-scope ambiguity | stop for Three Amigos if baseline is disputed | active workflow baseline is accepted or EPIC is added |
-| `LIVE-CONSENT` | safety | `MANDATORY` | Senior Security Sandbox Engineer | consent or refusal JSON | missing live consent | refuse before live command execution | live mode has valid consent, or dry-run mode avoids live commands |
-| `PREFLIGHT` | preflight | `MANDATORY` | Senior DevOps Engineer | `preflight.json` | host prerequisite missing | self-remediate only for deterministic local checks; otherwise ask operator | all mandatory prerequisites pass |
-| `HOST` | preflight | `MANDATORY` | Senior DevOps Engineer | OS, WSL/Linux, Python, Multipass, Docker CLI and port checks | host prerequisite missing | stop with actionable host remediation | host satisfies runtime prerequisites |
-| `PYTHON-ENTRYPOINT` | preflight | `MANDATORY` | Senior Python Automation Developer | command output for service discovery | implementation defect | self-remediate in owning slice when 90 percent clear | canonical entrypoint is discoverable from repo root |
-| `VM-LIFECYCLE` | platform | `MANDATORY` | Senior Python Automation Developer | manager and worker VM state results | runtime/platform failure | retry bounded readiness checks, then classify | expected VMs exist or are created and verified |
-| `NETWORK` | platform | `MANDATORY` | Senior Python Automation Developer | IP, gateway, netplan and forwarding probe results | runtime/platform failure | self-remediate deterministic path/config defects only | network state required for service reachability is verified |
-| `DOCKER` | platform | `MANDATORY` | Senior Python Automation Developer | per-node Docker daemon health results | runtime/platform failure | retry bounded daemon readiness, then fail | Docker daemon is healthy on every node |
-| `SWARM` | platform | `MANDATORY` | Senior Python Automation Developer | manager state, join token and `docker node ls` results | runtime/platform failure | self-remediate idempotency/parsing defects when 90 percent clear | manager active and workers joined |
-| `STACK-PORTAINER` | deployment | `MANDATORY` | Senior Python Automation Developer | stack status and endpoint probe | deployment failure | stop if secrets or stack contract are missing | Portainer stack is deployed and reachable |
-| `STACK-SUPPORTING` | deployment | `RESOURCE_GATED` | Senior Requirement Engineer | stack status for Nexus, Jenkins, RabbitMQ, SonarQube and Swagger/NGINX, plus any gate approval | resource limitation or deployment failure | Three Amigos approval required to omit any service | all services deploy for `PASS`; approved omissions produce `PASS_WITH_RESOURCE_GATES` |
-| `REACHABILITY` | verification | `MANDATORY` | Senior Tester | host endpoint probe results | service reachability failure | retry bounded readiness checks, then fail | mandatory endpoints respond from host |
-| `RERUN-SAFETY` | verification | `MANDATORY` | Senior Tester | second-run state-detection summary | destructive behavior risk | stop on implicit destructive behavior | rerun detects existing state without implicit reset |
-| `EVIDENCE` | evidence | `MANDATORY` | Senior Tester | complete redacted evidence bundle | missing evidence | block until evidence is complete | manifest, summary, phase results, probes, checksums and redaction report exist |
-| `EXTENDED-DIAGNOSTICS` | diagnostics | `OPTIONAL` | Senior DevOps Engineer | optional log tails, timing report or extra probes | diagnostic unavailable | record `NOT_APPLICABLE` | optional evidence is either present or explicitly skipped |
+- Desired inventory describes intended managed resources and belongs to product
+  configuration, currently rooted under `infra/config`.
+- Observed inventory describes discovered runtime facts and must be kept in an
+  ignored local state root, not committed product config.
+- Inventory must distinguish desired VMs, observed VM facts, network facts,
+  Docker daemon facts, Swarm membership, stack deployment facts, service
+  endpoint facts and artifact registry facts.
+- Verification produces typed status: `not_checked`, `verified`,
+  `failed_to_apply`, `failed_to_verify`, `blocked`, or `refused`.
+- Domain models must not import YAML, filesystem, command runners, HTTP clients
+  or infrastructure adapters.
 
-Resource-gated approval record:
+### Verify-After-Apply Contract
 
-- Must be written to the execution report before live deployment begins.
-- Must name the omitted service, measured host resource value, approving roles,
-  reason the service is gated and the resulting maximum status
-  `PASS_WITH_RESOURCE_GATES`.
-- Must not be used when the user requires a strict full-functionality `PASS`.
-
-## Live-Run Consent Contract
-
-Live commands are any commands that can create or delete VMs, change networking,
-install Docker, initialize or mutate Docker Swarm, deploy compose stacks, start
-port forwarding or bootstrap services.
-
-The live runner must require all of the following before any live command is
-handed to a command runner:
-
-- CLI flag: `--live`.
-- Environment variable:
-  `TSW_LIVE_INFRASTRUCTURE_CONSENT=I_UNDERSTAND_THIS_CHANGES_LOCAL_INFRASTRUCTURE`.
-- Interactive typed phrase:
-  `RUN TINY SWARM WORLD LIVE INSTALLATION`.
-
-Non-interactive live execution is refused by this workflow. A future workflow
-must explicitly define a separate non-interactive consent contract before CI or
-automation can run live infrastructure commands.
-
-Consent evidence must record:
-
-- UTC timestamp;
-- active git branch and commit;
-- host identifier with user-controlled names redacted when needed;
-- selected cleanup mode;
-- command categories approved for this run;
-- operator identity from the local environment when available, redacted if it
-  contains sensitive data.
-
-Refusal semantics:
-
-- Missing or invalid consent exits non-zero before live command execution.
-- The refusal phase is `REFUSED_LIVE_CONSENT_MISSING`.
-- The refusal report records only blocked command categories, not raw host
-  state or secrets.
-- Refusal must happen before any `multipass`, `docker swarm`, `netplan`,
-  `socat`, compose/stack deployment or service bootstrap command is executed.
-
-## Evidence Bundle Contract
-
-Evidence path:
-
-```text
-.tiny-swarm-world/evidence/live-installation/<run-id>/
-```
-
-`<run-id>` format:
-
-```text
-YYYYMMDDTHHMMSSZ-<short-git-sha>-<mode>
-```
-
-The implementation slice that creates the live runner must also add the
-evidence root to `.gitignore` before any evidence is written.
-
-Required files:
-
-- `manifest.json`: run id, workflow version, branch, commit, host class,
-  started/finished timestamps and command categories.
-- `summary.json`: final status, failed checks, resource-gated checks and next
-  action.
-- `preflight.json`: host, resource, secret-source and port validation.
-- `consent.json` or `refusal.json`: live consent result without secrets.
-- `phases/<phase-id>.json`: per-phase status, owner, timings and retries.
-- `commands/<phase-id>/<ordinal>.json`: command category, node, timeout,
-  exit code and redacted stdout/stderr.
-- `probes/<probe-id>.json`: endpoint, expected result, actual result and
-  timing.
-- `redaction-report.json`: redaction patterns applied and fields withheld.
-- `checksums.sha256`: checksums for evidence files after redaction.
-
-Redaction rules:
-
-- Never write raw secrets, passwords, tokens, join tokens, cookies, HTTP
-  authorization headers, Portainer credentials, Nexus credentials, Jenkins
-  credentials, RabbitMQ credentials, SonarQube credentials or service bootstrap
-  credentials to logs, prompts, evidence or documentation.
-- Secrets must come from environment variables or ignored local files only.
-- Secrets must not be passed as command-line arguments when a safer environment
-  or file-based mechanism is available.
-- Missing secrets fail preflight before stack deployment.
-- Redaction must apply to stdout, stderr, command metadata, URLs, headers,
-  probe results, local env snapshots and failure reports before evidence is
-  written.
-
-## Scope
-
-In scope:
-
-- Workflow and context documentation.
-- Future opt-in live integration test harness.
-- Preflight checks for host, Python, Multipass, Docker, ports, secrets and
-  resource availability.
-- Dry-run command plan verification.
-- Full live install sequence verification.
-- Health probes for platform and service endpoints.
-- Evidence capture and failure reporting.
-- Documentation updates and readiness checklist synchronization.
-
-Out of scope:
-
-- Executing live infrastructure during workflow creation.
-- Running live infrastructure in default CI.
-- Expanding Windows-native support.
-- Refactoring unrelated legacy modules.
-- Changing Java example application behavior.
-
-## Architecture Constraints
-
-- Preserve hexagonal architecture.
-- Domain code must not import application or infrastructure.
-- Application services depend on ports and domain objects, not concrete
-  adapters.
-- Infrastructure adapters implement ports and own technology-specific behavior.
-- Standard runtime wiring remains in `src/tiny_swarm_world/infrastructure/composition.py`.
-- `src/tiny_swarm_world/__main__.py` stays thin.
-- Live-test tooling must make live side effects explicit.
-- Secrets must come from environment or ignored local files, never committed
-  defaults.
-- Linux/WSL and POSIX paths are the only supported runtime model.
-
-## Python Automation Assessment
-
-Expected implementation direction:
-
-- Add a preflight model that validates host/runtime readiness before any live
-  command runs.
-- Add or expose a canonical full-install command sequence without hiding
-  external execution in constructors.
-- Add structured phase results for VM, network, Docker, Swarm, deployment and
-  service probes.
-- Keep command construction deterministic and testable with mocks.
-- Preserve `PYTHONPATH=src` or package execution behavior documented by the
-  repository until packaging is explicitly changed.
-
-## Frontend Assessment
-
-No frontend changes are planned. The integration test checks operational
-endpoints, not browser UX. Any future dashboard, replay UI or evidence viewer
-requires a separate frontend workflow and Three Amigos review.
-
-## Test Strategy
-
-Default verification:
-
-```bash
-python3 tools/quality_gate.py lint
-python3 tools/quality_gate.py arch-lint
-python3 tools/quality_gate.py arch-tests
-python3 tools/quality_gate.py typecheck
-python3 tools/quality_gate.py test
-python3 tools/quality_gate.py quality
-```
-
-Targeted development checks should use the nearest relevant existing gate from
-`QUALITY.md`. New live integration tooling must also include deterministic unit
-tests with mocked command execution and mocked endpoint probes.
-
-Live verification:
-
-- introduced by a later implementation slice;
-- never included in the default quality gate;
-- requires explicit operator confirmation;
-- refuses to run without a successful preflight;
-- stores evidence in an ignored artifact directory;
-- reports every failed phase with owner, command, exit status and remediation
-  classification.
-
-## Resilience Requirements
-
-- Every external command must have a timeout.
-- Retriable readiness checks must have bounded retries and diagnostics.
-- Non-retriable critical failures must abort the live run.
-- Cleanup must be explicit and never implicit after failure.
-- Reruns must detect existing VMs, Docker state, Swarm state and stacks.
-- A failure report must separate host blockers, product defects, configuration
-  gaps, secret gaps and resource limits.
-
-## Blocker Remediation And Three Amigos Q&A
-
-When a blocker appears during workflow execution, use this decision path:
-
-1. Capture evidence: phase, command or probe, expected result, actual result,
-   logs, exit code, stdout, stderr and affected files.
-2. Classify the blocker:
-   - host prerequisite missing;
-   - configuration or secret missing;
-   - deterministic implementation defect;
-   - flaky runtime readiness;
-   - architecture ambiguity;
-   - product-scope ambiguity;
-   - resource limitation.
-3. Self-remediate only when all are true:
-   - root cause confidence is at least 90 percent;
-   - the fix stays inside the active slice write scope;
-   - the fix does not require new product policy;
-   - the fix preserves architecture and safety rules;
-   - verification can prove the fix in the current environment.
-4. Retry at most three targeted remediation loops for the same blocker.
-5. Stop and start Three Amigos Q&A when confidence is below 90 percent, the
-   fix requires scope clarification, the environment decision belongs to the
-   operator, or the third retry fails.
-
-Three Amigos Q&A must ask concise blocking questions with these roles:
-
-- Requirement: what result must count as successful functionality?
-- Architecture: which boundary or runtime behavior is authoritative?
-- Testing: what evidence proves the run is acceptable?
-- Python automation: which command, adapter or workflow owns the fix?
-- Operations: which host, secret, resource or cleanup decision is allowed?
+- Every mutating workflow step must declare a verify step.
+- A workflow may proceed to the next mutating step only after the previous
+  verify step passes.
+- Verification failure is not the same as apply failure and must be reported
+  separately.
+- Automatic retry or repair after failed verification is allowed only when the
+  owning workflow explicitly defines the bounded retry behavior.
+- No workflow may silently continue after missing verification evidence.
 
 ## Ordered Slices
 
-### Slice 01 - Integration Test Contract
+### Slice 01 - Requirement And Safety Contract
 
 Purpose:
 
-- Convert this workflow into a concrete integration-test contract with
-  mandatory checks, optional checks, live-run consent and evidence semantics.
+- Define the operation taxonomy, destructive-operation policy, reset/destroy
+  confirmation contract, inventory ownership assumptions and acceptance
+  criteria before production code changes.
 
 ```yaml
 slice_id: "01"
 profile: "FULL_PATH"
 owner: "Senior Requirement Engineer"
 secondary_reviewers:
-  - "Senior Tester"
   - "Senior System Architect"
+  - "Senior Tester"
+  - "Senior Security Sandbox Engineer"
 affected_files:
-  - "documentation/workflow/workflow.md"
-  - "documentation/workflow/context-pack.md"
-  - "documentation/workflow/context-pack.json"
-  - "documentation/workflow/execution-report.md"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
+  - "documentation/workflow/**"
+  - "documentation/architecture/**"
 affected_modules: []
 affected_contracts:
-  - "full-installation-integration-test-contract"
+  - "operation-taxonomy"
+  - "destructive-operation-policy"
+  - "reset-destroy-confirmation"
 dependencies: []
 parallel_group: "A"
 file_locks:
   - "documentation/workflow/**"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
+  - "documentation/architecture/**"
 contract_locks:
-  - "integration-test-success-criteria"
+  - "operation-taxonomy"
+  - "destructive-operation-policy"
 architecture_locks:
   - "live-infrastructure-safety"
 quality_gates:
@@ -570,461 +404,782 @@ quality_gates:
   required:
     - "git diff --check"
 documentation:
-  arc42: "check only"
-  adr: "check ADR platform/artifacts/deployment split"
+  arc42: "check constraints, runtime, quality and risks"
+  adr: "check destructive operation ADR need"
 stop_conditions:
-  - "mandatory functionality cannot be defined without product clarification"
-  - "live-run consent semantics are unclear"
+  - "reset or destroy confirmation semantics are unclear"
+  - "init or reconcile semantics would still allow implicit deletion"
 ```
 
 Allowed write scope:
 
-- Workflow and readiness documentation only.
+- Workflow and architecture documentation only.
 
 Done criteria:
 
-- Mandatory, optional and resource-gated checks are explicit.
-- Live side effects require opt-in consent.
-- Evidence semantics are documented.
+- `init`, `reconcile`, `reset`, `destroy`, and `verify` are defined.
+- Destructive operation policy is explicit.
+- EPIC trace gap is recorded.
+- Implementation slices have testable acceptance criteria.
 
-### Slice 02 - Preflight And Configuration Validation
+Verification commands:
+
+```bash
+git diff --check
+python3 -m json.tool documentation/workflow/context-pack.json
+```
+
+### Slice 02 - ADR And arc42 Baseline
 
 Purpose:
 
-- Add deterministic preflight checks that fail before live side effects when
-  host, dependencies, secrets, ports or resource limits are not ready.
+- Accept or supersede the proposed Platform/Artifacts/Deployment ADR and align
+  arc42 baseline sections before boundary-moving slices.
 
 ```yaml
 slice_id: "02"
 profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
+owner: "Senior System Architect"
 secondary_reviewers:
-  - "Senior Tester"
-  - "Senior DevOps Engineer"
-  - "Senior Security Sandbox Engineer"
+  - "Senior Documentation Engineer"
+  - "Senior Requirement Engineer"
 affected_files:
-  - "src/tiny_swarm_world/application/**"
-  - "src/tiny_swarm_world/domain/**"
-  - "src/tiny_swarm_world/infrastructure/**"
-  - "tests/**"
-  - "tools/**"
-affected_modules:
-  - "tiny_swarm_world.application"
-  - "tiny_swarm_world.domain"
-  - "tiny_swarm_world.infrastructure"
+  - "documentation/architecture/adr-separate-platform-artifacts-deployment.adoc"
+  - "documentation/arc42/**"
+  - "documentation/architecture/**"
+affected_modules: []
 affected_contracts:
-  - "preflight-result"
-  - "live-run-consent"
+  - "platform-artifacts-deployment-boundaries"
 dependencies:
   - "01"
 parallel_group: "B"
 file_locks:
-  - "src/tiny_swarm_world/**"
-  - "tests/**"
-  - "tools/**"
+  - "documentation/architecture/**"
+  - "documentation/arc42/**"
 contract_locks:
-  - "preflight-result"
+  - "responsibility-boundaries"
 architecture_locks:
-  - "hexagonal-import-boundaries"
-  - "external-command-safety"
+  - "hexagonal-architecture"
+  - "composition-root-wiring"
 quality_gates:
   targeted:
-    - "python3 tools/quality_gate.py test"
-    - "python3 tools/quality_gate.py typecheck"
+    - "git diff --check"
+    - "python3 tools/quality_gate.py arch-tests"
   required:
-    - "python3 tools/quality_gate.py quality"
+    - "git diff --check"
 documentation:
-  arc42: "update if a new preflight concept is introduced"
-  adr: "not required unless responsibility boundaries change"
+  arc42: "update building blocks, runtime, deployment, decisions, quality, risks"
+  adr: "accept or supersede responsibility ADR"
 stop_conditions:
-  - "preflight would need to execute live infrastructure commands"
-  - "secret handling cannot be made explicit"
+  - "Platform/Artifacts/Deployment are described as microservices without runtime evidence"
+  - "ADR status remains ambiguous before source boundary moves"
 ```
 
 Allowed write scope:
 
-- Python preflight code, tests and tool entrypoints needed for preflight only.
+- Architecture documentation, ADRs and arc42 files.
 
 Done criteria:
 
-- Preflight can run without creating VMs or changing networking.
-- Missing prerequisites produce actionable failures.
-- Unit tests cover each preflight outcome.
+- Responsibility boundary decision is accepted or superseded.
+- arc42 documents current and target responsibilities without claiming
+  implementation that does not exist.
 
-### Slice 03 - Canonical Full-Installation Plan
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py arch-tests
+```
+
+### Slice 03 - Typed Command YAML Contract
 
 Purpose:
 
-- Define a canonical full-installation plan that sequences existing platform
-  services and identifies missing deployment steps before live execution.
+- Introduce typed command catalog models and validation so workflow plans can
+  reject unsafe or malformed command specs before execution.
 
 ```yaml
 slice_id: "03"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior Tester"
+  - "Senior System Architect"
+affected_files:
+  - "src/tiny_swarm_world/domain/command/**"
+  - "src/tiny_swarm_world/application/ports/commands/**"
+  - "src/tiny_swarm_world/application/services/commands/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
+  - "infra/config/**/command_*.yaml"
+  - "tests/domain/command/**"
+  - "tests/infrastructure/adapters/command_runner/**"
+affected_modules:
+  - "tiny_swarm_world.domain.command"
+  - "tiny_swarm_world.application.ports.commands"
+  - "tiny_swarm_world.infrastructure.adapters.command_runner"
+  - "tiny_swarm_world.infrastructure.adapters.repositories"
+affected_contracts:
+  - "typed-command-yaml-schema"
+  - "command-safety-classification"
+  - "command-verification-spec"
+dependencies:
+  - "01"
+  - "02"
+parallel_group: "C"
+file_locks:
+  - "src/tiny_swarm_world/domain/command/**"
+  - "src/tiny_swarm_world/application/ports/commands/**"
+  - "src/tiny_swarm_world/application/services/commands/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/command_runner/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
+  - "infra/config/**/command_*.yaml"
+  - "tests/domain/command/**"
+  - "tests/infrastructure/adapters/command_runner/**"
+contract_locks:
+  - "typed-command-yaml-schema"
+  - "destructive-command-classification"
+architecture_locks:
+  - "domain-no-infrastructure-imports"
+  - "application-no-infrastructure-imports"
+quality_gates:
+  targeted:
+    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py arch-tests"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "update concepts and quality if schema becomes product contract"
+  adr: "add ADR if typed command YAML is a lasting architecture decision"
+stop_conditions:
+  - "destructive command strings cannot be classified deterministically"
+  - "YAML validation would require ad hoc string parsing instead of structured loading"
+  - "application services would need concrete infrastructure imports"
+```
+
+Allowed write scope:
+
+- Command domain, command ports/services, command YAML repository/runner
+  adapters, command YAML files and matching tests.
+
+Done criteria:
+
+- YAML validation fails closed.
+- Destructive commands declare safety class and allowed workflows.
+- Existing command YAML files are either typed or explicitly bridged by a
+  compatibility adapter with tests.
+- Command workflow no longer relies on raw filename strings as the only
+  application contract.
+
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py typecheck
+python3 tools/quality_gate.py quality
+```
+
+### Slice 04 - State And Inventory Model
+
+Purpose:
+
+- Add the domain and port contracts for desired inventory, observed state and
+  verification evidence without live runtime mutation.
+
+```yaml
+slice_id: "04"
 profile: "FULL_PATH"
 owner: "Senior System Architect"
 secondary_reviewers:
   - "Senior Python Automation Developer"
   - "Senior Tester"
 affected_files:
-  - "src/tiny_swarm_world/application/**"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "src/tiny_swarm_world/__main__.py"
-  - "tests/**"
-  - "documentation/**"
+  - "src/tiny_swarm_world/domain/**"
+  - "src/tiny_swarm_world/application/ports/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
+  - "infra/config/vm/**"
+  - "tests/domain/**"
+  - "tests/infrastructure/adapters/repositories/**"
 affected_modules:
-  - "tiny_swarm_world.application.services.platform"
-  - "tiny_swarm_world.infrastructure.composition"
+  - "tiny_swarm_world.domain"
+  - "tiny_swarm_world.application.ports"
+  - "tiny_swarm_world.infrastructure.adapters.repositories"
 affected_contracts:
-  - "full-installation-plan"
+  - "desired-inventory"
+  - "observed-state"
+  - "verification-result"
 dependencies:
   - "01"
   - "02"
 parallel_group: "C"
 file_locks:
-  - "src/tiny_swarm_world/application/**"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "src/tiny_swarm_world/__main__.py"
-  - "tests/**"
-contract_locks:
-  - "full-installation-plan"
-architecture_locks:
-  - "thin-entrypoint"
-  - "composition-root-wiring"
-quality_gates:
-  targeted:
-    - "python3 tools/quality_gate.py arch-tests"
-    - "python3 tools/quality_gate.py test"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "runtime and deployment view check"
-  adr: "check ADR platform/artifacts/deployment split"
-stop_conditions:
-  - "canonical sequence cannot be defined from current services"
-  - "entrypoint would need low-level infrastructure imports"
-```
-
-Allowed write scope:
-
-- Full-installation planning use case, composition wiring, thin CLI exposure
-  and matching tests.
-
-Done criteria:
-
-- A dry-run plan lists every phase in order.
-- The plan has no hidden live execution.
-- Tests prove the order and failure propagation.
-
-### Slice 04 - Platform Runtime Readiness Probes
-
-Purpose:
-
-- Implement platform probes for VM state, network readiness, Docker daemon
-  health, Swarm manager state, worker join status and rerun safety.
-
-```yaml
-slice_id: "04"
-profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
-secondary_reviewers:
-  - "Senior DevOps Engineer"
-  - "Senior Tester"
-  - "Senior System Architect"
-affected_files:
-  - "src/tiny_swarm_world/application/**"
   - "src/tiny_swarm_world/domain/**"
-  - "src/tiny_swarm_world/infrastructure/**"
-  - "infra/config/**"
-  - "tests/**"
-affected_modules:
-  - "tiny_swarm_world.application.services.platform"
-  - "tiny_swarm_world.infrastructure.adapters"
-affected_contracts:
-  - "platform-readiness-result"
-dependencies:
-  - "03"
-parallel_group: "D"
-file_locks:
-  - "src/tiny_swarm_world/**"
-  - "infra/config/**"
-  - "tests/**"
+  - "src/tiny_swarm_world/application/ports/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
+  - "infra/config/vm/**"
+  - "tests/domain/**"
+  - "tests/infrastructure/adapters/repositories/**"
 contract_locks:
-  - "platform-readiness-result"
+  - "state-inventory-model"
 architecture_locks:
-  - "platform-responsibility-boundary"
-  - "command-result-evidence"
+  - "domain-isolation"
+  - "observed-state-not-committed"
 quality_gates:
   targeted:
     - "python3 tools/quality_gate.py test"
     - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py arch-tests"
   required:
     - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "runtime view update if probes become product behavior"
-  adr: "not required unless ownership changes"
+  arc42: "update concepts and runtime view"
+  adr: "add ADR if state persistence authority is established"
 stop_conditions:
-  - "probe requires destructive reset as default behavior"
-  - "Docker or Swarm output parsing is ambiguous"
+  - "observed host state would be committed to product config"
+  - "domain model would import YAML, filesystem, command runner or HTTP details"
+  - "inventory persistence authority remains undefined"
 ```
 
 Allowed write scope:
 
-- Platform readiness code, command result parsing, tests and relevant config
-  validation.
+- State/inventory domain objects, ports, repository adapters, tests and
+  documentation needed to define ownership.
 
 Done criteria:
 
-- Probes are mock-testable.
-- Live probe failures contain node, command and expected state.
-- Rerun safety is explicitly checked.
+- Desired inventory and observed state are separate concepts.
+- Verification status is typed.
+- Observed state storage is ignored or otherwise prevented from being committed.
+- Tests cover missing, stale and conflicting observed state.
 
-### Slice 05 - Deployment And Service Readiness Probes
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py typecheck
+python3 tools/quality_gate.py quality
+```
+
+### Slice 05 - Workflow Taxonomy And Non-Destructive Init
 
 Purpose:
 
-- Implement deployment probes that verify Portainer, stack lifecycle and service
-  endpoint health for the supported service set.
+- Replace destructive normal init behavior with explicit platform workflows for
+  init, reconcile, reset, destroy and verify.
 
 ```yaml
 slice_id: "05"
 profile: "FULL_PATH"
 owner: "Senior Python Automation Developer"
 secondary_reviewers:
-  - "Senior DevOps Engineer"
-  - "Senior Security Sandbox Engineer"
   - "Senior Tester"
+  - "Senior Security Sandbox Engineer"
+  - "Senior System Architect"
 affected_files:
-  - "src/tiny_swarm_world/application/**"
-  - "src/tiny_swarm_world/domain/**"
-  - "src/tiny_swarm_world/infrastructure/**"
-  - "infra/config/compose/**"
-  - "infra/compose/**"
-  - "tests/**"
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/multipass/**"
+  - "src/tiny_swarm_world/application/services/network/**"
+  - "src/tiny_swarm_world/application/services/vm/**"
+  - "src/tiny_swarm_world/application/ports/commands/**"
+  - "infra/config/multipass/**"
+  - "infra/config/docker/**"
+  - "infra/config/network/**"
+  - "tests/application/services/platform/**"
+  - "tests/application/services/multipass/**"
 affected_modules:
-  - "tiny_swarm_world.application.services.deployment"
-  - "tiny_swarm_world.infrastructure.adapters"
+  - "tiny_swarm_world.application.services.platform"
+  - "tiny_swarm_world.application.services.multipass"
+  - "tiny_swarm_world.application.services.network"
+  - "tiny_swarm_world.application.services.vm"
 affected_contracts:
-  - "deployment-readiness-result"
-  - "service-health-probe"
+  - "platform-init"
+  - "platform-reconcile"
+  - "platform-reset"
+  - "platform-destroy"
+  - "platform-verify"
 dependencies:
   - "03"
+  - "04"
 parallel_group: "D"
 file_locks:
-  - "src/tiny_swarm_world/**"
-  - "infra/config/compose/**"
-  - "infra/compose/**"
-  - "tests/**"
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/multipass/**"
+  - "src/tiny_swarm_world/application/services/network/**"
+  - "src/tiny_swarm_world/application/services/vm/**"
+  - "infra/config/multipass/**"
+  - "infra/config/docker/**"
+  - "infra/config/network/**"
+  - "tests/application/services/platform/**"
+  - "tests/application/services/multipass/**"
 contract_locks:
-  - "deployment-readiness-result"
-  - "service-health-probe"
+  - "platform-workflow-taxonomy"
+  - "destructive-operation-policy"
 architecture_locks:
-  - "deployment-responsibility-boundary"
-  - "secret-handling"
+  - "platform-responsibility-boundary"
+  - "external-command-safety"
 quality_gates:
   targeted:
     - "python3 tools/quality_gate.py test"
     - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py arch-tests"
   required:
     - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "deployment view update if deployment behavior changes"
-  adr: "not required unless service ownership changes"
+  arc42: "update runtime view when workflows are implemented"
+  adr: "destructive operation semantics ADR if not already added"
 stop_conditions:
-  - "hardcoded credentials would be required"
-  - "stack manifests are not safe for Swarm validation"
-  - "mandatory service list cannot be satisfied on target resources"
+  - "init still calls command_multipass_clean_repository_yaml.yaml"
+  - "init or reconcile can select multipass delete or purge"
+  - "reset or destroy can run without explicit confirmation contract"
 ```
 
 Allowed write scope:
 
-- Deployment readiness code, service health probes, tests and stack validation
-  support.
+- Platform application workflows, compatibility wrappers, platform command
+  YAML references and tests.
 
 Done criteria:
 
-- Service probes are explicit and timeout-bounded.
-- Missing secrets fail before stack deployment.
-- Portainer and service endpoint failures produce actionable evidence.
+- Normal init does not run clean/delete/purge.
+- `reconcile`, `reset`, `destroy` and `verify` are distinct use cases.
+- Reset/destroy are gated.
+- Tests prove destructive commands are unreachable from init/reconcile.
 
-### Slice 06 - Live Integration Runner And Evidence Bundle
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py quality
+```
+
+### Slice 06 - Service Wiring Separation
 
 Purpose:
 
-- Add the opt-in live runner that executes preflight, dry-run plan,
-  full-installation phases, probes and evidence collection.
+- Introduce real `PlatformServices`, `ArtifactServices`, and
+  `DeploymentServices` composition boundaries and remove the platform-only
+  application alias.
 
 ```yaml
 slice_id: "06"
 profile: "FULL_PATH"
-owner: "Senior DevOps Engineer"
+owner: "Senior System Architect"
 secondary_reviewers:
   - "Senior Python Automation Developer"
   - "Senior Tester"
-  - "Senior Security Sandbox Engineer"
 affected_files:
-  - "tools/**"
-  - "src/tiny_swarm_world/**"
-  - "tests/**"
-  - ".gitignore"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/artifacts/**"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "tests/infrastructure/test_composition.py"
+  - "tests/application/services/platform/**"
+  - "tests/application/services/artifacts/**"
+  - "tests/application/services/deployment/**"
+  - "tests/architecture/**"
 affected_modules:
-  - "tiny_swarm_world.application"
-  - "tiny_swarm_world.infrastructure"
+  - "tiny_swarm_world.infrastructure.composition"
+  - "tiny_swarm_world.application.services.platform"
+  - "tiny_swarm_world.application.services.artifacts"
+  - "tiny_swarm_world.application.services.deployment"
 affected_contracts:
-  - "live-integration-runner"
-  - "evidence-bundle"
+  - "composition-service-builders"
 dependencies:
+  - "02"
   - "04"
-  - "05"
-parallel_group: "E"
+parallel_group: "D"
 file_locks:
-  - "tools/**"
-  - "src/tiny_swarm_world/**"
-  - "tests/**"
-  - ".gitignore"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/artifacts/**"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "tests/infrastructure/test_composition.py"
+  - "tests/application/services/**"
+  - "tests/architecture/**"
 contract_locks:
-  - "live-integration-runner"
-  - "evidence-bundle"
+  - "composition-service-builders"
 architecture_locks:
-  - "live-infrastructure-safety"
-  - "failure-propagation"
+  - "composition-root-wiring"
+  - "thin-entrypoint"
+  - "responsibility-boundaries"
 quality_gates:
   targeted:
+    - "python3 tools/quality_gate.py arch-tests"
     - "python3 tools/quality_gate.py test"
     - "python3 tools/quality_gate.py typecheck"
   required:
     - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "runtime view and quality requirements check"
-  adr: "not required unless live-test policy changes"
+  arc42: "update building blocks"
+  adr: "not required unless responsibility ADR changes"
 stop_conditions:
-  - "runner can execute live commands without explicit confirmation"
-  - "evidence artifacts would be committed"
-  - "critical command failures can be hidden"
+  - "application services import concrete infrastructure adapters"
+  - "ApplicationServices remains a platform-only alias"
+  - "service builders create external side effects during construction"
 ```
 
 Allowed write scope:
 
-- Live runner, evidence paths, ignored artifact directories and tests.
+- Composition root, service namespace exports and related tests.
 
 Done criteria:
 
-- The live runner refuses to run without explicit confirmation.
-- Dry-run mode is available.
-- Evidence output is deterministic and ignored by Git.
-- Critical failures produce non-zero exit status.
+- Separate builders and dataclasses exist for Platform, Artifacts and
+  Deployment.
+- Constructors remain side-effect free.
+- `__main__.py` still does not import concrete adapters.
+- Architecture tests protect the split.
 
-### Slice 07 - Documentation And Readiness Synchronization
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py quality
+```
+
+### Slice 07 - Nexus Stack Deployment Extraction
 
 Purpose:
 
-- Update operator documentation, troubleshooting and readiness checklist from
-  the implemented integration-test behavior.
+- Move Nexus stack deployment behavior to Deployment ownership while keeping
+  Nexus repository and artifact bootstrap behavior in Artifacts.
 
 ```yaml
 slice_id: "07"
 profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior System Architect"
+  - "Senior Tester"
+affected_files:
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "src/tiny_swarm_world/application/services/artifacts/**"
+  - "src/tiny_swarm_world/application/services/nexus/**"
+  - "src/tiny_swarm_world/application/ports/clients/port_portainer_client.py"
+  - "src/tiny_swarm_world/application/ports/repositories/port_compose_file_repository.py"
+  - "tests/application/services/deployment/**"
+  - "tests/application/services/artifacts/**"
+  - "tests/application/services/nexus/**"
+  - "tests/architecture/**"
+affected_modules:
+  - "tiny_swarm_world.application.services.deployment"
+  - "tiny_swarm_world.application.services.artifacts"
+  - "tiny_swarm_world.application.services.nexus"
+affected_contracts:
+  - "deployment-stack-lifecycle"
+  - "nexus-artifact-bootstrap"
+dependencies:
+  - "06"
+parallel_group: "E"
+file_locks:
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "src/tiny_swarm_world/application/services/artifacts/**"
+  - "src/tiny_swarm_world/application/services/nexus/**"
+  - "src/tiny_swarm_world/application/ports/clients/port_portainer_client.py"
+  - "src/tiny_swarm_world/application/ports/repositories/port_compose_file_repository.py"
+  - "tests/application/services/deployment/**"
+  - "tests/application/services/artifacts/**"
+  - "tests/application/services/nexus/**"
+  - "tests/architecture/**"
+contract_locks:
+  - "nexus-stack-deployment-boundary"
+architecture_locks:
+  - "deployment-responsibility-boundary"
+  - "artifact-responsibility-boundary"
+quality_gates:
+  targeted:
+    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py arch-tests"
+    - "python3 tools/quality_gate.py typecheck"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "update deployment view and building blocks"
+  adr: "not required unless responsibility decision changes"
+stop_conditions:
+  - "Nexus artifact services still import Portainer or compose repository ports after extraction"
+  - "deployment service reaches into Nexus repository internals"
+  - "live Portainer or Nexus calls are needed for tests"
+```
+
+Allowed write scope:
+
+- Deployment/artifact/Nexus application services, relevant ports and tests.
+
+Done criteria:
+
+- Stack deployment is generalized or moved under Deployment.
+- Artifact services depend on deployment readiness by explicit input, not by
+  deploying stacks themselves.
+- Tests prove artifact services do not export or import stack deployment.
+
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+### Slice 08 - Workflow-Level CLI
+
+Purpose:
+
+- Replace the public low-level service CLI with workflow-level commands while
+  keeping the entrypoint thin and all wiring in composition.
+
+```yaml
+slice_id: "08"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior Tester"
+  - "Senior UX Designer"
+  - "Senior System Architect"
+affected_files:
+  - "src/tiny_swarm_world/__main__.py"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/application/services/**"
+  - "tests/test_package_entrypoint.py"
+  - "tests/infrastructure/test_composition.py"
+  - "README.md"
+  - "documentation/user_guide/**"
+affected_modules:
+  - "tiny_swarm_world.__main__"
+  - "tiny_swarm_world.infrastructure.composition"
+  - "tiny_swarm_world.application.services"
+affected_contracts:
+  - "workflow-level-cli"
+dependencies:
+  - "05"
+  - "06"
+  - "07"
+parallel_group: "F"
+file_locks:
+  - "src/tiny_swarm_world/__main__.py"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "src/tiny_swarm_world/application/services/**"
+  - "tests/test_package_entrypoint.py"
+  - "tests/infrastructure/test_composition.py"
+  - "README.md"
+  - "documentation/user_guide/**"
+contract_locks:
+  - "workflow-level-cli"
+architecture_locks:
+  - "thin-entrypoint"
+  - "composition-root-wiring"
+quality_gates:
+  targeted:
+    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py arch-tests"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "update runtime view"
+  adr: "not required unless public CLI compatibility decision is architectural"
+stop_conditions:
+  - "__main__.py embeds low-level orchestration logic"
+  - "list/help paths construct live services"
+  - "destroy or reset can run without explicit confirmation"
+```
+
+Allowed write scope:
+
+- CLI, composition, workflow dispatch services, CLI tests and CLI docs.
+
+Done criteria:
+
+- CLI exposes workflow-level commands such as platform init/reconcile/reset/
+  destroy/verify and deployment/artifact workflows.
+- Listing workflows does not build services.
+- No command runs by default.
+- Destructive workflow commands require explicit confirmation.
+
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py quality
+```
+
+### Slice 09 - Verify After Every Apply
+
+Purpose:
+
+- Enforce verification after every mutating apply step across platform and
+  deployment workflows.
+
+```yaml
+slice_id: "09"
+profile: "FULL_PATH"
+owner: "Senior Tester"
+secondary_reviewers:
+  - "Senior Python Automation Developer"
+  - "Senior System Architect"
+affected_files:
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "src/tiny_swarm_world/application/ports/commands/**"
+  - "src/tiny_swarm_world/domain/**"
+  - "infra/config/**/command_*.yaml"
+  - "tests/application/services/platform/**"
+  - "tests/application/services/deployment/**"
+  - "tests/domain/**"
+  - "tests/infrastructure/adapters/command_runner/**"
+affected_modules:
+  - "tiny_swarm_world.application.services.platform"
+  - "tiny_swarm_world.application.services.deployment"
+  - "tiny_swarm_world.application.ports.commands"
+  - "tiny_swarm_world.domain"
+affected_contracts:
+  - "verify-after-apply"
+  - "verification-evidence"
+dependencies:
+  - "03"
+  - "04"
+  - "05"
+  - "07"
+  - "08"
+parallel_group: "G"
+file_locks:
+  - "src/tiny_swarm_world/application/services/platform/**"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "src/tiny_swarm_world/application/ports/commands/**"
+  - "src/tiny_swarm_world/domain/**"
+  - "infra/config/**/command_*.yaml"
+  - "tests/application/services/platform/**"
+  - "tests/application/services/deployment/**"
+  - "tests/domain/**"
+  - "tests/infrastructure/adapters/command_runner/**"
+contract_locks:
+  - "verify-after-apply"
+  - "command-verification-spec"
+architecture_locks:
+  - "failure-propagation"
+  - "evidence-integrity"
+quality_gates:
+  targeted:
+    - "python3 tools/quality_gate.py test"
+    - "python3 tools/quality_gate.py typecheck"
+    - "python3 tools/quality_gate.py arch-tests"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "update runtime and quality requirements"
+  adr: "add ADR if verification semantics become architecture decision"
+stop_conditions:
+  - "mutating command has no verification spec"
+  - "workflow continues after failed verification"
+  - "verification failure is collapsed into generic command failure"
+  - "verification requires live infrastructure during default quality gate"
+```
+
+Allowed write scope:
+
+- Platform/deployment workflow code, verification domain models, command YAML
+  verification specs and tests.
+
+Done criteria:
+
+- Every apply step has an immediate verification step.
+- Verification failures stop workflow execution.
+- Apply failure and verify failure are reported distinctly.
+- Tests prove no mutating workflow can succeed without verification evidence.
+
+Verification commands:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py typecheck
+python3 tools/quality_gate.py quality
+```
+
+### Slice 10 - Documentation, Quality Sync, And Legacy Quarantine
+
+Purpose:
+
+- Synchronize documentation, quality evidence and legacy cleanup notes after
+  implementation slices have proven supported replacement workflows.
+
+```yaml
+slice_id: "10"
+profile: "FULL_PATH"
 owner: "Senior Documentation Engineer"
 secondary_reviewers:
   - "Senior Tester"
-  - "Senior DevOps Engineer"
   - "Senior System Architect"
+  - "Senior Python Automation Developer"
 affected_files:
   - "README.md"
   - "documentation/**"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
+  - "tests/architecture/**"
+  - "infra/swarm/**"
+  - "infra/prepare/**"
 affected_modules: []
 affected_contracts:
   - "operator-runbook"
+  - "legacy-quarantine-policy"
 dependencies:
+  - "02"
+  - "03"
+  - "04"
+  - "05"
   - "06"
-parallel_group: "F"
+  - "07"
+  - "08"
+  - "09"
+parallel_group: "H"
 file_locks:
   - "README.md"
   - "documentation/**"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
+  - "tests/architecture/**"
+  - "infra/swarm/**"
+  - "infra/prepare/**"
 contract_locks:
   - "operator-runbook"
+  - "legacy-quarantine-policy"
 architecture_locks:
   - "documentation-authority"
+  - "live-infrastructure-safety"
 quality_gates:
   targeted:
     - "git diff --check"
+    - "python3 tools/quality_gate.py arch-tests"
   required:
-    - "git diff --check"
+    - "python3 tools/quality_gate.py quality"
 documentation:
-  arc42: "update runtime, deployment, quality and risk sections as needed"
-  adr: "not required unless policy changes"
+  arc42: "final synchronization across building blocks, runtime, deployment, concepts, quality and risks"
+  adr: "check all new architecture decisions are listed"
 stop_conditions:
-  - "documentation would claim live validation without evidence"
+  - "documentation claims live validation without evidence"
+  - "legacy scripts are removed before supported replacements are verified"
   - "runbook contains host-specific secrets or absolute paths"
 ```
 
 Allowed write scope:
 
-- README, documentation and readiness checklist only.
+- Documentation, architecture tests and explicitly approved legacy quarantine
+  files only.
 
 Done criteria:
 
-- Runbook has exact commands and prerequisites.
-- Troubleshooting maps common failures to remediation.
-- Readiness checklist reflects implemented and verified behavior.
+- README and user docs describe workflow-level commands.
+- arc42 and ADR index match implemented behavior.
+- Legacy/destructive scripts are marked, quarantined or removed only after
+  replacement workflows and references are proven.
+- Final quality gate result is recorded.
 
-### Slice 08 - Controlled Live Verification
+Verification commands:
 
-Purpose:
-
-- Run the implemented opt-in integration test in a suitable Linux/WSL
-  environment and record the result without weakening default quality gates.
-
-```yaml
-slice_id: "08"
-profile: "FULL_PATH"
-owner: "Senior Tester"
-secondary_reviewers:
-  - "Senior DevOps Engineer"
-  - "Senior Security Sandbox Engineer"
-  - "Senior Requirement Engineer"
-affected_files:
-  - "documentation/workflow/execution-report.md"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
-affected_modules: []
-affected_contracts:
-  - "live-verification-evidence"
-dependencies:
-  - "07"
-parallel_group: "G"
-file_locks:
-  - "documentation/workflow/execution-report.md"
-  - "OPERATIONAL_READINESS_CHECKLIST.md"
-contract_locks:
-  - "live-verification-evidence"
-architecture_locks:
-  - "live-infrastructure-safety"
-quality_gates:
-  targeted:
-    - "python3 tools/quality_gate.py quality"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "check after live evidence"
-  adr: "not required unless live policy changes"
-stop_conditions:
-  - "operator has not explicitly approved live infrastructure execution"
-  - "preflight fails"
-  - "same blocker has failed three targeted remediation attempts"
-  - "confidence is below 90 percent and Three Amigos questions are unresolved"
+```bash
+git diff --check
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
 ```
-
-Allowed write scope:
-
-- Execution report and readiness evidence updates only, unless a blocker is
-  self-remediated with at least 90 percent confidence inside the owning slice.
-
-Done criteria:
-
-- Live test either passes with evidence or stops with a classified blocker.
-- Any self-remediation has targeted verification.
-- Any unresolved blocker has Three Amigos questions recorded.
 
 ## Slice Dependency Graph
 
@@ -1032,41 +1187,63 @@ Done criteria:
 01
   -> 02
       -> 03
-          -> 04
+      -> 04
           -> 05
-              -> 06
-                  -> 07
-                      -> 08
+          -> 06
+              -> 07
+                  -> 08
+                      -> 09
+                          -> 10
 ```
 
 Parallelization:
 
-- Slice 04 and Slice 05 may be implemented in parallel only after Slice 03
-  stabilizes shared result contracts.
-- Slice 07 documentation can draft structure early, but final content depends
-  on Slice 06 command names and evidence paths.
-- Slice 08 is always sequential and gated by live-run approval.
+- Slice 03 and Slice 04 may run in parallel after Slice 02 if write scopes stay
+  disjoint.
+- Slice 05 and Slice 06 may overlap only after their shared contracts are
+  stable and file ownership is split explicitly.
+- Slice 10 can draft documentation structure early, but final content depends
+  on implemented command names, verification states and quality evidence.
 
 ## Role Ownership Map
 
-- Senior Requirement Engineer: requirement contract, acceptance criteria,
-  Three Amigos Q&A and resource-gated service decisions.
-- Senior System Architect: architecture boundaries, responsibility ownership,
-  composition root and arc42 alignment.
-- Senior Python Automation Developer: preflight, command orchestration,
-  readiness probes and testable implementation.
-- Senior DevOps Engineer: live runner, host prerequisites, evidence layout,
-  runtime diagnostics and shell/script interaction.
-- Senior Security Sandbox Engineer: secret handling, destructive command
-  controls and live-run consent.
-- Senior Tester: unit coverage, live verification strategy, failure evidence
-  and final test report.
-- Senior Documentation Engineer: runbook, troubleshooting and readiness
-  checklist synchronization.
+- Senior Workflow Architect: dependency graph, slice metadata and execution
+  readiness.
+- Senior Requirement Engineer: operation taxonomy, destructive policy,
+  acceptance criteria and EPIC traceability.
+- Senior System Architect: responsibility boundaries, ADRs, arc42 and
+  composition constraints.
+- Senior Python Automation Developer: command YAML typing, state/inventory
+  implementation, workflow use cases, service builders and CLI dispatch.
+- Senior Tester: regression tests, architecture tests, verify-after-apply and
+  quality gate evidence.
+- Senior Security Sandbox Engineer: destructive operation gates, live
+  infrastructure refusal and secret/state safety.
+- Senior Documentation Engineer: README, arc42, user guide and legacy
+  quarantine documentation.
+- Senior React Frontend Developer: no implementation role for this workflow;
+  reviews only CLI/operator UX impact.
+
+## Subagent Review Summary
+
+Subagent reviews completed during workflow creation:
+
+- Senior Requirement Engineer: requirement classification, acceptance criteria,
+  non-goals, EPIC trace gap and recommended slices.
+- Senior System Architect: architecture constraints, boundary risks, ADR/arc42
+  needs, affected files and stop conditions.
+- Senior Python Automation Developer: command/YAML, inventory, workflow and
+  service split implementation sequence.
+- Senior React Frontend Developer: confirmed no frontend module and scoped UX
+  impact to CLI/operator behavior.
+- Senior Tester: safe targeted gates, regression tests per slice, acceptance
+  checks and stop conditions.
+
+No subagent was authorized to run live infrastructure commands.
 
 ## Quality-Gate Expectations
 
-Required default gate for implementation slices:
+Required final gate for implementation slices:
 
 ```bash
 python3 tools/quality_gate.py quality
@@ -1088,75 +1265,106 @@ Documentation-only gate:
 git diff --check
 ```
 
-Live integration commands introduced by this workflow are not replacements for
-the default quality gate. They are additional opt-in evidence commands after
-the implementation slices define them.
+Workflow creation checks:
+
+```bash
+git diff --check
+python3 -m json.tool documentation/workflow/context-pack.json
+```
 
 ## Documentation Synchronization Points
 
-- After Slice 01: readiness checklist aligns with success criteria.
-- After Slice 03: README and runtime docs know the canonical plan name.
-- After Slice 06: runbook records exact live runner command, preflight command,
-  dry-run command and evidence path.
-- After Slice 08: execution report records pass/fail evidence and unresolved
-  blockers.
+- After Slice 01: workflow safety and destructive operation semantics are
+  stable enough for implementation.
+- After Slice 02: ADR/arc42 baseline authorizes boundary-moving slices.
+- After Slice 03: command YAML documentation explains typed command specs.
+- After Slice 04: state/inventory documentation explains desired versus
+  observed state.
+- After Slice 05: operator docs no longer describe destructive init as normal.
+- After Slice 08: README and user guide describe workflow-level CLI commands.
+- After Slice 09: runtime and quality docs describe verify-after-apply
+  evidence and failure semantics.
+- After Slice 10: legacy script status and final quality evidence are recorded.
 
 ## Stop Conditions
 
 Stop workflow execution when:
 
-- the active branch is not the workflow branch;
-- unrelated worktree changes conflict with the slice write scope;
+- active branch is not `architecture/workflow-init-service-boundaries-20260523`;
+- unrelated worktree changes overlap the active slice write scope;
+- `init` still implies `multipass delete --all` or `multipass purge`;
+- `reconcile` can run destructive cleanup;
+- `reset` or `destroy` can run without explicit confirmation;
+- typed command YAML, inventory ownership or destructive operation policy is
+  unclear in the active slice;
+- Platform/Artifacts/Deployment are described as microservices without runtime
+  independence evidence;
+- application services import concrete infrastructure adapters;
+- Nexus stack deployment remains artifact-owned after extraction begins;
+- a mutating workflow step lacks a verification spec;
+- a workflow continues after failed verification;
 - a required quality gate fails;
-- a live command would run without explicit approval;
-- a command failure is not propagated;
-- hardcoded secrets would be committed;
-- default behavior would delete VMs or stacks implicitly;
-- a service success criterion is ambiguous;
-- a blocker cannot be solved with at least 90 percent confidence;
-- Three Amigos questions are unresolved.
+- a test is skipped or weakened to make a gate pass;
+- live infrastructure would be needed for a default quality gate;
+- user secrets, host-specific paths or local observed state would be committed.
 
 ## Commit And Push Plan
 
-- Commit only after the relevant required gates pass.
-- Keep workflow creation documentation separate from implementation slices.
-- Do not include generated evidence artifacts, logs, local env files or secrets.
-- Use git commit preparation before committing or pushing.
-- Do not push or open a PR unless explicitly requested.
+- Do not commit or push unless explicitly requested.
+- Commit workflow-creation documentation separately from implementation slices.
+- Each implementation slice should be committed only after its required gates
+  pass or documented blockers are accepted.
+- Do not include generated evidence, local state, logs, virtual environments,
+  caches or secrets.
+- Use the repository git commit preparation workflow before committing or
+  pushing.
 
 ## Definition Of Done
 
 This workflow is done when:
 
-- the live integration test contract is documented;
-- preflight and dry-run modes exist;
-- full live install verification is opt-in and safety-gated;
-- platform, deployment and service health probes are implemented;
-- evidence is deterministic and ignored by Git;
-- default quality gate passes;
-- live verification either passes or stops with classified blockers and Three
-  Amigos questions;
-- README, documentation and readiness checklist match the implemented behavior.
+- normal init is non-destructive;
+- `reconcile`, `reset`, `destroy` and `verify` are separate workflows;
+- PlatformServices, ArtifactServices and DeploymentServices are real
+  composition boundaries;
+- CLI exposes workflows rather than only low-level service names;
+- Nexus stack deployment is Deployment-owned;
+- command YAMLs are typed and safety-classified;
+- desired inventory, observed state and verification evidence are modeled;
+- every mutating apply step is followed by verification;
+- docs and architecture tests reflect implemented behavior;
+- `python3 tools/quality_gate.py quality` passes for implementation slices;
+- no live infrastructure action is part of the default quality gate.
 
 ## Handoff To Workflow Execute
 
-Workflow execute must begin with Slice 01. It must not skip directly to live
-execution. Slice 08 requires explicit live infrastructure approval after
-Slices 01 through 07 have passed their required gates.
+Workflow execution must begin with Slice 01. It must not jump directly to
+source changes or live validation.
+
+Before any implementation slice edits source files, the executor must inspect
+the current worktree and resolve ownership of any existing changes that overlap
+the slice file locks. The workflow authoring step observed source/preflight
+changes outside `documentation/workflow/**`; these must be treated as user or
+parallel work unless the user explicitly says otherwise.
 
 ## arc42 Check Status
 
 Checked files:
 
+- `documentation/arc42/02_constraints.adoc`
+- `documentation/arc42/03_solution_strategy.adoc`
 - `documentation/arc42/05_building_blocks.adoc`
 - `documentation/arc42/06_runtime_view.adoc`
 - `documentation/arc42/07_deployment_view.adoc`
+- `documentation/arc42/08_concepts.adoc`
+- `documentation/arc42/09_architecture_decisions.adoc`
 - `documentation/arc42/10_quality_requirements.adoc`
 - `documentation/arc42/11_risks_and_debt.adoc`
+- `documentation/arc42/12_glossary.adoc`
 - `documentation/architecture/adr-separate-platform-artifacts-deployment.adoc`
 
 Current status:
 
 - No arc42 content was changed during workflow creation.
-- Future slices must update runtime, deployment, quality and risk sections if
-  integration-test behavior becomes product behavior.
+- Slice 02 must update arc42 and ADR status before implementation slices move
+  responsibility boundaries.

--- a/src/tiny_swarm_world/__main__.py
+++ b/src/tiny_swarm_world/__main__.py
@@ -1,7 +1,14 @@
 import asyncio
+import json
+import os
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 
+from tiny_swarm_world.domain.preflight import (
+    LIVE_CONSENT_ENVIRONMENT_VARIABLE,
+    LIVE_CONSENT_PHRASE,
+    LiveConsent,
+)
 from tiny_swarm_world.infrastructure.composition import (
     ApplicationServices,
     build_application_services,
@@ -31,6 +38,16 @@ def parse_args(argv: Sequence[str] | None = None) -> Namespace:
         choices=SERVICE_CHOICES,
         help="Run one explicit automation service. This may execute infrastructure commands.",
     )
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="Run static preflight validation without executing live infrastructure commands.",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Allow live infrastructure execution after the required consent checks pass.",
+    )
     return parser.parse_args(argv)
 
 
@@ -45,9 +62,25 @@ async def main(argv: Sequence[str] | None = None) -> None:
             print(service_name)
         return
 
+    if args.preflight:
+        services = build_application_services()
+        live_consent = _live_consent_from_args(args) if args.live else None
+        result = await services.preflight.run(live_consent)
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+        if not result.passed:
+            raise SystemExit(1)
+        return
+
     if args.run is None:
         print("No automation service selected. Use --list-services to inspect available services.")
         return
+
+    live_consent = _live_consent_from_args(args)
+    if not live_consent.accepted:
+        print("REFUSED_LIVE_CONSENT_MISSING")
+        for reason in live_consent.missing_reasons:
+            print(f"- {reason}")
+        raise SystemExit(2)
 
     services = build_application_services()
     logger.info("Running automation service: %s", args.run)
@@ -75,6 +108,20 @@ async def run_service(services: ApplicationServices, service_name: str) -> None:
             await services.vm_ip_list.run()
         case _:
             raise ValueError(f"Unsupported automation service: {service_name}")
+
+
+def _live_consent_from_args(args: Namespace) -> LiveConsent:
+    typed_phrase = None
+    if args.live:
+        try:
+            typed_phrase = input(f"Type '{LIVE_CONSENT_PHRASE}' to continue: ")
+        except EOFError:
+            typed_phrase = None
+    return LiveConsent(
+        live_flag=args.live,
+        environment_value=os.environ.get(LIVE_CONSENT_ENVIRONMENT_VARIABLE),
+        typed_phrase=typed_phrase,
+    )
 
 
 if __name__ == "__main__":

--- a/src/tiny_swarm_world/application/ports/preflight/__init__.py
+++ b/src/tiny_swarm_world/application/ports/preflight/__init__.py
@@ -1,0 +1,5 @@
+from tiny_swarm_world.application.ports.preflight.port_host_preflight_probe import (
+    PortHostPreflightProbe,
+)
+
+__all__ = ["PortHostPreflightProbe"]

--- a/src/tiny_swarm_world/application/ports/preflight/port_host_preflight_probe.py
+++ b/src/tiny_swarm_world/application/ports/preflight/port_host_preflight_probe.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+
+
+class PortHostPreflightProbe(ABC):
+    @abstractmethod
+    def is_linux_or_wsl(self) -> bool:
+        pass
+
+    @abstractmethod
+    def python_version(self) -> str:
+        pass
+
+    @abstractmethod
+    def executable_available(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def cpu_count(self) -> int:
+        pass
+
+    @abstractmethod
+    def memory_bytes(self) -> int:
+        pass
+
+    @abstractmethod
+    def disk_free_bytes(self, path: str) -> int:
+        pass
+
+    @abstractmethod
+    def port_available(self, port: int) -> bool:
+        pass
+
+    @abstractmethod
+    def secret_available(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def path_ignored_by_git(self, path: str) -> bool:
+        pass
+
+    @abstractmethod
+    def forbidden_tracked_secret_fingerprints(
+        self,
+        fingerprints: Mapping[str, str],
+    ) -> Sequence[str]:
+        pass

--- a/src/tiny_swarm_world/application/services/platform/__init__.py
+++ b/src/tiny_swarm_world/application/services/platform/__init__.py
@@ -17,6 +17,7 @@ from tiny_swarm_world.application.services.multipass.multipass_init_vms import (
 from tiny_swarm_world.application.services.multipass.multipass_restart_vms import (
     MultipassRestartVMs,
 )
+from tiny_swarm_world.application.services.platform.preflight_service import PreflightService
 from tiny_swarm_world.application.services.network.netplant.network_prepare_netplan import (
     NetworkPrepareNetplan,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "MultipassDockerSwarmInit",
     "MultipassInitVms",
     "MultipassRestartVMs",
+    "PreflightService",
     "NetworkPrepareNetplan",
     "NetworkSetupNetplan",
     "SocatManager",

--- a/src/tiny_swarm_world/application/services/platform/preflight_service.py
+++ b/src/tiny_swarm_world/application/services/platform/preflight_service.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
+from tiny_swarm_world.domain.preflight import (
+    LiveConsent,
+    PreflightCategory,
+    PreflightCheck,
+    PreflightConfiguration,
+    PreflightResult,
+    PreflightSeverity,
+    PreflightStatus,
+    default_preflight_configuration,
+)
+
+
+class PreflightService:
+    def __init__(
+        self,
+        host_probe: PortHostPreflightProbe,
+        configuration: PreflightConfiguration | None = None,
+    ):
+        self.host_probe = host_probe
+        self.configuration = configuration or default_preflight_configuration()
+
+    async def run(self, live_consent: LiveConsent | None = None) -> PreflightResult:
+        checks = [
+            self._host_check(),
+            self._python_check(),
+            *self._dependency_checks(),
+            self._cpu_check(),
+            self._memory_check(),
+            self._disk_check(),
+            *self._port_checks(),
+            *self._secret_checks(),
+            *self._ignore_policy_checks(),
+            self._forbidden_secret_fingerprint_check(),
+        ]
+        if live_consent is not None:
+            checks.insert(0, self._live_consent_check(live_consent))
+        return PreflightResult(tuple(checks))
+
+    def _live_consent_check(self, live_consent: LiveConsent) -> PreflightCheck:
+        if live_consent.accepted:
+            return _passed(
+                "LIVE-CONSENT",
+                PreflightCategory.LIVE_CONSENT,
+                "Live infrastructure consent is complete.",
+                {"required_controls": "flag,environment,typed_phrase"},
+            )
+        return _failed(
+            "LIVE-CONSENT",
+            PreflightCategory.LIVE_CONSENT,
+            "Live infrastructure consent is missing or incomplete.",
+            "Provide --live, the required consent environment variable, and the exact typed phrase.",
+            {"missing": ",".join(live_consent.missing_reasons)},
+        )
+
+    def _host_check(self) -> PreflightCheck:
+        if self.host_probe.is_linux_or_wsl():
+            return _passed("HOST", PreflightCategory.HOST, "Host is Linux or WSL compatible.")
+        return _failed(
+            "HOST",
+            PreflightCategory.HOST,
+            "Host is not reported as Linux or WSL.",
+            "Run Tiny Swarm World from Linux or WSL.",
+        )
+
+    def _python_check(self) -> PreflightCheck:
+        actual = _parse_python_version(self.host_probe.python_version())
+        expected = self.configuration.minimum_python_version
+        if actual >= expected:
+            return _passed(
+                "PYTHON",
+                PreflightCategory.HOST,
+                "Python version satisfies the runtime baseline.",
+                {
+                    "actual": _format_python_version(actual),
+                    "minimum": _format_python_version(expected),
+                },
+            )
+        return _failed(
+            "PYTHON",
+            PreflightCategory.HOST,
+            "Python version is below the runtime baseline.",
+            f"Run Tiny Swarm World with Python {_format_python_version(expected)} or newer.",
+            {
+                "actual": _format_python_version(actual),
+                "minimum": _format_python_version(expected),
+            },
+        )
+
+    def _dependency_checks(self) -> tuple[PreflightCheck, ...]:
+        checks: list[PreflightCheck] = []
+        for dependency in self.configuration.required_dependencies:
+            if self.host_probe.executable_available(dependency.name):
+                checks.append(
+                    _passed(
+                        f"DEPENDENCY-{dependency.name}",
+                        PreflightCategory.DEPENDENCY,
+                        f"Dependency '{dependency.name}' is available.",
+                    )
+                )
+                continue
+            checks.append(
+                _failed(
+                    f"DEPENDENCY-{dependency.name}",
+                    PreflightCategory.DEPENDENCY,
+                    f"Dependency '{dependency.name}' is missing.",
+                    f"Install '{dependency.name}' or make it available on PATH.",
+                )
+            )
+        return tuple(checks)
+
+    def _cpu_check(self) -> PreflightCheck:
+        actual = self.host_probe.cpu_count()
+        expected = self.configuration.resources.minimum_cpu_count
+        if actual >= expected:
+            return _passed(
+                "RESOURCE-CPU",
+                PreflightCategory.RESOURCE,
+                "CPU resource threshold is satisfied.",
+                {"actual": str(actual), "minimum": str(expected)},
+                severity=PreflightSeverity.RESOURCE_GATED,
+            )
+        return _failed(
+            "RESOURCE-CPU",
+            PreflightCategory.RESOURCE,
+            "CPU resource threshold is not satisfied.",
+            "Provide more CPU capacity or request resource-gated execution.",
+            {"actual": str(actual), "minimum": str(expected)},
+            severity=PreflightSeverity.RESOURCE_GATED,
+        )
+
+    def _memory_check(self) -> PreflightCheck:
+        actual = self.host_probe.memory_bytes()
+        expected = self.configuration.resources.minimum_memory_bytes
+        if actual >= expected:
+            return _passed(
+                "RESOURCE-MEMORY",
+                PreflightCategory.RESOURCE,
+                "Memory resource threshold is satisfied.",
+                {"actual_bytes": str(actual), "minimum_bytes": str(expected)},
+                severity=PreflightSeverity.RESOURCE_GATED,
+            )
+        return _failed(
+            "RESOURCE-MEMORY",
+            PreflightCategory.RESOURCE,
+            "Memory resource threshold is not satisfied.",
+            "Provide more memory or request resource-gated execution.",
+            {"actual_bytes": str(actual), "minimum_bytes": str(expected)},
+            severity=PreflightSeverity.RESOURCE_GATED,
+        )
+
+    def _disk_check(self) -> PreflightCheck:
+        path = self.configuration.resources.disk_path
+        actual = self.host_probe.disk_free_bytes(path)
+        expected = self.configuration.resources.minimum_disk_free_bytes
+        if actual >= expected:
+            return _passed(
+                "RESOURCE-DISK",
+                PreflightCategory.RESOURCE,
+                "Disk resource threshold is satisfied.",
+                {"path": path, "actual_bytes": str(actual), "minimum_bytes": str(expected)},
+                severity=PreflightSeverity.RESOURCE_GATED,
+            )
+        return _failed(
+            "RESOURCE-DISK",
+            PreflightCategory.RESOURCE,
+            "Disk resource threshold is not satisfied.",
+            "Free disk space or choose a larger target storage path.",
+            {"path": path, "actual_bytes": str(actual), "minimum_bytes": str(expected)},
+            severity=PreflightSeverity.RESOURCE_GATED,
+        )
+
+    def _port_checks(self) -> tuple[PreflightCheck, ...]:
+        checks: list[PreflightCheck] = []
+        for required_port in self.configuration.required_ports:
+            check_id = f"PORT-{required_port.port}"
+            if self.host_probe.port_available(required_port.port):
+                checks.append(
+                    _passed(
+                        check_id,
+                        PreflightCategory.PORT,
+                        f"Port {required_port.port} for {required_port.service} is available.",
+                        {"port": str(required_port.port), "service": required_port.service},
+                    )
+                )
+                continue
+            checks.append(
+                _failed(
+                    check_id,
+                    PreflightCategory.PORT,
+                    f"Port {required_port.port} for {required_port.service} is occupied.",
+                    "Stop the process using the port or change the service mapping before live execution.",
+                    {"port": str(required_port.port), "service": required_port.service},
+                )
+            )
+        return tuple(checks)
+
+    def _secret_checks(self) -> tuple[PreflightCheck, ...]:
+        checks: list[PreflightCheck] = []
+        for secret in self.configuration.required_secrets:
+            if self.host_probe.secret_available(secret.name):
+                checks.append(
+                    _passed(
+                        f"SECRET-{secret.name}",
+                        PreflightCategory.SECRET,
+                        f"Secret source for {secret.service} is present.",
+                        {"secret": secret.name, "service": secret.service},
+                    )
+                )
+                continue
+            checks.append(
+                _failed(
+                    f"SECRET-{secret.name}",
+                    PreflightCategory.SECRET,
+                    f"Secret source for {secret.service} is missing.",
+                    "Provide the secret through an environment variable or ignored local file.",
+                    {"secret": secret.name, "service": secret.service},
+                )
+            )
+        return tuple(checks)
+
+    def _ignore_policy_checks(self) -> tuple[PreflightCheck, ...]:
+        checks: list[PreflightCheck] = []
+        for path in self.configuration.required_ignored_paths:
+            if self.host_probe.path_ignored_by_git(path):
+                checks.append(
+                    _passed(
+                        f"IGNORE-{path}",
+                        PreflightCategory.IGNORE_POLICY,
+                        f"Local path '{path}' is ignored by Git.",
+                        {"path": path},
+                    )
+                )
+                continue
+            checks.append(
+                _failed(
+                    f"IGNORE-{path}",
+                    PreflightCategory.IGNORE_POLICY,
+                    f"Local path '{path}' is not ignored by Git.",
+                    "Add the local evidence or secret path to .gitignore before using it.",
+                    {"path": path},
+                )
+            )
+        return tuple(checks)
+
+    def _forbidden_secret_fingerprint_check(self) -> PreflightCheck:
+        fingerprints = {
+            fingerprint.identifier: fingerprint.sha256_digest
+            for fingerprint in self.configuration.forbidden_secret_fingerprints
+        }
+        found = tuple(self.host_probe.forbidden_tracked_secret_fingerprints(fingerprints))
+        if not found:
+            return _passed(
+                "SECRET-FORBIDDEN-FINGERPRINTS",
+                PreflightCategory.SECRET,
+                "No forbidden tracked secret fingerprints were detected.",
+            )
+        return _failed(
+            "SECRET-FORBIDDEN-FINGERPRINTS",
+            PreflightCategory.SECRET,
+            "Forbidden tracked secret fingerprints were detected.",
+            "Remove hardcoded/default secrets or route them through ignored secret sources.",
+            {"fingerprint_ids": ",".join(found)},
+        )
+
+
+def _passed(
+    check_id: str,
+    category: PreflightCategory,
+    message: str,
+    evidence: Mapping[str, str] | None = None,
+    severity: PreflightSeverity = PreflightSeverity.MANDATORY,
+) -> PreflightCheck:
+    return PreflightCheck(
+        check_id=check_id,
+        category=category,
+        status=PreflightStatus.PASSED,
+        severity=severity,
+        message=message,
+        remediation="None",
+        evidence=evidence or {},
+    )
+
+
+def _failed(
+    check_id: str,
+    category: PreflightCategory,
+    message: str,
+    remediation: str,
+    evidence: Mapping[str, str] | None = None,
+    severity: PreflightSeverity = PreflightSeverity.MANDATORY,
+) -> PreflightCheck:
+    return PreflightCheck(
+        check_id=check_id,
+        category=category,
+        status=PreflightStatus.FAILED,
+        severity=severity,
+        message=message,
+        remediation=remediation,
+        evidence=evidence or {},
+    )
+
+
+def _parse_python_version(version_text: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for raw_part in version_text.split("."):
+        try:
+            parts.append(int(raw_part))
+        except ValueError:
+            break
+    return tuple(parts)
+
+
+def _format_python_version(version: tuple[int, ...]) -> str:
+    if not version:
+        return "unknown"
+    return ".".join(str(part) for part in version)

--- a/src/tiny_swarm_world/domain/preflight/__init__.py
+++ b/src/tiny_swarm_world/domain/preflight/__init__.py
@@ -1,0 +1,41 @@
+from tiny_swarm_world.domain.preflight.live_consent import (
+    LIVE_CONSENT_ENVIRONMENT_VARIABLE,
+    LIVE_CONSENT_ENVIRONMENT_VALUE,
+    LIVE_CONSENT_PHRASE,
+    LiveConsent,
+)
+from tiny_swarm_world.domain.preflight.preflight_check import (
+    PreflightCategory,
+    PreflightCheck,
+    PreflightSeverity,
+    PreflightStatus,
+)
+from tiny_swarm_world.domain.preflight.preflight_configuration import (
+    ForbiddenSecretFingerprint,
+    PreflightConfiguration,
+    RequiredDependency,
+    RequiredPort,
+    RequiredSecret,
+    ResourceThresholds,
+    default_preflight_configuration,
+)
+from tiny_swarm_world.domain.preflight.preflight_result import PreflightResult
+
+__all__ = [
+    "LIVE_CONSENT_ENVIRONMENT_VARIABLE",
+    "LIVE_CONSENT_ENVIRONMENT_VALUE",
+    "LIVE_CONSENT_PHRASE",
+    "ForbiddenSecretFingerprint",
+    "LiveConsent",
+    "PreflightCategory",
+    "PreflightCheck",
+    "PreflightConfiguration",
+    "PreflightResult",
+    "PreflightSeverity",
+    "PreflightStatus",
+    "RequiredDependency",
+    "RequiredPort",
+    "RequiredSecret",
+    "ResourceThresholds",
+    "default_preflight_configuration",
+]

--- a/src/tiny_swarm_world/domain/preflight/live_consent.py
+++ b/src/tiny_swarm_world/domain/preflight/live_consent.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+LIVE_CONSENT_ENVIRONMENT_VARIABLE = "TSW_LIVE_INFRASTRUCTURE_CONSENT"
+LIVE_CONSENT_ENVIRONMENT_VALUE = "I_UNDERSTAND_THIS_CHANGES_LOCAL_INFRASTRUCTURE"
+LIVE_CONSENT_PHRASE = "RUN TINY SWARM WORLD LIVE INSTALLATION"
+
+
+@dataclass(frozen=True)
+class LiveConsent:
+    live_flag: bool
+    environment_value: str | None
+    typed_phrase: str | None
+
+    @property
+    def accepted(self) -> bool:
+        return (
+            self.live_flag
+            and self.environment_value == LIVE_CONSENT_ENVIRONMENT_VALUE
+            and self.typed_phrase == LIVE_CONSENT_PHRASE
+        )
+
+    @property
+    def missing_reasons(self) -> tuple[str, ...]:
+        reasons: list[str] = []
+        if not self.live_flag:
+            reasons.append("missing --live")
+        if self.environment_value != LIVE_CONSENT_ENVIRONMENT_VALUE:
+            reasons.append(f"missing {LIVE_CONSENT_ENVIRONMENT_VARIABLE}")
+        if self.typed_phrase != LIVE_CONSENT_PHRASE:
+            reasons.append("missing typed live confirmation phrase")
+        return tuple(reasons)

--- a/src/tiny_swarm_world/domain/preflight/preflight_check.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_check.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
+
+
+class PreflightStatus(str, Enum):
+    PASSED = "PASSED"
+    FAILED = "FAILED"
+
+
+class PreflightCategory(str, Enum):
+    HOST = "HOST"
+    DEPENDENCY = "DEPENDENCY"
+    RESOURCE = "RESOURCE"
+    PORT = "PORT"
+    SECRET = "SECRET"
+    LIVE_CONSENT = "LIVE_CONSENT"
+    IGNORE_POLICY = "IGNORE_POLICY"
+    CONFIGURATION = "CONFIGURATION"
+
+
+class PreflightSeverity(str, Enum):
+    MANDATORY = "MANDATORY"
+    OPTIONAL = "OPTIONAL"
+    RESOURCE_GATED = "RESOURCE_GATED"
+
+
+@dataclass(frozen=True)
+class PreflightCheck:
+    check_id: str
+    category: PreflightCategory
+    status: PreflightStatus
+    severity: PreflightSeverity
+    message: str
+    remediation: str
+    evidence: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
+
+    @property
+    def passed(self) -> bool:
+        return self.status == PreflightStatus.PASSED
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "check_id": self.check_id,
+            "category": self.category.value,
+            "status": self.status.value,
+            "severity": self.severity.value,
+            "message": self.message,
+            "remediation": self.remediation,
+            "evidence": dict(self.evidence),
+        }

--- a/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+GIB = 1024**3
+
+
+@dataclass(frozen=True)
+class RequiredDependency:
+    name: str
+
+
+@dataclass(frozen=True)
+class RequiredPort:
+    port: int
+    service: str
+
+
+@dataclass(frozen=True)
+class RequiredSecret:
+    name: str
+    service: str
+
+
+@dataclass(frozen=True)
+class ForbiddenSecretFingerprint:
+    identifier: str
+    sha256_digest: str
+
+
+@dataclass(frozen=True)
+class ResourceThresholds:
+    minimum_cpu_count: int
+    minimum_memory_bytes: int
+    minimum_disk_free_bytes: int
+    disk_path: str
+
+
+@dataclass(frozen=True)
+class PreflightConfiguration:
+    required_dependencies: tuple[RequiredDependency, ...]
+    required_ports: tuple[RequiredPort, ...]
+    required_secrets: tuple[RequiredSecret, ...]
+    forbidden_secret_fingerprints: tuple[ForbiddenSecretFingerprint, ...]
+    required_ignored_paths: tuple[str, ...]
+    resources: ResourceThresholds
+    minimum_python_version: tuple[int, int]
+
+
+def default_preflight_configuration() -> PreflightConfiguration:
+    return PreflightConfiguration(
+        required_dependencies=(
+            RequiredDependency("python3"),
+            RequiredDependency("multipass"),
+            RequiredDependency("docker"),
+        ),
+        required_ports=(
+            RequiredPort(9000, "Portainer"),
+            RequiredPort(8081, "Nexus"),
+            RequiredPort(8080, "Jenkins"),
+            RequiredPort(5000, "Nexus Docker registry"),
+            RequiredPort(5672, "RabbitMQ AMQP"),
+            RequiredPort(15672, "RabbitMQ management"),
+            RequiredPort(9001, "SonarQube"),
+            RequiredPort(80, "Swagger/NGINX"),
+        ),
+        required_secrets=(
+            RequiredSecret("TSW_PORTAINER_PASSWORD", "Portainer"),
+            RequiredSecret("TSW_NEXUS_ADMIN_PASSWORD", "Nexus"),
+            RequiredSecret("TSW_JENKINS_ADMIN_PASSWORD", "Jenkins"),
+            RequiredSecret("TSW_RABBITMQ_PASSWORD", "RabbitMQ"),
+            RequiredSecret("TSW_SONARQUBE_ADMIN_PASSWORD", "SonarQube"),
+            RequiredSecret("TSW_POSTGRES_PASSWORD", "SonarQube PostgreSQL"),
+        ),
+        forbidden_secret_fingerprints=(
+            ForbiddenSecretFingerprint(
+                "portainer-default-password",
+                "7ba9293f74fb0b610b7cce1494530ba975d15348ffec0b478b143fbe198bd917",
+            ),
+            ForbiddenSecretFingerprint(
+                "legacy-nexus-admin-password",
+                "72fc9fee800d9f881eb0d85d8d7287a6230ed81bdf9b03634f9454b83ae603d7",
+            ),
+            ForbiddenSecretFingerprint(
+                "portainer-token-echo",
+                "d15db825d357c5a749f208ffc6de615140f53fb98f3f8aeedf0f82d0ca7bceda",
+            ),
+        ),
+        required_ignored_paths=(
+            ".tiny-swarm-world/",
+            ".env",
+            ".env.local",
+        ),
+        resources=ResourceThresholds(
+            minimum_cpu_count=4,
+            minimum_memory_bytes=16 * GIB,
+            minimum_disk_free_bytes=60 * GIB,
+            disk_path=".",
+        ),
+        minimum_python_version=(3, 12),
+    )

--- a/src/tiny_swarm_world/domain/preflight/preflight_result.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_result.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tiny_swarm_world.domain.preflight.preflight_check import PreflightCheck
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    checks: tuple[PreflightCheck, ...]
+
+    @property
+    def passed(self) -> bool:
+        return all(check.passed for check in self.checks)
+
+    @property
+    def failed_checks(self) -> tuple[PreflightCheck, ...]:
+        return tuple(check for check in self.checks if not check.passed)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": "PASSED" if self.passed else "FAILED",
+            "checks": [check.to_dict() for check in self.checks],
+        }

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/__init__.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/__init__.py
@@ -1,0 +1,5 @@
+from tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe import (
+    HostPreflightProbe,
+)
+
+__all__ = ["HostPreflightProbe"]

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import re
+import shutil
+import socket
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
+from tiny_swarm_world.infrastructure.project_paths import repository_root
+
+
+SECRET_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_-]{2,}")
+
+
+class HostPreflightProbe(PortHostPreflightProbe):
+    def __init__(self, root: Path | None = None):
+        self.root = root or repository_root()
+
+    def is_linux_or_wsl(self) -> bool:
+        return platform.system().lower() == "linux"
+
+    def python_version(self) -> str:
+        return ".".join(str(part) for part in sys.version_info[:3])
+
+    def executable_available(self, name: str) -> bool:
+        return shutil.which(name) is not None
+
+    def cpu_count(self) -> int:
+        return os.cpu_count() or 0
+
+    def memory_bytes(self) -> int:
+        meminfo = Path("/proc/meminfo")
+        if not meminfo.exists():
+            return 0
+        for line in meminfo.read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemTotal:"):
+                parts = line.split()
+                if len(parts) >= 2:
+                    return int(parts[1]) * 1024
+        return 0
+
+    def disk_free_bytes(self, path: str) -> int:
+        target = self.root / path
+        return shutil.disk_usage(target).free
+
+    def port_available(self, port: int) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", port))
+            except OSError:
+                return False
+        return True
+
+    def secret_available(self, name: str) -> bool:
+        return bool(os.environ.get(name))
+
+    def path_ignored_by_git(self, path: str) -> bool:
+        completed = subprocess.run(
+            ["git", "check-ignore", "-q", "--", path],
+            cwd=self.root,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return completed.returncode == 0
+
+    def forbidden_tracked_secret_fingerprints(
+        self,
+        fingerprints: Mapping[str, str],
+    ) -> Sequence[str]:
+        found: set[str] = set()
+        for source_file in self._tracked_text_files():
+            text = source_file.read_text(encoding="utf-8", errors="ignore")
+            text_fingerprints = set(_token_fingerprints(text))
+            for identifier, fingerprint in fingerprints.items():
+                if fingerprint in text_fingerprints:
+                    found.add(identifier)
+        return tuple(sorted(found))
+
+    def _tracked_text_files(self) -> tuple[Path, ...]:
+        suffixes = {".py", ".sh", ".yaml", ".yml", ".json", ".md", ".adoc"}
+        completed = subprocess.run(
+            ["git", "ls-files", "--", "src", "infra"],
+            cwd=self.root,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if completed.returncode == 0:
+            return tuple(
+                path
+                for path in self._paths_from_git_output(completed.stdout)
+                if path.suffix in suffixes
+            )
+
+        roots = (
+            self.root / "src",
+            self.root / "infra",
+        )
+        files: list[Path] = []
+        for root in roots:
+            if not root.exists():
+                continue
+            files.extend(
+                path
+                for path in root.rglob("*")
+                if path.is_file() and path.suffix in suffixes
+            )
+        return tuple(files)
+
+    def _paths_from_git_output(self, output: str) -> tuple[Path, ...]:
+        root = self.root.resolve()
+        paths: list[Path] = []
+        for line in output.splitlines():
+            candidate = (root / line).resolve()
+            try:
+                candidate.relative_to(root)
+            except ValueError:
+                continue
+            if candidate.is_file():
+                paths.append(candidate)
+        return tuple(paths)
+
+
+def _token_fingerprints(text: str) -> tuple[str, ...]:
+    return tuple(
+        hashlib.sha256(match.group(0).encode("utf-8")).hexdigest()
+        for match in SECRET_TOKEN_PATTERN.finditer(text)
+    )

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -9,12 +9,14 @@ from tiny_swarm_world.application.services.platform import (
     MultipassRestartVMs,
     NetworkPrepareNetplan,
     NetworkSetupNetplan,
+    PreflightService,
     SocatManager,
     VmIpList,
 )
 from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import CommandWorkflow
 from tiny_swarm_world.infrastructure.adapters.file_management.file_manager import FileManager
 from tiny_swarm_world.infrastructure.adapters.file_management.path_strategies.path_factory import PathFactory
+from tiny_swarm_world.infrastructure.adapters.preflight import HostPreflightProbe
 from tiny_swarm_world.infrastructure.adapters.repositories.netplan_repository import PortNetplanRepositoryYaml
 from tiny_swarm_world.infrastructure.adapters.repositories.vm_repository_yaml import PortVmRepositoryYaml
 from tiny_swarm_world.infrastructure.dependency_injection.infra_core_di_container import infra_core_container
@@ -31,6 +33,7 @@ class PlatformServices:
     multipass_restart_vms: MultipassRestartVMs
     multipass_docker_install: MultipassDockerInstall
     multipass_docker_swarm_init: MultipassDockerSwarmInit
+    preflight: PreflightService
     vm_ip_list: VmIpList
     socat_manager: SocatManager
 
@@ -49,6 +52,7 @@ def build_platform_services() -> PlatformServices:
     vm_repository = PortVmRepositoryYaml()
     netplan_repository = PortNetplanRepositoryYaml()
     command_workflow = CommandWorkflow(vm_repository=vm_repository)
+    preflight_probe = HostPreflightProbe()
 
     return PlatformServices(
         command_workflow=command_workflow,
@@ -64,6 +68,7 @@ def build_platform_services() -> PlatformServices:
         multipass_restart_vms=MultipassRestartVMs(command_workflow),
         multipass_docker_install=MultipassDockerInstall(command_workflow),
         multipass_docker_swarm_init=MultipassDockerSwarmInit(command_workflow),
+        preflight=PreflightService(preflight_probe),
         vm_ip_list=VmIpList(command_workflow=command_workflow, vm_repository=vm_repository),
         socat_manager=SocatManager(),
     )

--- a/tests/application/services/platform/test_platform_service_exports.py
+++ b/tests/application/services/platform/test_platform_service_exports.py
@@ -28,8 +28,12 @@ from tiny_swarm_world.application.services.platform import (
     MultipassRestartVMs,
     NetworkPrepareNetplan,
     NetworkSetupNetplan,
+    PreflightService,
     SocatManager,
     VmIpList,
+)
+from tiny_swarm_world.application.services.platform.preflight_service import (
+    PreflightService as ExistingPreflightService,
 )
 from tiny_swarm_world.application.services.vm.vm_ip_list import VmIpList as ExistingVmIpList
 
@@ -42,5 +46,6 @@ class TestPlatformServiceExports(unittest.TestCase):
         self.assertIs(MultipassRestartVMs, ExistingMultipassRestartVMs)
         self.assertIs(NetworkPrepareNetplan, ExistingNetworkPrepareNetplan)
         self.assertIs(NetworkSetupNetplan, ExistingNetworkSetupNetplan)
+        self.assertIs(PreflightService, ExistingPreflightService)
         self.assertIs(SocatManager, ExistingSocatManager)
         self.assertIs(VmIpList, ExistingVmIpList)

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -1,0 +1,177 @@
+import unittest
+from collections.abc import Mapping, Sequence
+
+from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
+from tiny_swarm_world.application.services.platform.preflight_service import PreflightService
+from tiny_swarm_world.domain.preflight import (
+    LIVE_CONSENT_ENVIRONMENT_VALUE,
+    LIVE_CONSENT_PHRASE,
+    LiveConsent,
+    PreflightSeverity,
+)
+
+
+class TestPreflightService(unittest.IsolatedAsyncioTestCase):
+    async def test_successful_preflight_reports_passed_checks(self):
+        result = await PreflightService(_FakeProbe()).run(
+            LiveConsent(
+                live_flag=True,
+                environment_value=LIVE_CONSENT_ENVIRONMENT_VALUE,
+                typed_phrase=LIVE_CONSENT_PHRASE,
+            )
+        )
+
+        check_ids = {check.check_id for check in result.checks}
+        self.assertTrue(result.passed)
+        self.assertIn("LIVE-CONSENT", check_ids)
+        self.assertIn("PYTHON", check_ids)
+        self.assertIn("DEPENDENCY-python3", check_ids)
+        self.assertIn("SECRET-TSW_PORTAINER_PASSWORD", check_ids)
+
+    async def test_static_preflight_can_run_without_live_consent_check(self):
+        result = await PreflightService(_FakeProbe()).run()
+
+        check_ids = {check.check_id for check in result.checks}
+        self.assertTrue(result.passed)
+        self.assertNotIn("LIVE-CONSENT", check_ids)
+
+    async def test_incomplete_live_consent_fails_preflight(self):
+        result = await PreflightService(_FakeProbe()).run(
+            LiveConsent(
+                live_flag=True,
+                environment_value=None,
+                typed_phrase=LIVE_CONSENT_PHRASE,
+            )
+        )
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        self.assertFalse(result.passed)
+        self.assertIn("LIVE-CONSENT", failed_by_id)
+        self.assertIn(
+            "missing TSW_LIVE_INFRASTRUCTURE_CONSENT",
+            failed_by_id["LIVE-CONSENT"].evidence["missing"],
+        )
+
+    async def test_missing_dependency_and_secret_are_actionable_failures(self):
+        probe = _FakeProbe(
+            executable_availability={"docker": False},
+            secret_availability={"TSW_NEXUS_ADMIN_PASSWORD": False},
+        )
+
+        result = await PreflightService(probe).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        self.assertFalse(result.passed)
+        self.assertIn("DEPENDENCY-docker", failed_by_id)
+        self.assertIn("SECRET-TSW_NEXUS_ADMIN_PASSWORD", failed_by_id)
+        self.assertIn("Install 'docker'", failed_by_id["DEPENDENCY-docker"].remediation)
+        self.assertIn(
+            "Provide the secret",
+            failed_by_id["SECRET-TSW_NEXUS_ADMIN_PASSWORD"].remediation,
+        )
+
+    async def test_host_port_and_ignore_policy_failures_are_reported(self):
+        result = await PreflightService(
+            _FakeProbe(
+                host_compatible=False,
+                port_availability={80: False},
+                ignored_paths={".env": False},
+            )
+        ).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        self.assertFalse(result.passed)
+        self.assertIn("HOST", failed_by_id)
+        self.assertIn("PORT-80", failed_by_id)
+        self.assertIn("IGNORE-.env", failed_by_id)
+        self.assertIn("Run Tiny Swarm World from Linux or WSL", failed_by_id["HOST"].remediation)
+
+    async def test_resource_failures_are_resource_gated(self):
+        result = await PreflightService(
+            _FakeProbe(cpu_count_value=2, memory_bytes_value=8, disk_free_bytes_value=8)
+        ).run()
+
+        resource_failures = [
+            check
+            for check in result.failed_checks
+            if check.check_id in {"RESOURCE-CPU", "RESOURCE-MEMORY", "RESOURCE-DISK"}
+        ]
+        self.assertEqual(3, len(resource_failures))
+        self.assertTrue(
+            all(check.severity == PreflightSeverity.RESOURCE_GATED for check in resource_failures)
+        )
+
+    async def test_forbidden_secret_fingerprint_failures_report_ids_only(self):
+        result = await PreflightService(
+            _FakeProbe(forbidden_fingerprints=("legacy-nexus-admin-password",))
+        ).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        failure = failed_by_id["SECRET-FORBIDDEN-FINGERPRINTS"]
+        self.assertEqual("legacy-nexus-admin-password", failure.evidence["fingerprint_ids"])
+
+    async def test_python_version_below_baseline_fails_preflight(self):
+        result = await PreflightService(_FakeProbe(python_version_value="3.11.9")).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        self.assertIn("PYTHON", failed_by_id)
+        self.assertEqual("3.11.9", failed_by_id["PYTHON"].evidence["actual"])
+
+
+class _FakeProbe(PortHostPreflightProbe):
+    def __init__(
+        self,
+        executable_availability: dict[str, bool] | None = None,
+        secret_availability: dict[str, bool] | None = None,
+        forbidden_fingerprints: tuple[str, ...] = (),
+        host_compatible: bool = True,
+        port_availability: dict[int, bool] | None = None,
+        ignored_paths: dict[str, bool] | None = None,
+        cpu_count_value: int = 8,
+        memory_bytes_value: int = 32 * 1024**3,
+        disk_free_bytes_value: int = 120 * 1024**3,
+        python_version_value: str = "3.12.3",
+    ):
+        self.executable_availability = executable_availability or {}
+        self.secret_availability = secret_availability or {}
+        self.forbidden_fingerprints = forbidden_fingerprints
+        self.host_compatible = host_compatible
+        self.port_availability = port_availability or {}
+        self.ignored_paths = ignored_paths or {}
+        self.cpu_count_value = cpu_count_value
+        self.memory_bytes_value = memory_bytes_value
+        self.disk_free_bytes_value = disk_free_bytes_value
+        self.python_version_value = python_version_value
+
+    def is_linux_or_wsl(self) -> bool:
+        return self.host_compatible
+
+    def python_version(self) -> str:
+        return self.python_version_value
+
+    def executable_available(self, name: str) -> bool:
+        return self.executable_availability.get(name, True)
+
+    def cpu_count(self) -> int:
+        return self.cpu_count_value
+
+    def memory_bytes(self) -> int:
+        return self.memory_bytes_value
+
+    def disk_free_bytes(self, path: str) -> int:
+        return self.disk_free_bytes_value
+
+    def port_available(self, port: int) -> bool:
+        return self.port_availability.get(port, True)
+
+    def secret_available(self, name: str) -> bool:
+        return self.secret_availability.get(name, True)
+
+    def path_ignored_by_git(self, path: str) -> bool:
+        return self.ignored_paths.get(path, True)
+
+    def forbidden_tracked_secret_fingerprints(
+        self,
+        fingerprints: Mapping[str, str],
+    ) -> Sequence[str]:
+        return self.forbidden_fingerprints

--- a/tests/domain/preflight/__init__.py
+++ b/tests/domain/preflight/__init__.py
@@ -1,0 +1,1 @@
+"""Preflight domain tests."""

--- a/tests/domain/preflight/test_preflight_result.py
+++ b/tests/domain/preflight/test_preflight_result.py
@@ -1,0 +1,90 @@
+import unittest
+
+from tiny_swarm_world.domain.preflight import (
+    LIVE_CONSENT_ENVIRONMENT_VALUE,
+    LIVE_CONSENT_PHRASE,
+    LiveConsent,
+    PreflightCategory,
+    PreflightCheck,
+    PreflightResult,
+    PreflightSeverity,
+    PreflightStatus,
+    default_preflight_configuration,
+)
+
+
+class TestLiveConsent(unittest.TestCase):
+    def test_accepts_exact_live_consent_contract(self):
+        consent = LiveConsent(
+            live_flag=True,
+            environment_value=LIVE_CONSENT_ENVIRONMENT_VALUE,
+            typed_phrase=LIVE_CONSENT_PHRASE,
+        )
+
+        self.assertTrue(consent.accepted)
+        self.assertEqual((), consent.missing_reasons)
+
+    def test_reports_missing_live_consent_controls_without_values(self):
+        consent = LiveConsent(
+            live_flag=False,
+            environment_value=None,
+            typed_phrase=None,
+        )
+
+        self.assertFalse(consent.accepted)
+        self.assertIn("missing --live", consent.missing_reasons)
+        self.assertIn("missing TSW_LIVE_INFRASTRUCTURE_CONSENT", consent.missing_reasons)
+        self.assertIn("missing typed live confirmation phrase", consent.missing_reasons)
+
+
+class TestPreflightResult(unittest.TestCase):
+    def test_result_fails_when_any_check_fails(self):
+        passing = PreflightCheck(
+            check_id="HOST",
+            category=PreflightCategory.HOST,
+            status=PreflightStatus.PASSED,
+            severity=PreflightSeverity.MANDATORY,
+            message="Host is ready.",
+            remediation="None",
+        )
+        failing = PreflightCheck(
+            check_id="SECRET",
+            category=PreflightCategory.SECRET,
+            status=PreflightStatus.FAILED,
+            severity=PreflightSeverity.MANDATORY,
+            message="Secret is missing.",
+            remediation="Provide the secret source.",
+        )
+
+        result = PreflightResult((passing, failing))
+
+        self.assertFalse(result.passed)
+        self.assertEqual((failing,), result.failed_checks)
+        self.assertEqual("FAILED", result.to_dict()["status"])
+
+    def test_check_evidence_is_immutable_and_serializable(self):
+        evidence = {"path": ".env"}
+        check = PreflightCheck(
+            check_id="IGNORE",
+            category=PreflightCategory.IGNORE_POLICY,
+            status=PreflightStatus.PASSED,
+            severity=PreflightSeverity.MANDATORY,
+            message="Path ignored.",
+            remediation="None",
+            evidence=evidence,
+        )
+        evidence["path"] = "changed"
+
+        self.assertEqual(".env", check.evidence["path"])
+        self.assertEqual(".env", check.to_dict()["evidence"]["path"])
+
+    def test_default_forbidden_secret_fingerprints_do_not_expose_raw_values(self):
+        configuration_text = repr(default_preflight_configuration())
+        raw_values = (
+            "admin" + "1234567890",
+            "MyAdmin" + "PassWord1234",
+            "PORTAINER" + "_TOKEN",
+        )
+
+        for raw_value in raw_values:
+            self.assertNotIn(raw_value, configuration_text)

--- a/tests/infrastructure/adapters/preflight/__init__.py
+++ b/tests/infrastructure/adapters/preflight/__init__.py
@@ -1,0 +1,1 @@
+"""Preflight infrastructure adapter tests."""

--- a/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
+++ b/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
@@ -1,0 +1,74 @@
+import hashlib
+import os
+import socket
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from tiny_swarm_world.infrastructure.adapters.preflight import HostPreflightProbe
+
+
+class TestHostPreflightProbe(unittest.TestCase):
+    def test_secret_available_uses_environment_without_reading_values(self):
+        probe = HostPreflightProbe(Path.cwd())
+
+        with patch.dict(os.environ, {"TSW_TEST_SECRET": "secret-value"}):
+            self.assertTrue(probe.secret_available("TSW_TEST_SECRET"))
+
+        self.assertFalse(probe.secret_available("TSW_TEST_SECRET"))
+
+    def test_port_available_reports_occupied_loopback_port(self):
+        probe = HostPreflightProbe(Path.cwd())
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            occupied_port = listener.getsockname()[1]
+
+            self.assertFalse(probe.port_available(occupied_port))
+
+        self.assertTrue(probe.port_available(occupied_port))
+
+    def test_path_ignored_by_git_uses_check_ignore(self):
+        probe = HostPreflightProbe(Path.cwd())
+        completed = subprocess.CompletedProcess(
+            args=["git", "check-ignore"],
+            returncode=0,
+        )
+
+        with patch(
+            "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe.subprocess.run",
+            return_value=completed,
+        ) as run:
+            self.assertTrue(probe.path_ignored_by_git(".env"))
+
+        run.assert_called_once()
+
+    def test_forbidden_tracked_secret_fingerprints_scan_git_tracked_files(self):
+        token = "synthetic-test-token"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_file = root / "src" / "example.py"
+            source_file.parent.mkdir()
+            source_file.write_text(f"TOKEN = '{token}'\n", encoding="utf-8")
+            probe = HostPreflightProbe(root)
+            completed = subprocess.CompletedProcess(
+                args=["git", "ls-files"],
+                returncode=0,
+                stdout="src/example.py\n",
+            )
+
+            with patch(
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe.subprocess.run",
+                return_value=completed,
+            ):
+                found = probe.forbidden_tracked_secret_fingerprints(
+                    {
+                        "example-default-token": hashlib.sha256(
+                            token.encode("utf-8")
+                        ).hexdigest()
+                    }
+                )
+
+        self.assertEqual(("example-default-token",), tuple(found))

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -1,7 +1,10 @@
+from dataclasses import fields
 import unittest
 from unittest.mock import patch
 
+from tiny_swarm_world.application.services.platform.preflight_service import PreflightService
 from tiny_swarm_world.infrastructure import composition
+from tiny_swarm_world.infrastructure.adapters.preflight import HostPreflightProbe
 
 
 class TestComposition(unittest.TestCase):
@@ -20,3 +23,21 @@ class TestComposition(unittest.TestCase):
 
         self.assertIs(services, expected_services)
         build_platform_services.assert_called_once_with()
+
+    def test_platform_services_contains_preflight_service(self):
+        field_names = {field.name for field in fields(composition.PlatformServices)}
+
+        self.assertIn("preflight", field_names)
+
+    def test_build_platform_services_wires_preflight_adapter(self):
+        with patch.object(composition, "PortVmRepositoryYaml") as vm_repository_factory:
+            with patch.object(
+                composition,
+                "PortNetplanRepositoryYaml",
+            ) as netplan_repository_factory:
+                services = composition.build_platform_services()
+
+        vm_repository_factory.assert_called_once_with()
+        netplan_repository_factory.assert_called_once_with()
+        self.assertIsInstance(services.preflight, PreflightService)
+        self.assertIsInstance(services.preflight.host_probe, HostPreflightProbe)

--- a/tests/test_package_entrypoint.py
+++ b/tests/test_package_entrypoint.py
@@ -7,6 +7,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from tiny_swarm_world import __main__ as entrypoint
+from tiny_swarm_world.domain.preflight import (
+    LIVE_CONSENT_ENVIRONMENT_VALUE,
+    LIVE_CONSENT_PHRASE,
+)
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
@@ -35,17 +39,105 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         self.assertIn("vm-ip-list", output.getvalue())
         self.assertIn("multipass-init-vms", output.getvalue())
 
-    async def test_explicit_service_selection_runs_selected_service(self):
+    async def test_explicit_service_selection_requires_live_consent_before_building_services(self):
+        output = io.StringIO()
+
+        with patch.object(entrypoint, "build_application_services") as build_services:
+            with redirect_stdout(output):
+                with self.assertRaises(SystemExit) as raised:
+                    await entrypoint.main(["--run", "vm-ip-list"])
+
+        self.assertEqual(2, raised.exception.code)
+        build_services.assert_not_called()
+        self.assertIn("REFUSED_LIVE_CONSENT_MISSING", output.getvalue())
+        self.assertIn("missing --live", output.getvalue())
+
+    async def test_explicit_service_selection_refuses_missing_consent_environment(self):
+        output = io.StringIO()
+
+        with patch("builtins.input", return_value=LIVE_CONSENT_PHRASE):
+            with patch.object(entrypoint, "build_application_services") as build_services:
+                with redirect_stdout(output):
+                    with self.assertRaises(SystemExit) as raised:
+                        await entrypoint.main(["--run", "vm-ip-list", "--live"])
+
+        self.assertEqual(2, raised.exception.code)
+        build_services.assert_not_called()
+        self.assertIn("missing TSW_LIVE_INFRASTRUCTURE_CONSENT", output.getvalue())
+
+    async def test_explicit_service_selection_refuses_wrong_typed_phrase(self):
+        output = io.StringIO()
+
+        with patch.dict(
+            "os.environ",
+            {entrypoint.LIVE_CONSENT_ENVIRONMENT_VARIABLE: LIVE_CONSENT_ENVIRONMENT_VALUE},
+        ):
+            with patch("builtins.input", return_value="wrong phrase"):
+                with patch.object(entrypoint, "build_application_services") as build_services:
+                    with redirect_stdout(output):
+                        with self.assertRaises(SystemExit) as raised:
+                            await entrypoint.main(["--run", "vm-ip-list", "--live"])
+
+        self.assertEqual(2, raised.exception.code)
+        build_services.assert_not_called()
+        self.assertIn("missing typed live confirmation phrase", output.getvalue())
+
+    async def test_explicit_service_selection_refuses_noninteractive_eof(self):
+        output = io.StringIO()
+
+        with patch.dict(
+            "os.environ",
+            {entrypoint.LIVE_CONSENT_ENVIRONMENT_VARIABLE: LIVE_CONSENT_ENVIRONMENT_VALUE},
+        ):
+            with patch("builtins.input", side_effect=EOFError):
+                with patch.object(entrypoint, "build_application_services") as build_services:
+                    with redirect_stdout(output):
+                        with self.assertRaises(SystemExit) as raised:
+                            await entrypoint.main(["--run", "vm-ip-list", "--live"])
+
+        self.assertEqual(2, raised.exception.code)
+        build_services.assert_not_called()
+        self.assertIn("missing typed live confirmation phrase", output.getvalue())
+
+    async def test_explicit_service_selection_runs_selected_service_with_live_consent(self):
         vm_ip_list = SimpleNamespace(run=AsyncMock())
         services = SimpleNamespace(vm_ip_list=vm_ip_list)
         output = io.StringIO()
 
-        with patch.object(entrypoint, "build_application_services", return_value=services):
-            with redirect_stdout(output):
-                await entrypoint.main(["--run", "vm-ip-list"])
+        with patch.dict(
+            "os.environ",
+            {entrypoint.LIVE_CONSENT_ENVIRONMENT_VARIABLE: LIVE_CONSENT_ENVIRONMENT_VALUE},
+        ):
+            with patch("builtins.input", return_value=LIVE_CONSENT_PHRASE):
+                with patch.object(entrypoint, "build_application_services", return_value=services):
+                    with redirect_stdout(output):
+                        await entrypoint.main(["--run", "vm-ip-list", "--live"])
 
         vm_ip_list.run.assert_awaited_once_with()
         self.assertIn("Done", output.getvalue())
+
+    async def test_static_preflight_runs_without_live_consent(self):
+        preflight = SimpleNamespace(run=AsyncMock(return_value=_FakePreflightResult(True)))
+        services = SimpleNamespace(preflight=preflight)
+        output = io.StringIO()
+
+        with patch.object(entrypoint, "build_application_services", return_value=services):
+            with redirect_stdout(output):
+                await entrypoint.main(["--preflight"])
+
+        preflight.run.assert_awaited_once_with(None)
+        self.assertIn('"status": "PASSED"', output.getvalue())
+
+    async def test_failed_preflight_exits_nonzero(self):
+        preflight = SimpleNamespace(run=AsyncMock(return_value=_FakePreflightResult(False)))
+        services = SimpleNamespace(preflight=preflight)
+
+        with patch.object(entrypoint, "build_application_services", return_value=services):
+            with redirect_stdout(io.StringIO()):
+                with self.assertRaises(SystemExit) as raised:
+                    await entrypoint.main(["--preflight"])
+
+        self.assertEqual(1, raised.exception.code)
 
     def test_entrypoint_has_no_direct_low_level_infrastructure_imports(self):
         imports = _direct_imports(ENTRYPOINT_PATH)
@@ -78,3 +170,11 @@ def _direct_imports(source_file: Path) -> list[str]:
         if isinstance(node, ast.ImportFrom) and node.module:
             imports.append(node.module)
     return imports
+
+
+class _FakePreflightResult:
+    def __init__(self, passed: bool):
+        self.passed = passed
+
+    def to_dict(self) -> dict[str, object]:
+        return {"status": "PASSED" if self.passed else "FAILED", "checks": []}

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,19 @@
+"""Run Tiny Swarm World static preflight validation."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
+SOURCE_ROOT = REPOSITORY_ROOT / "src"
+if str(SOURCE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SOURCE_ROOT))
+
+from tiny_swarm_world.__main__ import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main(["--preflight"])))


### PR DESCRIPTION
## Summary
- add guarded preflight domain/application/infrastructure flow with live-consent checks before explicit live execution
- wire PlatformServices with a preflight adapter and expose a standalone preflight tool
- regenerate workflow documentation/context for the init cleanup and service-boundary roadmap
- harden secret checks to use fingerprints instead of raw forbidden secret values and ignore local runtime artifacts

## Verification
- `.venv/bin/python tools/quality_gate.py quality`
  - ruff lint passed
  - import-linter contracts passed
  - architecture tests passed
  - mypy passed
  - unittest discovery passed: 134 tests, 3 skipped

## Safety
- no Multipass, Docker Swarm, compose deployment, netplan, socat, or service bootstrap command was executed
- this PR only pushes the feature branch; it does not merge into `main`