### PR TITLE
ci(quality): install requests type stubs

### DIFF
--- a/.github/workflows/sonar_check.yml
+++ b/.github/workflows/sonar_check.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Generate Coverage Report
         run: |
-          coverage run --branch -m unittest discover -s tests -t .
+          PYTHONPATH=src coverage run --branch -m unittest discover -s tests -t .
           coverage xml -o coverage.xml
 
       - name: SonarCloud Scan

--- a/.github/workflows/sonar_check.yml
+++ b/.github/workflows/sonar_check.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install coverage import-linter mypy ruff
+          python -m pip install coverage import-linter mypy ruff types-requests
 
       - name: Quality Gate
         run: python tools/quality_gate.py quality

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ source .venv/bin/activate
 ```bash
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
-python3 -m pip install ruff mypy import-linter
+python3 -m pip install ruff mypy import-linter types-requests
 ```
 
 4. Run the development quality gate
@@ -387,7 +387,7 @@ Prepare a local environment:
 - `source .venv/bin/activate`
 - `python3 -m pip install --upgrade pip`
 - `python3 -m pip install -r requirements.txt`
-- `python3 -m pip install ruff mypy import-linter`
+- `python3 -m pip install ruff mypy import-linter types-requests`
 
 Run the full gate before handing off a change:
 

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -31,7 +31,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
-python3 -m pip install ruff mypy import-linter
+python3 -m pip install ruff mypy import-linter types-requests
 ----
 
 Use the active virtual environment or the system `python3` interpreter for the

--- a/documentation/user_guide/troubleshooting.adoc
+++ b/documentation/user_guide/troubleshooting.adoc
@@ -2,12 +2,12 @@
 
 == Quality Gate Fails: Missing Tool
 
-If Ruff, mypy, or import-linter is missing, install the development tools in
-the active Python environment:
+If Ruff, mypy, import-linter, or the Requests type stubs are missing, install
+the development tools in the active Python environment:
 
 [source,bash]
 ----
-python3 -m pip install ruff mypy import-linter
+python3 -m pip install ruff mypy import-linter types-requests
 ----
 
 Then rerun:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Runtime dependencies used directly by Tiny Swarm World.
 #
 # Development quality tools are installed separately:
-#   python -m pip install ruff mypy import-linter
+#   python -m pip install ruff mypy import-linter types-requests
 
 pydantic==2.10.6
 PyYAML==6.0.1


### PR DESCRIPTION
## Summary
- Add `types-requests` to the SonarCloud quality-tool installation so mypy can typecheck `requests` imports.
- Set `PYTHONPATH=src` for the SonarCloud coverage unittest run so the src-layout package imports during coverage collection.
- Align local setup and troubleshooting documentation with the CI quality-tool requirements.

## Changed Files / Areas
- `.github/workflows/sonar_check.yml`: installs `types-requests` before running the quality gate and runs coverage tests with `PYTHONPATH=src`.
- `requirements.txt`: documents the development quality-tool install command with `types-requests` while leaving runtime dependencies unchanged.
- `README.md`, `documentation/user_guide/installation.adoc`, `documentation/user_guide/troubleshooting.adoc`: update local setup guidance for the Requests type stubs.

## Verification
- `git diff --check`: passed.
- `.venv/bin/python tools/quality_gate.py typecheck`: passed.
- `.venv/bin/python tools/quality_gate.py quality`: passed, including 620 tests with 1 skipped.
- `PYTHONPATH=src .venv/bin/python -m coverage run --branch -m unittest discover -s tests -t .`: passed, including 620 tests with 1 skipped.
- `.venv/bin/python -m coverage xml -o coverage.xml`: passed.

## Impact
- CI and local typecheck environments can resolve Requests stubs.
- CI coverage can import the src-layout package during unittest discovery.
- Runtime behavior: None.

## Risks And Limitations
- None identified for the PR changes.
- Unrelated local `install.sh` edits are present in the worktree and were not staged, committed, or pushed.

No push to `main` or merge was performed.