### PR TITLE
fix(deployment): surface admin bootstrap diagnostics

### DIFF
--- a/infra/config/compose/portainer/docker-compose.yml
+++ b/infra/config/compose/portainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   portainer:
-    image: portainer/portainer-ce:2.25.1
+    image: portainer/portainer-ce:2.39.2
     restart: always
     volumes:
       - portainer_data:/data
@@ -17,7 +17,7 @@ services:
         constraints:
           - node.role == manager
   agent:
-    image: portainer/agent:2.25.1
+    image: portainer/agent:2.39.2
     environment:
       AGENT_CLUSTER_ADDR: tasks.agent # Swarm Communication
     volumes:

--- a/src/tiny_swarm_world/application/ports/clients/port_portainer_admin_client.py
+++ b/src/tiny_swarm_world/application/ports/clients/port_portainer_admin_client.py
@@ -4,6 +4,10 @@ from abc import ABC, abstractmethod
 class PortainerAdminInitializationRejected(RuntimeError):
     """Raised when Portainer rejects admin initialization after becoming reachable."""
 
+    def __init__(self, message: str | None = None, *, status_code: int | None = None):
+        super().__init__(message or "Portainer rejected admin initialization.")
+        self.status_code = status_code
+
 
 class PortPortainerAdminClient(ABC):
     @abstractmethod

--- a/src/tiny_swarm_world/application/services/artifacts/workflows.py
+++ b/src/tiny_swarm_world/application/services/artifacts/workflows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
@@ -85,6 +86,7 @@ class ArtifactPrepareWorkflow:
     ):
         self.steps = tuple(steps)
         self.blocked_reason = blocked_reason
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self) -> ArtifactWorkflowResult:
         if not self.steps:
@@ -119,19 +121,25 @@ class ArtifactPrepareWorkflow:
                 if inspect.isawaitable(prepare_result):
                     await prepare_result
             except Exception as exc:
+                safe_error = _safe_exception_summary(exc)
+                self.logger.error(
+                    "Failed to prepare artifact target '%s'. Error: %s",
+                    target_id,
+                    safe_error,
+                )
                 return ArtifactWorkflowResult(
                     kind=ArtifactWorkflowKind.PREPARE,
                     status=ArtifactWorkflowStatus.FAILED_TO_PREPARE,
                     message="artifacts prepare failed for a configured artifact contract.",
-                    reason=f"prepare failed with {exc.__class__.__name__}",
+                    reason=_prepare_failure_reason(target_id, exc),
                     executed=True,
                     verification_results=(
                         *verification_results,
                         VerificationResult(
                             target_id=target_id,
                             status=VerificationStatus.FAILED_TO_APPLY,
-                            message=f"Prepare failed for {target_id}: {exc.__class__.__name__}",
-                            evidence={"phase": "prepare"},
+                            message=f"Prepare failed for {target_id}: {safe_error}",
+                            evidence=_prepare_failure_evidence(exc),
                         ),
                     ),
                 )
@@ -264,3 +272,33 @@ async def _verify_step(
         message=VERIFICATION_EVIDENCE_MISSING_MESSAGE,
         evidence={"phase": "verify"},
     )
+
+
+def _safe_exception_summary(exc: Exception) -> str:
+    diagnostic = getattr(exc, "diagnostic", None)
+    if diagnostic:
+        return f"{exc.__class__.__name__}. Diagnostic: {diagnostic}."
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        return f"{exc.__class__.__name__} HTTP {status_code}. Diagnostic payload redacted."
+    return f"{exc.__class__.__name__}. Diagnostic payload redacted."
+
+
+def _prepare_failure_reason(target_id: str, exc: Exception) -> str:
+    if getattr(exc, "diagnostic", None):
+        return f"prepare failed for {target_id}: {_safe_exception_summary(exc)}"
+    return f"prepare failed with {exc.__class__.__name__}"
+
+
+def _prepare_failure_evidence(exc: Exception) -> dict[str, str]:
+    evidence = {"phase": "prepare", "failure_class": exc.__class__.__name__}
+    diagnostic = getattr(exc, "diagnostic", None)
+    if diagnostic:
+        evidence["diagnostic"] = str(diagnostic)
+    operator_action = getattr(exc, "operator_action", None)
+    if operator_action:
+        evidence["operator_action"] = str(operator_action)
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        evidence["http_status"] = str(status_code)
+    return evidence

--- a/src/tiny_swarm_world/application/services/deployment/ensure_portainer_admin_access.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_portainer_admin_access.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from tiny_swarm_world.application.ports.clients.port_portainer_admin_client import (
     PortainerAdminInitializationRejected,
     PortPortainerAdminClient,
 )
+from tiny_swarm_world.application.ports.ui.port_ui import AGGREGATE_INSTANCE, PortUI
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 
 
@@ -20,12 +22,15 @@ class EnsurePortainerAdminAccess:
         password: str,
         max_attempts: int = 30,
         wait_seconds: int = 5,
+        ui: PortUI | None = None,
     ):
         self.portainer_admin_client = portainer_admin_client
         self.username = username
         self.password = password
         self.max_attempts = max_attempts
         self.wait_seconds = wait_seconds
+        self.ui = ui
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self) -> None:
         for attempt in range(1, self.max_attempts + 1):
@@ -34,7 +39,19 @@ class EnsurePortainerAdminAccess:
 
             try:
                 self.portainer_admin_client.initialize_admin_user(self.username, self.password)
-            except PortainerAdminInitializationRejected:
+            except PortainerAdminInitializationRejected as exc:
+                safe_error = _safe_exception_summary(exc)
+                self.logger.error(
+                    "Failed to initialize Portainer admin access. Error: %s",
+                    safe_error,
+                )
+                if self.ui is not None:
+                    self.ui.update_status(
+                        instance=AGGREGATE_INSTANCE,
+                        task=self.deployment_target_id,
+                        step="Error",
+                        result="failed_to_apply",
+                    )
                 raise
             except Exception:
                 if attempt >= self.max_attempts:
@@ -85,3 +102,10 @@ class EnsurePortainerAdminAccess:
             return self.portainer_admin_client.can_authenticate(self.username, self.password)
         except Exception:
             return False
+
+
+def _safe_exception_summary(exc: Exception) -> str:
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        return f"{exc.__class__.__name__} HTTP {status_code}. Diagnostic payload redacted."
+    return f"{exc.__class__.__name__}. Diagnostic payload redacted."

--- a/src/tiny_swarm_world/application/services/deployment/workflows.py
+++ b/src/tiny_swarm_world/application/services/deployment/workflows.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import inspect
+import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol
 
+from tiny_swarm_world.application.ports.clients.port_portainer_admin_client import (
+    PortainerAdminInitializationRejected,
+)
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 
 
@@ -93,6 +97,7 @@ class DeploymentApplyWorkflow:
         self.pre_apply_checks = tuple(pre_apply_checks)
         self.blocked_reason = blocked_reason
         self.kind = kind
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self) -> DeploymentWorkflowResult:
         if not self.steps:
@@ -135,19 +140,25 @@ class DeploymentApplyWorkflow:
                 if inspect.isawaitable(apply_result):
                     await apply_result
             except Exception as exc:
+                safe_error = _safe_exception_summary(exc)
+                self.logger.error(
+                    "Failed to apply deployment target '%s'. Error: %s",
+                    target_id,
+                    safe_error,
+                )
                 return DeploymentWorkflowResult(
                     kind=self.kind,
                     status=DeploymentWorkflowStatus.FAILED_TO_PREPARE,
                     message="deployment prepare failed for a configured stack contract.",
-                    reason=f"prepare failed with {exc.__class__.__name__}",
+                    reason=_prepare_failure_reason(target_id, exc, safe_error),
                     executed=True,
                     verification_results=(
                         *verification_results,
                         VerificationResult(
                             target_id=target_id,
                             status=VerificationStatus.FAILED_TO_APPLY,
-                            message=f"Apply failed for {target_id}: {exc.__class__.__name__}",
-                            evidence={"phase": "apply"},
+                            message=f"Apply failed for {target_id}: {safe_error}",
+                            evidence=_apply_failure_evidence(exc),
                         ),
                     ),
                 )
@@ -232,6 +243,35 @@ class DeploymentVerifyWorkflow:
 
 def _step_has_verification(step: DeploymentApplyStep | DeploymentVerifyCheck) -> bool:
     return callable(getattr(step, "verify", None))
+
+
+def _safe_exception_summary(exc: Exception) -> str:
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        return f"{exc.__class__.__name__} HTTP {status_code}. Diagnostic payload redacted."
+    return f"{exc.__class__.__name__}. Diagnostic payload redacted."
+
+
+def _prepare_failure_reason(target_id: str, exc: Exception, safe_error: str) -> str:
+    if isinstance(exc, PortainerAdminInitializationRejected):
+        return f"prepare failed for {target_id}: {safe_error}"
+    return f"prepare failed with {exc.__class__.__name__}"
+
+
+def _apply_failure_evidence(exc: Exception) -> dict[str, str]:
+    evidence = {
+        "phase": "apply",
+        "failure_class": exc.__class__.__name__,
+    }
+    status_code = getattr(exc, "status_code", None)
+    if status_code is not None:
+        evidence["diagnostic"] = f"http_status_{status_code}"
+    if isinstance(exc, PortainerAdminInitializationRejected):
+        evidence["operator_action"] = (
+            "Check configured Portainer admin access value or reset existing "
+            "Portainer state before rerunning setup."
+        )
+    return evidence
 
 
 def _verification_target_id(

--- a/src/tiny_swarm_world/application/services/nexus/ensure_nexus_admin_access.py
+++ b/src/tiny_swarm_world/application/services/nexus/ensure_nexus_admin_access.py
@@ -4,7 +4,15 @@ import time
 
 from tiny_swarm_world.application.ports.clients.port_container_runtime import PortContainerRuntime
 from tiny_swarm_world.application.ports.clients.port_nexus_client import PortNexusClient
+from tiny_swarm_world.application.ports.ui.port_ui import AGGREGATE_INSTANCE, PortUI
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
+
+
+class NexusAdminAccessRecoveryBlocked(RuntimeError):
+    def __init__(self, message: str, *, diagnostic: str, operator_action: str):
+        super().__init__(message)
+        self.diagnostic = diagnostic
+        self.operator_action = operator_action
 
 
 class EnsureNexusAdminAccess:
@@ -20,6 +28,7 @@ class EnsureNexusAdminAccess:
         initial_password_path: str,
         max_attempts: int,
         wait_seconds: int,
+        ui: PortUI | None = None,
     ):
         self.nexus_client = nexus_client
         self.container_runtime = container_runtime
@@ -29,9 +38,28 @@ class EnsureNexusAdminAccess:
         self.initial_password_path = initial_password_path
         self.max_attempts = max_attempts
         self.wait_seconds = wait_seconds
+        self.ui = ui
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def run(self) -> None:
+        try:
+            self._run()
+        except Exception as exc:
+            safe_error = _safe_exception_summary(exc)
+            self.logger.error(
+                "Failed to ensure Nexus admin access. Error: %s",
+                safe_error,
+            )
+            if self.ui is not None:
+                self.ui.update_status(
+                    instance=AGGREGATE_INSTANCE,
+                    task=self.verification_target_id,
+                    step="Error",
+                    result="failed_to_apply",
+                )
+            raise
+
+    def _run(self) -> None:
         if self.nexus_client.can_authenticate(self.admin_username, self.admin_password):
             self.logger.info("Nexus admin credentials are already active.")
             return
@@ -39,7 +67,11 @@ class EnsureNexusAdminAccess:
         container_name = self._resolve_container_name()
         initial_password = self._read_initial_password(container_name)
 
-        admin_user = self.nexus_client.get_user(self.admin_username, initial_password, self.admin_username)
+        admin_user = self.nexus_client.get_user(
+            self.admin_username,
+            initial_password,
+            self.admin_username,
+        )
         if admin_user.status != "active":
             self.logger.info("Activating Nexus admin user.")
             self.nexus_client.update_user(
@@ -57,7 +89,14 @@ class EnsureNexusAdminAccess:
         )
 
         if not self.nexus_client.can_authenticate(self.admin_username, self.admin_password):
-            raise RuntimeError("Nexus admin password rotation completed without producing valid credentials.")
+            raise NexusAdminAccessRecoveryBlocked(
+                "Nexus admin password rotation completed without producing valid credentials.",
+                diagnostic="rotated_credentials_inactive",
+                operator_action=(
+                    "Check configured Nexus admin access value or reset existing "
+                    "Nexus state before rerunning setup."
+                ),
+            )
 
     def _resolve_container_name(self) -> str:
         for attempt in range(1, self.max_attempts + 1):
@@ -74,7 +113,11 @@ class EnsureNexusAdminAccess:
                 )
                 time.sleep(self.wait_seconds)
 
-        raise RuntimeError(f"No container found for filter '{self.container_name_filter}'.")
+        raise NexusAdminAccessRecoveryBlocked(
+            f"No container found for filter '{self.container_name_filter}'.",
+            diagnostic="nexus_container_not_found",
+            operator_action="Verify the Nexus stack service is running before rerunning setup.",
+        )
 
     def _read_initial_password(self, container_name: str) -> str:
         for attempt in range(1, self.max_attempts + 1):
@@ -91,7 +134,14 @@ class EnsureNexusAdminAccess:
                 )
                 time.sleep(self.wait_seconds)
 
-        raise RuntimeError(f"Could not read Nexus admin password from '{self.initial_password_path}'.")
+        raise NexusAdminAccessRecoveryBlocked(
+            f"Could not read Nexus admin password from '{self.initial_password_path}'.",
+            diagnostic="initial_admin_value_unavailable",
+            operator_action=(
+                "Check configured Nexus admin access value or reset existing Nexus "
+                "state before rerunning setup."
+            ),
+        )
 
     async def verify(self) -> VerificationResult:
         await asyncio.sleep(0)
@@ -117,3 +167,10 @@ class EnsureNexusAdminAccess:
             message="Nexus admin credentials are not active.",
             evidence={"access_state": "inactive", "phase": "verify"},
         )
+
+
+def _safe_exception_summary(exc: Exception) -> str:
+    diagnostic = getattr(exc, "diagnostic", None)
+    if diagnostic:
+        return f"{exc.__class__.__name__}. Diagnostic: {diagnostic}."
+    return f"{exc.__class__.__name__}. Diagnostic payload redacted."

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_swarm_runtime.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_swarm_runtime.py
@@ -290,7 +290,8 @@ class LxcPortainerAdminClient(PortPortainerAdminClient):
             raise RuntimeError("Failed to initialize Portainer admin user.") from exc
         if response.status_code >= 400 and not self.can_authenticate(username, password):
             raise PortainerAdminInitializationRejected(
-                f"Failed to initialize Portainer admin user. HTTP {response.status_code}."
+                f"Failed to initialize Portainer admin user. HTTP {response.status_code}.",
+                status_code=response.status_code,
             )
 
     def _base_url(self) -> str:

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/multipass_portainer_admin_client.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/multipass_portainer_admin_client.py
@@ -51,7 +51,8 @@ class MultipassPortainerAdminClient(PortPortainerAdminClient):
             raise RuntimeError("Failed to initialize Portainer admin user.") from exc
         if response.status_code >= 400 and not self.can_authenticate(username, password):
             raise PortainerAdminInitializationRejected(
-                f"Failed to initialize Portainer admin user. HTTP {response.status_code}."
+                f"Failed to initialize Portainer admin user. HTTP {response.status_code}.",
+                status_code=response.status_code,
             )
 
     def _base_url(self) -> str:

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -842,7 +842,7 @@ def build_platform_services(
     )
 
 
-def build_artifact_services() -> ArtifactServices:
+def build_artifact_services(ui: PortUI | None = None) -> ArtifactServices:
     nexus_admin_password = _operator_secret_value("TSW_NEXUS_ADMIN_PASSWORD")
     nexus_client = MultipassNexusHttpClient()
     container_runtime = MultipassContainerRuntime()
@@ -864,6 +864,7 @@ def build_artifact_services() -> ArtifactServices:
         initial_password_path="/nexus-data/admin.password",
         max_attempts=60,
         wait_seconds=10,
+        ui=ui,
     )
     nexus_repository_steps = (
         EnsureNexusDockerHostedRepository(
@@ -909,13 +910,14 @@ def build_artifact_services() -> ArtifactServices:
 
 def build_artifact_services_for_provider(
     node_provider_request: NodeProviderSelectionRequest | None = None,
+    ui: PortUI | None = None,
 ) -> ArtifactServices:
     provider_request = node_provider_request or NodeProviderSelectionRequest()
     if provider_request.requested_provider == NodeProviderKind.MULTIPASS_LEGACY:
-        return build_artifact_services()
+        return build_artifact_services(ui=ui)
     backend = _lxc_backend_for_provider_request(provider_request)
     if backend is not None:
-        return build_lxc_artifact_services(backend=backend)
+        return build_lxc_artifact_services(backend=backend, ui=ui)
     return ArtifactServices(
         workflows=ArtifactWorkflows(
             prepare=cast(
@@ -936,7 +938,11 @@ def build_artifact_services_for_provider(
     )
 
 
-def build_lxc_artifact_services(*, backend: ManagedLxcBackend) -> ArtifactServices:
+def build_lxc_artifact_services(
+    *,
+    backend: ManagedLxcBackend,
+    ui: PortUI | None = None,
+) -> ArtifactServices:
     nexus_admin_password = _operator_secret_value("TSW_NEXUS_ADMIN_PASSWORD")
     nexus_client = LxcNexusHttpClient(backend=backend)
     container_runtime = LxcContainerRuntime(backend=backend)
@@ -959,6 +965,7 @@ def build_lxc_artifact_services(*, backend: ManagedLxcBackend) -> ArtifactServic
         initial_password_path="/nexus-data/admin.password",
         max_attempts=60,
         wait_seconds=10,
+        ui=ui,
     )
     nexus_repository_steps = (
         EnsureNexusDockerHostedRepository(
@@ -1004,6 +1011,7 @@ def build_lxc_artifact_services(*, backend: ManagedLxcBackend) -> ArtifactServic
 
 def build_deployment_services(
     service_profile: ServiceStackProfile | str = DEFAULT_SETUP_SERVICE_PROFILE,
+    ui: PortUI | None = None,
 ) -> DeploymentServices:
     selected_service_profile = ServiceStackProfile(service_profile)
     service_stack_contracts = service_stack_contracts_for_profile(selected_service_profile)
@@ -1037,6 +1045,7 @@ def build_deployment_services(
             password=_operator_secret_value("TSW_PORTAINER_PASSWORD"),
             max_attempts=60,
             wait_seconds=5,
+            ui=ui,
         ),
         stack_steps["nexus"],
     )
@@ -1075,15 +1084,17 @@ def build_deployment_services(
 def build_deployment_services_for_provider(
     service_profile: ServiceStackProfile | str = DEFAULT_SETUP_SERVICE_PROFILE,
     node_provider_request: NodeProviderSelectionRequest | None = None,
+    ui: PortUI | None = None,
 ) -> DeploymentServices:
     provider_request = node_provider_request or NodeProviderSelectionRequest()
     if provider_request.requested_provider == NodeProviderKind.MULTIPASS_LEGACY:
-        return build_deployment_services(service_profile=service_profile)
+        return build_deployment_services(service_profile=service_profile, ui=ui)
     backend = _lxc_backend_for_provider_request(provider_request)
     if backend is not None:
         return build_lxc_deployment_services(
             service_profile=service_profile,
             backend=backend,
+            ui=ui,
         )
     return DeploymentServices(
         workflows=DeploymentWorkflows(
@@ -1116,6 +1127,7 @@ def build_lxc_deployment_services(
     *,
     backend: ManagedLxcBackend,
     service_profile: ServiceStackProfile | str = DEFAULT_SETUP_SERVICE_PROFILE,
+    ui: PortUI | None = None,
 ) -> DeploymentServices:
     selected_service_profile = ServiceStackProfile(service_profile)
     service_stack_contracts = service_stack_contracts_for_profile(selected_service_profile)
@@ -1149,6 +1161,7 @@ def build_lxc_deployment_services(
             password=_operator_secret_value("TSW_PORTAINER_PASSWORD"),
             max_attempts=60,
             wait_seconds=5,
+            ui=ui,
         ),
         stack_steps["nexus"],
     )
@@ -1200,11 +1213,13 @@ def build_setup_services(
         trace_correlation_id=trace_correlation_id,
     )
     artifacts = build_artifact_services_for_provider(
-        node_provider_request=node_provider_request
+        node_provider_request=node_provider_request,
+        ui=ui,
     )
-    deployment = build_deployment_services_for_provider(
+    deployment = _build_deployment_services_for_request(
         service_profile=service_profile,
         node_provider_request=node_provider_request,
+        ui=ui,
     )
     workflow_progress = _build_workflow_progress_sink(ui)
     method_trace = _build_method_trace_sink(ui)
@@ -1274,9 +1289,10 @@ def build_application_services(
         artifacts=build_artifact_services_for_provider(
             node_provider_request=node_provider_request
         ),
-        deployment=build_deployment_services_for_provider(
+        deployment=_build_deployment_services_for_request(
             service_profile=service_profile,
             node_provider_request=node_provider_request,
+            ui=ui,
         ),
     )
 
@@ -1312,6 +1328,23 @@ def _build_platform_services_for_request(
         node_provider_request=node_provider_request,
         ui=ui,
         trace_correlation_id=trace_correlation_id,
+    )
+
+
+def _build_deployment_services_for_request(
+    service_profile: ServiceStackProfile | str,
+    node_provider_request: NodeProviderSelectionRequest | None,
+    ui: PortUI | None = None,
+) -> DeploymentServices:
+    if ui is None:
+        return build_deployment_services_for_provider(
+            service_profile=service_profile,
+            node_provider_request=node_provider_request,
+        )
+    return build_deployment_services_for_provider(
+        service_profile=service_profile,
+        node_provider_request=node_provider_request,
+        ui=ui,
     )
 
 

--- a/tests/application/services/artifacts/test_artifact_workflows.py
+++ b/tests/application/services/artifacts/test_artifact_workflows.py
@@ -9,6 +9,9 @@ from tiny_swarm_world.application.services.artifacts.workflows import (
     ArtifactWorkflowKind,
     ArtifactWorkflowStatus,
 )
+from tiny_swarm_world.application.services.nexus.ensure_nexus_admin_access import (
+    NexusAdminAccessRecoveryBlocked,
+)
 
 
 class TestArtifactWorkflows(unittest.IsolatedAsyncioTestCase):
@@ -68,6 +71,20 @@ class TestArtifactWorkflows(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("secret", result.reason)
         self.assertEqual(VerificationStatus.FAILED_TO_APPLY, result.verification_results[0].status)
 
+    async def test_prepare_workflow_reports_safe_diagnostic_evidence(self):
+        step = _DiagnosticFailingPrepareStep()
+
+        result = await ArtifactPrepareWorkflow((step,)).run()
+
+        self.assertEqual(ArtifactWorkflowStatus.FAILED_TO_PREPARE, result.status)
+        self.assertIn("initial_admin_value_unavailable", result.reason)
+        self.assertEqual("initial_admin_value_unavailable", result.verification_results[0].evidence["diagnostic"])
+        self.assertEqual(
+            "NexusAdminAccessRecoveryBlocked",
+            result.verification_results[0].evidence["failure_class"],
+        )
+        self.assertIn("reset existing Nexus state", result.verification_results[0].evidence["operator_action"])
+
     async def test_prepare_workflow_reports_failed_verification(self):
         step = _FailedVerificationPrepareStep()
 
@@ -126,6 +143,25 @@ class _FailingPrepareStep:
     async def run(self) -> None:
         await async_checkpoint()
         raise RuntimeError(sensitive_assignment())
+
+    async def verify(self) -> VerificationResult:
+        await async_checkpoint()
+        return _verification_result(self.verification_target_id, VerificationStatus.VERIFIED)
+
+
+class _DiagnosticFailingPrepareStep:
+    verification_target_id = "artifacts:nexus-admin-access"
+
+    async def run(self) -> None:
+        await async_checkpoint()
+        raise NexusAdminAccessRecoveryBlocked(
+            "Could not read Nexus admin password from configured path.",
+            diagnostic="initial_admin_value_unavailable",
+            operator_action=(
+                "Check configured Nexus admin access value or reset existing Nexus "
+                "state before rerunning setup."
+            ),
+        )
 
     async def verify(self) -> VerificationResult:
         await async_checkpoint()

--- a/tests/application/services/deployment/test_deployment_workflows.py
+++ b/tests/application/services/deployment/test_deployment_workflows.py
@@ -6,6 +6,9 @@ from tests.support.sonar_safe_literals import operator_credential, sensitive_ass
 from tiny_swarm_world.application.services.deployment.ensure_portainer_admin_access import (
     EnsurePortainerAdminAccess,
 )
+from tiny_swarm_world.application.ports.clients.port_portainer_admin_client import (
+    PortainerAdminInitializationRejected,
+)
 from tiny_swarm_world.application.services.deployment.workflows import (
     DeploymentApplyWorkflow,
     DeploymentVerifyWorkflow,
@@ -95,6 +98,37 @@ class TestDeploymentWorkflows(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("prepare failed with RuntimeError", result.reason)
         self.assertNotIn("sensitive response", result.reason)
         self.assertEqual(VerificationStatus.FAILED_TO_APPLY, result.verification_results[0].status)
+
+    async def test_apply_workflow_reports_portainer_admin_rejection_with_safe_diagnostics(self):
+        class RejectedPortainerAdminStep:
+            verification_target_id = "deployment:portainer-admin-access"
+
+            async def run(self) -> None:
+                await async_checkpoint()
+                raise PortainerAdminInitializationRejected(
+                    f"HTTP 409 {sensitive_assignment()}",
+                    status_code=409,
+                )
+
+            async def verify(self) -> VerificationResult:
+                await async_checkpoint()
+                raise AssertionError("verify must not run after failed apply")
+
+        with self.assertLogs("DeploymentApplyWorkflow", level="ERROR") as captured:
+            result = await DeploymentApplyWorkflow(
+                (RejectedPortainerAdminStep(),),
+                kind=DeploymentWorkflowKind.BOOTSTRAP,
+            ).run()
+
+        self.assertEqual(DeploymentWorkflowStatus.FAILED_TO_PREPARE, result.status)
+        self.assertIn("PortainerAdminInitializationRejected HTTP 409", result.reason)
+        self.assertNotIn(sensitive_assignment(), result.reason)
+        self.assertIn("PortainerAdminInitializationRejected HTTP 409", captured.output[0])
+        self.assertNotIn(sensitive_assignment(), captured.output[0])
+        verification = result.verification_results[0]
+        self.assertEqual(VerificationStatus.FAILED_TO_APPLY, verification.status)
+        self.assertEqual("http_status_409", verification.evidence["diagnostic"])
+        self.assertIn("Portainer state", verification.evidence["operator_action"])
 
     async def test_apply_workflow_blocks_before_running_steps_when_pre_apply_check_blocks(self):
         pre_apply_check = _BlockedDeploymentCheck("deployment:service-access-external-input")

--- a/tests/application/services/deployment/test_ensure_portainer_admin_access.py
+++ b/tests/application/services/deployment/test_ensure_portainer_admin_access.py
@@ -98,6 +98,32 @@ class TestEnsurePortainerAdminAccess(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(1, client.initialize_calls)
 
+    async def test_run_logs_and_updates_ui_when_portainer_rejects_initialization(self):
+        client = _RejectedInitializationPortainerAdminClient(
+            message=f"HTTP 409 {sensitive_assignment()}",
+            status_code=409,
+        )
+        ui = _RecordingUI()
+        service = EnsurePortainerAdminAccess(
+            client,
+            username="admin",
+            password=operator_credential(),
+            max_attempts=60,
+            wait_seconds=0,
+            ui=ui,
+        )
+
+        with self.assertLogs("EnsurePortainerAdminAccess", level="ERROR") as captured:
+            with self.assertRaises(PortainerAdminInitializationRejected):
+                await service.run()
+
+        self.assertIn("PortainerAdminInitializationRejected HTTP 409", captured.output[0])
+        self.assertNotIn(sensitive_assignment(), captured.output[0])
+        self.assertEqual(
+            [("all", "deployment:portainer-admin-access", "Error", "failed_to_apply")],
+            ui.calls,
+        )
+
 
 class _SequencePortainerAdminClient:
     def __init__(self, authentication_results: list[bool]):
@@ -134,15 +160,32 @@ class _InitializeAfterTransientFailurePortainerAdminClient:
 
 
 class _RejectedInitializationPortainerAdminClient:
-    def __init__(self):
+    def __init__(
+        self,
+        message: str = "HTTP 409",
+        status_code: int | None = None,
+    ):
         self.initialize_calls = 0
+        self.message = message
+        self.status_code = status_code
 
     def can_authenticate(self, username: str, password: str) -> bool:
         return False
 
     def initialize_admin_user(self, username: str, password: str) -> None:
         self.initialize_calls += 1
-        raise PortainerAdminInitializationRejected("HTTP 409")
+        raise PortainerAdminInitializationRejected(
+            self.message,
+            status_code=self.status_code,
+        )
+
+
+class _RecordingUI:
+    def __init__(self):
+        self.calls: list[tuple[str, str, str, str]] = []
+
+    def update_status(self, instance, task, step, result=None):
+        self.calls.append((instance, task, step, result))
 
 
 if __name__ == "__main__":

--- a/tests/application/services/nexus/test_bootstrap_nexus.py
+++ b/tests/application/services/nexus/test_bootstrap_nexus.py
@@ -7,6 +7,9 @@ from tests.support.sonar_safe_literals import sample_text
 from tiny_swarm_world.application.services.nexus.bootstrap_nexus import BootstrapNexus
 from tiny_swarm_world.application.services.nexus.enable_nexus_anonymous_access import EnableNexusAnonymousAccess
 from tiny_swarm_world.application.services.nexus.ensure_nexus_admin_access import EnsureNexusAdminAccess
+from tiny_swarm_world.application.services.nexus.ensure_nexus_admin_access import (
+    NexusAdminAccessRecoveryBlocked,
+)
 from tiny_swarm_world.application.services.nexus.nexus_bootstrap_configuration import NexusBootstrapConfiguration
 from tiny_swarm_world.application.services.nexus.wait_for_nexus_ready import WaitForNexusReady
 from tiny_swarm_world.domain.nexus.nexus_user import NexusUser
@@ -144,6 +147,39 @@ class TestEnsureNexusAdminAccess(unittest.TestCase):
         self.assertNotIn(leaked_value, result.message)
         self.assertNotIn("auth", str(result.evidence))
 
+    @patch("tiny_swarm_world.application.services.nexus.ensure_nexus_admin_access.time.sleep")
+    def test_run_logs_and_updates_ui_when_initial_password_is_unavailable(self, _mock_sleep):
+        nexus_client = MagicMock()
+        nexus_client.can_authenticate.return_value = False
+        container_runtime = MagicMock()
+        container_runtime.find_container_names.return_value = ["nexus-app-1"]
+        container_runtime.file_exists.return_value = False
+        ui = _RecordingUI()
+        service = EnsureNexusAdminAccess(
+            nexus_client=nexus_client,
+            container_runtime=container_runtime,
+            admin_username="admin",
+            admin_password=sample_text("se", "cret"),
+            container_name_filter="nexus",
+            initial_password_path="/nexus-data/admin.password",
+            max_attempts=1,
+            wait_seconds=0,
+            ui=ui,
+        )
+
+        with self.assertLogs("EnsureNexusAdminAccess", level="ERROR") as captured:
+            with self.assertRaises(NexusAdminAccessRecoveryBlocked) as raised:
+                service.run()
+
+        self.assertEqual("initial_admin_value_unavailable", raised.exception.diagnostic)
+        self.assertIn("NexusAdminAccessRecoveryBlocked", captured.output[0])
+        self.assertIn("initial_admin_value_unavailable", captured.output[0])
+        self.assertNotIn(sample_text("se", "cret"), captured.output[0])
+        self.assertEqual(
+            [("all", "artifacts:nexus-admin-access", "Error", "failed_to_apply")],
+            ui.calls,
+        )
+
 
 class TestBootstrapNexus(unittest.TestCase):
     def test_runs_bootstrap_steps_in_order_without_anonymous_access_by_default(self):
@@ -236,3 +272,11 @@ def _run_async(coro):
     import asyncio
 
     return asyncio.run(coro)
+
+
+class _RecordingUI:
+    def __init__(self):
+        self.calls: list[tuple[str, str, str, str]] = []
+
+    def update_status(self, instance, task, step, result=None):
+        self.calls.append((instance, task, step, result))

--- a/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
@@ -156,6 +156,7 @@ services:
                 client.initialize_admin_user("admin", operator_credential())
 
         self.assertIn("HTTP 409", str(raised.exception))
+        self.assertEqual(409, raised.exception.status_code)
         self.assertNotIn(sensitive_assignment(), str(raised.exception))
 
     def test_portainer_admin_client_accepts_failed_init_when_authentication_works(self):

--- a/tests/infrastructure/adapters/clients/test_multipass_portainer_admin_client.py
+++ b/tests/infrastructure/adapters/clients/test_multipass_portainer_admin_client.py
@@ -48,6 +48,7 @@ class TestMultipassPortainerAdminClient(unittest.TestCase):
                 client.initialize_admin_user("admin", operator_credential())
 
         self.assertIn("HTTP 409", str(raised.exception))
+        self.assertEqual(409, raised.exception.status_code)
         self.assertNotIn(sensitive_assignment(), str(raised.exception))
 
     def test_initialize_admin_user_accepts_rejected_init_when_credentials_already_work(self):

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -762,7 +762,7 @@ class TestComposition(unittest.TestCase):
             ui=None,
             trace_correlation_id=services.workflows.run.trace_correlation_id,
         )
-        build_artifacts.assert_called_once_with(node_provider_request=None)
+        build_artifacts.assert_called_once_with(node_provider_request=None, ui=None)
         build_deployment.assert_called_once_with(
             service_profile=ServiceStackProfile.SERVICE_ACCESS,
             node_provider_request=None,
@@ -790,6 +790,17 @@ class TestComposition(unittest.TestCase):
             captured["trace_correlation_id"] = trace_correlation_id
             return _platform_phase_bundle()
 
+        def build_deployment(
+            *,
+            service_profile: object,
+            node_provider_request: object | None = None,
+            ui: object | None = None,
+        ):
+            captured["deployment_service_profile"] = service_profile
+            captured["deployment_node_provider_request"] = node_provider_request
+            captured["deployment_ui"] = ui
+            return _deployment_phase_bundle()
+
         with patch.object(composition, "build_preflight_service", return_value=_phase_bundle()):
             with patch.object(composition, "build_platform_services", side_effect=build_platform):
                 with patch.object(
@@ -800,7 +811,7 @@ class TestComposition(unittest.TestCase):
                     with patch.object(
                         composition,
                         "build_deployment_services_for_provider",
-                        return_value=_deployment_phase_bundle(),
+                        side_effect=build_deployment,
                     ):
                         services = composition.build_setup_services(live_consent, ui=ui)
 
@@ -812,7 +823,10 @@ class TestComposition(unittest.TestCase):
         method_trace_sinks = cast(composition.CompositeMethodTrace, method_trace_sink).sinks
 
         self.assertIs(ui, captured["ui"])
+        self.assertIs(ui, captured["deployment_ui"])
         self.assertIs(live_consent, captured["live_consent"])
+        self.assertEqual(ServiceStackProfile.SERVICE_ACCESS, captured["deployment_service_profile"])
+        self.assertIsNone(captured["deployment_node_provider_request"])
         self.assertEqual(
             services.workflows.run.trace_correlation_id,
             captured["trace_correlation_id"],


### PR DESCRIPTION
## Summary
- Add secret-safe Portainer and Nexus admin bootstrap diagnostics in workflow evidence and logs.
- Propagate setup UI status into deployment and artifact services so failures are visible in the console.
- Update Portainer CE and agent images to 2.39.2.
- Add regression coverage for rejection status codes, diagnostic evidence, and UI updates.

## Verification
- `git diff --check` passed.
- `PYTHONPATH=src python3 -m unittest tests.application.services.nexus.test_bootstrap_nexus tests.application.services.artifacts.test_artifact_workflows tests.application.services.deployment.test_deployment_workflows tests.application.services.deployment.test_ensure_portainer_admin_access tests.infrastructure.test_composition tests.infrastructure.adapters.clients.test_lxc_swarm_runtime tests.infrastructure.adapters.clients.test_multipass_portainer_admin_client` passed, 101 tests.
- `.venv/bin/python tools/quality_gate.py quality` passed, 667 tests, 1 skipped.

## Impact
- Deployment and artifact bootstrap failures now provide safer operator-action evidence without credential values.
- Portainer stack config now targets `portainer/portainer-ce:2.39.2` and `portainer/agent:2.39.2`.

## Risks And Limitations
- Live setup still blocks at service-access deployment until the operator-provided Vaultwarden Swarm secret exists.
- No push to `main` or merge was performed.