### PR TITLE
[codex] Fix config contract gaps

### DIFF
--- a/config/secrets/infisical-secrets.yaml
+++ b/config/secrets/infisical-secrets.yaml
@@ -15,6 +15,14 @@ secrets:
     source: generated_local_secret
     required: true
     policy: keep_existing
+  - key: TSW_INFISICAL_LOGIN_EMAIL
+    service: infisical
+    type: placeholder_only
+    environment: local
+    description: Infisical bootstrap admin login email provided by the operator
+    source: placeholder_only
+    required: true
+    policy: keep_existing
   - key: TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD
     service: infisical
     type: generated_secret

--- a/src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py
@@ -24,8 +24,7 @@ class ComposeFileRepositoryYaml(PortComposeFileRepository):
             raise ValueError("compose stack name contains invalid characters")
 
         for base_directory in self.base_directories:
-            compose_path = base_directory / stack_name / "docker-compose.yml"
-            if compose_path.is_file():
+            for compose_path in self._compose_paths_for(base_directory, stack_name):
                 self.logger.info("Loaded compose file for stack '%s'.", stack_name)
                 return StackDefinition(
                     name=stack_name,
@@ -33,3 +32,17 @@ class ComposeFileRepositoryYaml(PortComposeFileRepository):
                 )
 
         raise FileNotFoundError(f"No docker-compose.yml found for stack '{stack_name}' in {self.base_directories}.")
+
+    def _compose_paths_for(self, base_directory: Path, stack_name: str) -> list[Path]:
+        if not base_directory.is_dir():
+            return []
+
+        direct_path = base_directory / stack_name / "docker-compose.yml"
+        if direct_path.is_file():
+            return [direct_path]
+
+        return sorted(
+            compose_path
+            for compose_path in base_directory.rglob("docker-compose.yml")
+            if compose_path.parent.name == stack_name
+        )

--- a/tests/application/services/deployment/test_secret_management.py
+++ b/tests/application/services/deployment/test_secret_management.py
@@ -62,6 +62,17 @@ class TestSecretManagement(unittest.TestCase):
         self.assertEqual("infisical_bootstrap_identity", entry.source)
         self.assertFalse(entry.required)
 
+    def test_committed_manifest_tracks_required_infisical_login_identity(self):
+        entries = SecretManifestRenderer(Path("config/secrets/infisical-secrets.yaml")).run()
+        entries_by_key = {entry.key: entry for entry in entries}
+
+        entry = entries_by_key["TSW_INFISICAL_LOGIN_EMAIL"]
+
+        self.assertEqual("infisical", entry.service)
+        self.assertEqual("placeholder_only", entry.type)
+        self.assertEqual("placeholder_only", entry.source)
+        self.assertTrue(entry.required)
+
     def test_secret_discovery_classifies_managed_placeholder_and_blocker(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -35,6 +35,20 @@ class TestComposeFileRepositoryYaml(unittest.TestCase):
             self.assertEqual(stack_definition.name, "nexus")
             self.assertIn("image: nexus:latest", stack_definition.compose_content)
 
+    def test_recursively_loads_compose_content_from_matching_stack_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            compose_root = Path(temp_dir) / "compose"
+            config_root = Path(temp_dir) / "config" / "compose"
+            config_root.joinpath("platform", "services", "nexus").mkdir(parents=True)
+            compose_file = config_root / "platform" / "services" / "nexus" / "docker-compose.yml"
+            compose_file.write_text("services:\n  nexus:\n    image: nested\n", encoding="utf-8")
+
+            repository = ComposeFileRepositoryYaml(base_directories=[compose_root, config_root])
+            stack_definition = repository.get_compose_of("nexus")
+
+            self.assertEqual(stack_definition.name, "nexus")
+            self.assertIn("image: nested", stack_definition.compose_content)
+
     def test_prefers_first_matching_base_directory(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             compose_root = Path(temp_dir) / "compose"


### PR DESCRIPTION
## Summary

- Adds the missing `TSW_INFISICAL_LOGIN_EMAIL` entry to the committed Infisical secret manifest as a required placeholder-only operator identity.
- Adds regression coverage for the required Infisical login manifest contract.
- Extends compose-file repository lookup to find stack compose files in matching nested stack directories, with regression coverage.

## Root Cause

The operator configuration contract listed `TSW_INFISICAL_LOGIN_EMAIL` as required for the Infisical service-access profile, but the committed secret manifest did not track that key. The compose repository also only checked direct stack directories, so nested compose layouts were not resolved.

## Validation

- `wsl bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World && PYTHONPATH=src python3.12 -m unittest tests.application.services.deployment.test_secret_management'`
- `wsl bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World && python3.12 tools/quality_gate.py quality'`

Full WSL quality gate passed: Ruff, import-linter, architecture tests, mypy, and unittest discovery.