### PR TITLE
fix(configuration): report safe env source errors

### DIFF
--- a/documentation/configuration/operator-configuration-contract.md
+++ b/documentation/configuration/operator-configuration-contract.md
@@ -52,6 +52,7 @@ The default contract requires these keys before setup execution:
 ## Redaction
 
 Preflight reports configuration status, key names, scopes, value kinds,
-requiredness, and source classification only. It does not report raw secret
+requiredness, source classification, and redaction-safe parser details such as
+duplicate key names and line numbers only. It does not report raw secret
 values, full environment payloads, or local file contents. Parser failures are
 reported as configuration source errors without echoing the rejected line.

--- a/src/tiny_swarm_world/application/ports/configuration/__init__.py
+++ b/src/tiny_swarm_world/application/ports/configuration/__init__.py
@@ -1,5 +1,6 @@
 from tiny_swarm_world.application.ports.configuration.port_configuration_source import (
+    ConfigurationSourceLoadError,
     PortConfigurationSource,
 )
 
-__all__ = ["PortConfigurationSource"]
+__all__ = ["ConfigurationSourceLoadError", "PortConfigurationSource"]

--- a/src/tiny_swarm_world/application/ports/configuration/port_configuration_source.py
+++ b/src/tiny_swarm_world/application/ports/configuration/port_configuration_source.py
@@ -4,6 +4,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping
 
 
+class ConfigurationSourceLoadError(ValueError):
+    def __init__(self, message: str, *, safe_detail: str | None = None) -> None:
+        super().__init__(message)
+        self.safe_detail = safe_detail
+
+
 class PortConfigurationSource(ABC):
     @abstractmethod
     def load(self) -> Mapping[str, str]:

--- a/src/tiny_swarm_world/application/services/platform/preflight_service.py
+++ b/src/tiny_swarm_world/application/services/platform/preflight_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Mapping
 
+from tiny_swarm_world.application.ports.configuration import ConfigurationSourceLoadError
 from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
 from tiny_swarm_world.application.services.configuration import ConfigurationValidationService
 from tiny_swarm_world.domain.configuration import ConfigurationFinding
@@ -88,6 +89,19 @@ class PreflightService:
             return ()
         try:
             validation_result = self.configuration_validation.validate()
+        except ConfigurationSourceLoadError as exc:
+            evidence = {"classification": "configuration_source_error"}
+            if exc.safe_detail:
+                evidence["detail"] = exc.safe_detail
+            return (
+                _failed(
+                    "CONFIGURATION-CONTRACT",
+                    PreflightCategory.CONFIGURATION,
+                    "Configuration contract validation could not load operator configuration.",
+                    "Fix the operator-owned environment source syntax, then rerun preflight.",
+                    evidence,
+                ),
+            )
         except ValueError:
             return (
                 _failed(

--- a/src/tiny_swarm_world/infrastructure/adapters/configuration/configuration_sources.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/configuration/configuration_sources.py
@@ -5,11 +5,15 @@ import os
 from pathlib import Path
 import shlex
 
-from tiny_swarm_world.application.ports.configuration import PortConfigurationSource
+from tiny_swarm_world.application.ports.configuration import (
+    ConfigurationSourceLoadError,
+    PortConfigurationSource,
+)
 
 
-class ConfigurationSourceError(ValueError):
-    pass
+class ConfigurationSourceError(ConfigurationSourceLoadError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, safe_detail=message)
 
 
 class EnvironmentConfigurationSource(PortConfigurationSource):

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 from tests.support.sonar_safe_literals import token_marker
 
+from tiny_swarm_world.application.ports.configuration import ConfigurationSourceLoadError
 from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
 from tiny_swarm_world.application.services.platform.preflight_service import PreflightService
 from tiny_swarm_world.domain.configuration import (
@@ -128,6 +129,28 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             "configuration_source_error",
             failed_by_id["CONFIGURATION-CONTRACT"].evidence["classification"],
+        )
+        self.assertNotIn("secret-value", repr(result.to_dict()))
+
+    async def test_configuration_source_error_reports_safe_detail_without_value_leak(self):
+        result = await PreflightService(
+            _fake_probe(),
+            configuration_validation=_RaisingConfigurationValidation(
+                ConfigurationSourceLoadError(
+                    "Duplicate configuration key TSW_EXAMPLE_PASSWORD at lines 1 and 2.",
+                    safe_detail="Duplicate configuration key TSW_EXAMPLE_PASSWORD at lines 1 and 2.",
+                )
+            ),
+        ).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        evidence = failed_by_id["CONFIGURATION-CONTRACT"].evidence
+
+        self.assertFalse(result.passed)
+        self.assertEqual("configuration_source_error", evidence["classification"])
+        self.assertEqual(
+            "Duplicate configuration key TSW_EXAMPLE_PASSWORD at lines 1 and 2.",
+            evidence["detail"],
         )
         self.assertNotIn("secret-value", repr(result.to_dict()))
 

--- a/tests/infrastructure/adapters/configuration/test_configuration_sources.py
+++ b/tests/infrastructure/adapters/configuration/test_configuration_sources.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from tiny_swarm_world.application.services.configuration import ConfigurationValidationService
+from tiny_swarm_world.application.ports.configuration import ConfigurationSourceLoadError
 from tiny_swarm_world.domain.configuration import (
     ConfigurationContract,
     ConfigurationRequirement,
@@ -75,6 +76,8 @@ class TestConfigurationSources(unittest.TestCase):
         self.assertIn("lines 1 and 2", message)
         self.assertNotIn("first-secret", message)
         self.assertNotIn("second-secret", message)
+        self.assertIsInstance(failure.exception, ConfigurationSourceLoadError)
+        self.assertEqual(message, failure.exception.safe_detail)
 
     def test_shell_env_file_rejects_command_substitution_without_execution(self):
         with TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

Fixes the live-installation preflight failure caused by an operator-owned env source error that was previously reported only as a generic `configuration_source_error`.

## Changes

- Adds a port-level `ConfigurationSourceLoadError` with optional redaction-safe detail.
- Makes the shell env source raise that port error while preserving duplicate-key and line-number diagnostics without exposing values.
- Includes safe detail in `CONFIGURATION-CONTRACT` preflight evidence.
- Documents the redaction boundary for parser details.
- Adds focused unit coverage for the source and preflight behavior.

## Root Cause

The local live installation env file had a duplicate `TSW_SONARQUBE_ADMIN_PASSWORD` entry. The parser correctly failed closed, but preflight discarded the safe duplicate-key and line-number diagnostic, making the failure harder to repair.

## Verification

- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration.test_configuration_sources tests.application.services.platform.test_preflight_service` passed.
- `python3 tools/quality_gate.py quality` passed.
- `./install.sh --confirm-reset` passed in WSL with evidence at `.tiny-swarm-world/evidence/installation-tests/wsl2/20260613T154701Z`; `reset_exit=0`, `setup_exit=0`.
- SonarQube live checks passed: `sonar_db=1/1`, `sonarqube=1/1`, HTTP 200, `/api/system/status` returned `status: UP`.
- `git diff --cached --check` passed.

## Impact

Preflight diagnostics for operator-owned `TSW_*` env files are more actionable while still redacting secret values. Hexagonal dependency direction is preserved by placing the shared load error in the application port.

## Risks And Limitations

No known limitations. This PR does not push to `main` and does not merge itself.