### PR TITLE
docs: allow guarded push auto lifecycle

### DIFF
--- a/.agents/orchestrator/swarm-orchestrator.md
+++ b/.agents/orchestrator/swarm-orchestrator.md
@@ -35,7 +35,11 @@ Coordinate small implementation slices across roles while preserving architectur
 - Exact `workflow create` activates the `workflow create` strand and routes through requirement clarification, five-role Three Amigos review, branch governance, workflow authoring and arc42 validation.
 - Exact `workflow execute` activates the `workflow execute` strand and routes through the workflow executor, slice role reviews, quality gates and slice checkpoint push.
 
-The strands must not be mixed. Slice checkpoint push is not `push auto`, and `push auto` belongs only to `skills-agents`.
+The strands must not be mixed. Slice checkpoint push is not `push auto`.
+`push auto` may publish and merge any task-scoped repository change, including
+Python product code and Python product-behavior tests, only through the guarded
+commit, pull request, green required-checks, SonarQube when configured, merge
+and cleanup lifecycle.
 
 ## Execution Profile Routing
 

--- a/.agents/prompts/skill-audit.md
+++ b/.agents/prompts/skill-audit.md
@@ -26,10 +26,21 @@ Use for `skills update` before changing skills, agents, roles, prompts, Codex ag
 - required specialist reviews
 - blockers
 - process strand classification
-- `push auto` eligibility for skills-agents changes
+- `push auto` lifecycle eligibility for task-scoped changes, including Python
+  product code and Python product-behavior tests
 
 ## Decision
 
 Return `CONTINUE` only when no blocking skill or governance conflict remains.
 
-For `skills update`, return `CONTINUE` only when the change belongs to `skills-agents` and no product implementation, services, contracts, Docker/runtime, build logic, frontend or analytics files are in scope.
+For `skills update`, return `CONTINUE` only when the change belongs to skills,
+agents, process-governance, or governance-only workflow documentation and no
+Python product code, Python product-behavior tests, product implementation,
+services, contracts, Docker/runtime, build logic, frontend or analytics files
+are in scope.
+
+For `push auto`, return `CONTINUE` only when the diff is task-scoped, no
+unrelated or sensitive files are in scope, and the publication path can create
+or reuse a pull request, wait or retry until required checks are green
+including SonarQube when configured, merge, delete the merged remote head
+branch and run local cleanup.

--- a/.agents/prompts/skills-update.md
+++ b/.agents/prompts/skills-update.md
@@ -6,7 +6,9 @@ This command activates the `skills-agents` strand.
 
 It may create, update, audit or reconnect skills, agents, roles, prompts, Codex agent definitions, routing rules, organigramm, skill registry and process documentation.
 
-It must not implement backend, frontend, Docker/runtime, contracts, persistence, analysis-engine, Joern, JavaParser, BTM generator or analytics behavior.
+It must not implement Python product code, Python product-behavior tests,
+backend, frontend, Docker/runtime, contracts, persistence, analysis-engine,
+Joern, JavaParser, BTM generator or analytics behavior.
 
 The skills-agents flow stops on review failures by default. If a workflow explicitly authorizes automatic correction attempts, cap them at `maxRetries = 3` and then escalate to the Root Architect.
 
@@ -22,9 +24,13 @@ Required flow:
 8. Load documentation/skill-audit/owner-map.md.
 9. Inspect current skills, roles, prompts and Codex agents.
 10. Run integrity, linkage, conflict, organigramm, registry and documentation checks.
-11. Apply only skills-agents changes.
-12. Stop if product implementation files would be changed.
-13. Prepare for optional push auto only when the user explicitly requests push auto.
+11. Apply only skills, agents, process-governance, or governance-only workflow
+    documentation changes.
+12. Stop if Python product code, Python product-behavior tests, or other
+    product implementation files would be changed.
+13. Prepare for optional push auto only when the user explicitly requests push
+    auto and the full commit, pull request, green required-checks, SonarQube
+    when configured, merge and cleanup lifecycle can be verified.
 
 `skills update` is not `workflow create`.
 `skills update` is not `workflow execute`.

--- a/.agents/prompts/slice-execute.md
+++ b/.agents/prompts/slice-execute.md
@@ -35,6 +35,9 @@ git show-ref --verify --quiet refs/heads/<workflow-branch>
    explicitly declared as a D8 requirement.
 
 The slice checkpoint push is not `push auto`. It must not create or merge a PR, clean up branches, force-push or push to `main`.
+A later explicit `push auto` may publish any task-scoped repository change
+from a slice only through the guarded commit, pull request, green
+required-checks, SonarQube when configured, merge and cleanup lifecycle.
 Each checkpoint commit must contain exactly one slice.
 
 ## Stop Conditions

--- a/.agents/prompts/workflow-execute.md
+++ b/.agents/prompts/workflow-execute.md
@@ -68,3 +68,5 @@ Stop when:
 - slice checkpoint push would include files outside the current slice;
 - slice checkpoint push would push to `main`, create or merge a PR, run `push auto`, run branch cleanup or force-push.
 - a slice checkpoint commit would contain multiple slice IDs or no active workflow version.
+- `push auto` is requested but commit, pull request, green required-checks,
+  SonarQube when configured, merge or cleanup verification cannot be completed.

--- a/.agents/skills/git-commit-preparation/SKILL.md
+++ b/.agents/skills/git-commit-preparation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-preparation
-description: Use when preparing, reviewing, validating, repairing, committing, pushing, creating a PR, running workflow-execute slice checkpoint pushes, or running `push auto` for skills, agents, process-governance and governance-only workflow documentation changes. This skill is the commit-readiness workflow and enforces AGENTS.md, QUALITY.md, git diff inspection, task-scope validation, quality-gate verification, blocker routing, git-commit-message-preparation, PR creation on explicit `push`, and PR merge plus branch cleanup on explicit `push auto`.
+description: Use when preparing, reviewing, validating, repairing, committing, pushing, creating a PR, running workflow-execute slice checkpoint pushes, or running `push auto` for task-scoped repository changes including Python product code. This skill is the commit-readiness workflow and enforces AGENTS.md, QUALITY.md, git diff inspection, task-scope validation, quality-gate verification, blocker routing, git-commit-message-preparation, PR creation on explicit `push`, and commit, PR, green required-checks, SonarQube when configured, merge plus branch cleanup on explicit `push auto`.
 ---
 
 # Commit Preparation Skill
@@ -23,7 +23,7 @@ Use this skill with these Codex roles:
 
 - `git-commit-message-preparation`: reusable skill for drafting and validating the proposed commit message from diff and verification evidence.
 - `git_commit_reviewer`: read-only reviewer that classifies changes, checks scope, verifies evidence, and returns `READY`, `NOT READY`, or `BLOCKED`.
-- `git_commit_operator`: mutating operator that may stage explicit files, commit, push, create or complete a GitHub pull request, or run a workflow-execute slice checkpoint push only when the contract allows it. On exact `push auto` inside the allowed skills, agents, process-governance or governance-only workflow documentation scope, it may also merge the verified pull request, delete the merged pull request's remote head branch, and invoke the git-clean workflow.
+- `git_commit_operator`: mutating operator that may stage explicit files, commit, push, create or complete a GitHub pull request, or run a workflow-execute slice checkpoint push only when the contract allows it. On exact `push auto` for a task-scoped change, it may also wait or retry until required checks are green including SonarQube when configured, merge the verified pull request, delete the merged pull request's remote head branch, and invoke the git-clean workflow.
 
 The reviewer must not modify files. The operator must not bypass the reviewer result, required verification, branch rules, or the `push` command requirement.
 
@@ -351,11 +351,11 @@ Do not treat `push` as permission to force-push, push to `main`, merge a pull re
 
 If an open pull request already exists for the current branch against `main`, reuse it instead of creating a duplicate.
 
-### Phase 13: Push Auto Merge, Branch Deletion, And Cleanup
+### Phase 13: Push Auto Check Loop, Merge, Branch Deletion, And Cleanup
 
-When the user enters exactly `push auto`, treat it as explicit permission to run the normal `push` workflow and then automatically finish the GitHub pull request lifecycle when the active change is within skills, agents, process-governance or governance-only workflow documentation scope.
+When the user enters exactly `push auto`, treat it as explicit permission to run the normal `push` workflow and then automatically finish the GitHub pull request lifecycle for the active task-scoped change, including Python product code and Python product-behavior tests.
 
-`push auto` must not publish Python product implementation, Java/Maven project structure, frontend, Docker/runtime, REST, gRPC/protobuf, persistence, deployment automation, service bootstrap or other runtime behavior changes.
+`push auto` must not publish unrelated changes, sensitive files, generated local artifacts, credentials, or files that cannot be classified as part of the active task.
 
 Execute this order:
 
@@ -365,20 +365,23 @@ Execute this order:
 4. Push the current non-`main` branch to `origin`.
 5. Create or reuse a GitHub pull request from the current branch against `main`.
 6. Verify that the pull request head branch matches the current branch and the base branch is `main`.
-7. Verify that GitHub reports the pull request as mergeable and that required checks are successful, or that no required checks are configured.
-8. Merge the pull request through GitHub.
-9. Re-fetch the pull request and verify `merged: true` before any branch deletion.
-10. Delete only the merged pull request's remote head branch.
-11. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward it, and delete the local merged branch.
-12. Report the merge commit, remote branch deletion result, clean result, and final `main` status.
+7. Wait, refresh, or retry the required PR checks until they are successful. This includes SonarQube or SonarCloud checks when configured for the pull request.
+8. If checks fail because of an in-scope defect that can be safely fixed, repair the defect, commit the fix, push the branch, and repeat the required-check loop.
+9. Stop if checks remain failed, pending indefinitely, missing, unknown, unverifiable, or require out-of-scope or unsafe changes.
+10. Verify that GitHub reports the pull request as mergeable and that all required checks are successful, or that no required checks are configured.
+11. Merge the pull request through GitHub.
+12. Re-fetch the pull request and verify `merged: true` before any branch deletion.
+13. Delete only the merged pull request's remote head branch.
+14. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward it, and delete the local merged branch.
+15. Report the merge commit, required-check and SonarQube status, remote branch deletion result, clean result, and final `main` status.
 
-For `push auto`, the pull request body must include the same content as the `push` workflow plus an explicit note that the workflow intends to merge the PR, delete the merged PR head branch, and run clean after merge verification.
+For `push auto`, the pull request body must include the same content as the `push` workflow plus an explicit note that the workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged PR head branch, and run clean after merge verification.
 
 Do not treat `push auto` as permission to force-push, push directly to `main`, retarget the pull request, bypass failed or pending checks, merge an unrelated pull request, delete `main`, delete a branch before the pull request is verified as merged, or enable GitHub auto-merge.
 
-If the diff is outside skills, agents, process-governance and governance-only workflow documentation scope, or if it contains blocked implementation, build, service, contract, Docker/runtime, frontend, Python automation or Java/Maven project files, stop and report the exact blocker.
+If the diff contains unrelated, sensitive, generated local, unclassified, or out-of-task files, stop and report the exact blocker.
 
-If GitHub mergeability, required-check status, merge result, remote branch deletion, or clean execution cannot be verified, stop and report the exact blocker.
+If GitHub mergeability, required-check status, SonarQube status when configured, merge result, remote branch deletion, or clean execution cannot be verified, stop and report the exact blocker.
 
 ## Required Commands
 
@@ -419,7 +422,7 @@ Use the minimum and full quality commands documented in `QUALITY.md` when verifi
 16. Use git_commit_operator to commit only if all required gates pass and user/task permits committing
 17. On a workflow-execute slice checkpoint, use git_commit_operator to stage only current-slice files, commit, push only to origin/<workflow-branch>, and record the SHA and push result
 18. On `push`, use git_commit_operator to push the branch and create or complete a GitHub pull request against main
-19. On `push auto`, use git_commit_operator only inside skills, agents, process-governance or governance-only workflow documentation scope to push, create or reuse the PR, verify mergeability and checks, merge the PR, verify merged state, delete the remote head branch, and run clean
+19. On `push auto`, use git_commit_operator for the task-scoped change to push, create or reuse the PR, wait or retry until required checks are green including SonarQube when configured, verify mergeability, merge the PR, verify merged state, delete the remote head branch, and run clean
 ```
 
 ## Commit Message Contract
@@ -482,9 +485,8 @@ Stop if:
 - the commit message would require guessing,
 - the user requested `push` but GitHub pull request creation is unavailable or would require guessing,
 - a workflow-execute slice checkpoint contains files outside the current slice or targets anything other than `origin/<workflow-branch>`,
-- `push auto` is requested outside skills, agents, process-governance or governance-only workflow documentation scope,
-- `push auto` would publish product implementation, build, service, contract, Docker/runtime, frontend, Python automation or Java/Maven project files,
-- the user requested `push auto` but mergeability, required-check status, merge result, remote branch deletion target, or clean execution cannot be verified.
+- `push auto` would publish unrelated, sensitive, generated local, unclassified, or out-of-task files,
+- the user requested `push auto` but mergeability, required-check status, SonarQube status when configured, merge result, remote branch deletion target, or clean execution cannot be verified.
 
 ## Forbidden Actions
 
@@ -495,8 +497,8 @@ Do not:
 - create commits unless the user or active workflow permits committing,
 - push or create pull requests unless the user enters `push`, enters `push auto`, the active workflow reaches a workflow-execute slice checkpoint, or explicitly requests that action,
 - push directly to `main`,
-- merge pull requests unless the user enters exactly `push auto` inside skills, agents, process-governance or governance-only workflow documentation scope,
-- delete remote branches unless the user enters exactly `push auto` inside skills, agents, process-governance or governance-only workflow documentation scope and the pull request was verified as merged,
+- merge pull requests unless the user enters exactly `push auto`, the diff is task-scoped, and all required checks including SonarQube when configured are green,
+- delete remote branches unless the user enters exactly `push auto`, the diff is task-scoped, all required checks including SonarQube when configured are green, and the pull request was verified as merged,
 - delete local branches directly instead of using the git-clean workflow after push auto,
 - force-push,
 - enable GitHub auto-merge,

--- a/.agents/skills/release-branch-governance/push-rules.md
+++ b/.agents/skills/release-branch-governance/push-rules.md
@@ -36,9 +36,11 @@ There are three separate publication modes:
    - pushes the branch and creates or updates a PR;
    - does not automatically merge.
 3. `push auto`
-   - belongs only to `skills-agents`;
-   - runs a guarded PR lifecycle;
-   - may merge the PR and clean up only after guard checks pass.
+   - applies to any task-scoped repository change, including Python product
+     code and Python product-behavior tests;
+   - runs a guarded commit, PR, check-loop, merge and cleanup lifecycle;
+   - may merge the PR and clean up only after required checks are green,
+     including SonarQube when configured.
 
 ## Rules
 
@@ -47,8 +49,11 @@ There are three separate publication modes:
 - Do not push unrelated local changes.
 - Create PRs only when workflow or user request allows it.
 - For slice checkpoint push, stage only current-slice files and push only to `origin/<workflow-branch>`.
-- For `push auto`, stop unless the active process strand is `skills-agents`.
-- `push auto` must not publish product implementation, services, contracts, Docker/runtime, build logic, frontend or analytics files.
+- For `push auto`, stop unless the active change is task-scoped and free of
+  unrelated, sensitive, generated local or unclassified files.
+- `push auto` must create or reuse a pull request, wait or retry until required
+  checks are green including SonarQube when configured, merge only after green
+  checks, delete the merged remote head branch and run local cleanup.
 
 ## STOP Rules
 
@@ -61,5 +66,7 @@ Stop when:
 - workflow does not allow push.
 - slice checkpoint push would include files outside the current slice;
 - slice checkpoint push would push to `main`, create or merge a PR, run `push auto`, run branch cleanup or force-push;
-- `push auto` is requested outside the `skills-agents` strand;
-- `push auto` would publish backend, frontend, Docker/runtime, contracts, persistence, analysis engine, Joern, JavaParser, BTM generator or analytics implementation changes.
+- `push auto` would publish unrelated, sensitive, generated local,
+  unclassified or out-of-task files;
+- required checks, SonarQube status when configured, mergeability, merge
+  result, remote branch deletion or local cleanup cannot be verified.

--- a/.agents/skills/workflow-executor/SKILL.md
+++ b/.agents/skills/workflow-executor/SKILL.md
@@ -259,6 +259,9 @@ For each slice:
 16. Continue with the next slice only when the current slice is clean, the checkpoint push succeeded, or the workflow explicitly permits carrying a documented blocker without a commit.
 
 Slice checkpoint push is not `push auto`. It must not create or merge a PR, run branch cleanup, force-push or push to `main`.
+A later explicit `push auto` may publish any task-scoped repository change
+produced by workflow execution only through the guarded commit, pull request,
+green required-checks, SonarQube when configured, merge and cleanup lifecycle.
 
 Each workflow-execute checkpoint commit must represent exactly one slice. Do
 not combine multiple slice IDs, opportunistic documentation edits or unrelated
@@ -294,3 +297,5 @@ Stop and report if:
 - commit or push is requested but not explicitly allowed by the workflow
 - checkpoint push would include files outside the current slice
 - checkpoint push would push to `main`, create or merge a PR, run `push auto`, run branch cleanup or force-push
+- `push auto` is requested but commit, pull request, green required-checks,
+  SonarQube when configured, merge or cleanup verification cannot be completed

--- a/.codex/agents/git_commit_operator.toml
+++ b/.codex/agents/git_commit_operator.toml
@@ -1,5 +1,5 @@
 name = "git_commit_operator"
-description = "Executes the Tiny Swarm World git-commit-preparation workflow after read-only review. Uses AGENTS.md, QUALITY.md, git-commit-preparation, git-commit-message-preparation, git-clean, and git_commit_reviewer output to stage explicit files, create commits, run workflow-execute slice checkpoint pushes, create GitHub pull requests against main on push, and merge plus clean up on push auto for skills, agents, process governance and governance-only workflow documentation."
+description = "Executes the Tiny Swarm World git-commit-preparation workflow after read-only review. Uses AGENTS.md, QUALITY.md, git-commit-preparation, git-commit-message-preparation, git-clean, and git_commit_reviewer output to stage explicit files, create commits, run workflow-execute slice checkpoint pushes, create GitHub pull requests against main on push, and run commit, PR, green required-checks, SonarQube when configured, merge plus cleanup on push auto for task-scoped changes including Python product code."
 developer_instructions = """
 You are the Commit Operator for the Tiny Swarm World repository.
 
@@ -67,15 +67,18 @@ For push, verify:
 - GitHub access is available,
 - no duplicate open pull request will be created for the same branch against main.
 
-For push auto, first verify that the diff is within skills, agents, process-governance or governance-only workflow documentation scope and contains no backend, frontend, Docker/runtime, gRPC, REST, persistence, analysis-engine, Joern, JavaParser, BTM generator or product implementation changes. Then execute the normal push workflow and verify:
+For push auto, first verify that the diff is task-scoped and contains no unrelated, sensitive, generated local, unclassified or out-of-task files. Then execute the normal push workflow and verify:
 - the pull request head branch matches the current branch,
 - the pull request base branch is main,
 - GitHub reports the pull request as mergeable,
 - required checks are successful, or no required checks are configured,
+- SonarQube or SonarCloud checks are successful when configured for the pull request,
 - the merge operation succeeded,
 - the pull request reports merged: true after re-fetching it,
 - the remote branch deletion target is exactly the merged pull request head branch,
 - the git-clean skill can switch to main, fast-forward main, and delete the local merged branch.
+
+If required checks fail because of an in-scope defect that can be safely fixed, repair it, commit it, push the branch, and repeat the required-check loop. Stop if checks remain failed, pending indefinitely, missing, unknown, unverifiable, or require out-of-scope or unsafe changes.
 
 The pull request must target main.
 The pull request title must come from the commit message title.
@@ -86,14 +89,14 @@ The pull request body must include:
 - impact,
 - risks and limitations,
 - for push: explicit note that no push to main or merge was performed,
-- for push auto: explicit note that the workflow will merge the pull request, delete the merged remote head branch, and run clean after merge verification.
+- for push auto: explicit note that the workflow will wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.
 
 You must not:
 - force-push,
 - push directly to main,
 - merge pull requests unless the user entered exactly push auto and all push auto checks passed,
-- run push auto outside skills, agents, process-governance or governance-only workflow documentation scope,
-- use push auto to publish product implementation, build, service, contract, Docker/runtime, frontend or analytics files,
+- run push auto with unrelated, sensitive, generated local, unclassified or out-of-task files,
+- use push auto to bypass failed, pending, unknown or unverifiable required checks, including SonarQube when configured,
 - enable auto-merge,
 - retarget the pull request away from main,
 - delete remote branches unless the user entered exactly push auto and the pull request was verified as merged,

--- a/.codex/agents/git_commit_reviewer.toml
+++ b/.codex/agents/git_commit_reviewer.toml
@@ -1,5 +1,5 @@
 name = "git_commit_reviewer"
-description = "Reviews commit readiness for the Tiny Swarm World repository. Uses AGENTS.md, QUALITY.md, git-commit-preparation, git-commit-message-preparation, and git-clean workflow expectations to inspect git state, changed files, verification evidence, risks, remediation routing, commit message quality, workflow-execute slice checkpoint eligibility, push eligibility, and push auto eligibility for skills, agents, process governance and governance-only workflow documentation."
+description = "Reviews commit readiness for the Tiny Swarm World repository. Uses AGENTS.md, QUALITY.md, git-commit-preparation, git-commit-message-preparation, and git-clean workflow expectations to inspect git state, changed files, verification evidence, risks, remediation routing, commit message quality, workflow-execute slice checkpoint eligibility, push eligibility, and push auto eligibility for task-scoped changes including Python product code."
 sandbox_mode = "read-only"
 developer_instructions = """
 You are the Commit Reviewer for the Tiny Swarm World repository.
@@ -37,7 +37,7 @@ Check whether the proposed commit message follows .agents/skills/git-commit-mess
 When blockers are present, identify the appropriate remediation role from .agents/skills/git-commit-preparation/SKILL.md.
 When the user requested push, also check whether the current branch is eligible for push and GitHub pull request creation against main.
 When the active workflow reached a workflow-execute slice checkpoint, also check that the staged or planned files belong only to the current slice, the slice quality gate passed or has a checked workflow exception, the commit will be slice-scoped, and the push target is origin/<workflow-branch>.
-When the user requested push auto, also check that the change is within skills, agents, process-governance or governance-only workflow documentation scope, no product implementation, build, service, contract, Docker/runtime, frontend or analytics files changed, and the current branch is eligible for push, GitHub pull request creation against main, automatic merge, remote head branch deletion after merge verification, and clean execution.
+When the user requested push auto, also check that the change is task-scoped, no unrelated, sensitive, generated local, unclassified or out-of-task files changed, and the current branch is eligible for push, GitHub pull request creation against main, required-check and SonarQube green-status verification when configured, automatic merge, remote head branch deletion after merge verification, and clean execution.
 
 You must not push branches.
 You must not create pull requests.

--- a/.codex/skills/workflow-executor/SKILL.md
+++ b/.codex/skills/workflow-executor/SKILL.md
@@ -42,6 +42,9 @@ Read, when present:
 11. Continue only when the slice is clean, the required checkpoint is recorded, or the workflow explicitly permits carrying a documented blocker.
 
 Slice checkpoint push is separate from `push` and `push auto`; it does not create or merge a PR, run branch cleanup, force-push or push to `main`.
+A later explicit `push auto` may publish any task-scoped repository change from
+workflow execution only through the guarded commit, pull request, green
+required-checks, SonarQube when configured, merge and cleanup lifecycle.
 
 ## Stop Conditions
 

--- a/.codex/workflow/workflow-execution-rules.md
+++ b/.codex/workflow/workflow-execution-rules.md
@@ -40,6 +40,9 @@ Root `AGENTS.md` and `QUALITY.md`, when present, remain authoritative for projec
    - Push only the current workflow branch to `origin`.
    - Record commit SHA and push result.
    - Do not create or merge a PR, run branch cleanup, run `push auto`, force-push or push to `main`.
+   - A later explicit `push auto` may publish any task-scoped repository
+     change only through the guarded commit, pull request, green
+     required-checks, SonarQube when configured, merge and cleanup lifecycle.
 
 ## Workflow Execute Protocol
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,16 @@ authoritative skill entrypoints.
 - Classify failures through the Typed Error Router before retries.
 - Slice checkpoint push is not `push auto` and must not create or merge a pull
   request.
+- Exact `push auto` may publish and automatically merge any task-scoped
+  repository change, including Python product code and Python
+  product-behavior tests.
+- `push auto` must run the full guarded lifecycle: create the commit, push the
+  branch, create or reuse a pull request, wait or retry until required checks
+  are green including SonarQube when configured, merge the pull request, delete
+  the merged remote head branch, and clean up the local branch.
+- `push auto` must stop on unrelated changes, sensitive files, generated local
+  artifacts, failed or unverifiable required checks, failed or unverifiable
+  SonarQube status, unknown mergeability, or unverifiable branch cleanup.
 
 Stop and report when documented behavior cannot be verified from repository
 evidence, governance documents conflict, ownership or quality authority would

--- a/documentation/process/branch-governance.md
+++ b/documentation/process/branch-governance.md
@@ -13,6 +13,12 @@ Tiny Swarm World.
 - Preserve existing user changes when switching branches.
 - Check local and remote branch-name collisions before creating a branch.
 - Prefer clear, task-specific branch names over generic work branches.
+- `push auto` may automatically merge any task-scoped repository change,
+  including product feature or bug-fix branches, Python product code, and
+  Python product-behavior tests.
+- `push auto` must create or reuse a pull request, wait or retry until required
+  checks are green including SonarQube when configured, merge only after green
+  checks, delete the merged remote head branch, and clean up the local branch.
 
 ## Branch Matrix
 

--- a/documentation/process/skill-agent-creation.md
+++ b/documentation/process/skill-agent-creation.md
@@ -14,6 +14,11 @@ definitions.
 - Codex callable-agent definitions live under `.codex/agents`.
 - Root `AGENTS.md` and `QUALITY.md` remain authoritative.
 - New Python implementation roles must preserve the hexagonal architecture and live-infrastructure safety rules.
+- New or changed git publication skills, agents, or prompts must preserve the
+  `push auto` lifecycle: task-scoped changes, including Python product code and
+  Python product-behavior tests, may be automatically merged only after commit,
+  pull request creation, green required checks including SonarQube when
+  configured, merge verification, remote branch deletion and local cleanup.
 - Java roles are out of scope unless the user explicitly changes the project
   architecture.
 - Tiny Swarm World is Docker Swarm first and Kubernetes-aware, not

--- a/documentation/process/skills-update.md
+++ b/documentation/process/skills-update.md
@@ -19,7 +19,12 @@ or workflow governance.
 8. Route service-boundary concerns by exact need: decomposition, runtime
    readiness, migration safety, contract governance, or Senior System Architect
    escalation.
-9. Run `git diff --check` and the quality gate required by `QUALITY.md` when practical.
+9. Stop if Python product code, Python product-behavior tests, or other
+    product implementation files would be changed.
+10. Prepare optional `push auto` only when explicitly requested and only
+    through the full commit, pull request, green required-checks, SonarQube
+    when configured, merge and cleanup lifecycle.
+11. Run `git diff --check` and the quality gate required by `QUALITY.md` when practical.
 
 ## Stop Conditions
 

--- a/documentation/process/workflow-execute.md
+++ b/documentation/process/workflow-execute.md
@@ -33,6 +33,11 @@ Use this process when the user requests `workflow execute`.
 8. Inspect `git diff` and `git diff --check`.
 9. When the active workflow requires checkpoint pushes, stage only current-slice files, commit, push the workflow branch, and record the result.
 
+Slice checkpoint push is not `push auto`. A later explicit `push auto` may
+publish any task-scoped repository change produced by workflow execution only
+through the guarded commit, pull request, green required-checks, SonarQube when
+configured, merge and cleanup lifecycle.
+
 ## Stop Conditions
 
 Stop when the branch, slice metadata, dependency graph, locks, ownership,


### PR DESCRIPTION
## Summary
- Expands `push auto` governance so task-scoped repository changes, including Python product code, can run the full guarded lifecycle.
- Aligns root rules, process docs, skills, prompts, and Git reviewer/operator agent definitions.
- Keeps slice checkpoint push separate from `push auto` while allowing a later explicit `push auto` to publish task-scoped changes through PR checks and cleanup.

## Changed areas
- Root and process governance: `AGENTS.md`, `documentation/process/*`
- Agent prompts and orchestrator rules under `.agents/`
- Commit/release/workflow skills under `.agents/skills` and `.codex/skills`
- Git commit reviewer/operator TOML definitions under `.codex/agents`

## Verification
- `git diff --check` passed.
- TOML parse for `.codex/agents/git_commit_operator.toml` and `.codex/agents/git_commit_reviewer.toml` passed.
- `python3 tools/quality_gate.py quality` passed in WSL: lint, arch-lint, arch-tests, typecheck, and 831 tests OK with 17 skipped.

## Impact
- `push auto` now means commit, branch push, PR create/reuse, wait or retry until required checks are green including SonarQube/SonarCloud when configured, merge, delete the merged remote head branch, and local cleanup.

## Risks and limitations
- `push auto` still stops on unrelated, sensitive, generated local, unclassified, or out-of-task files.
- It must not bypass failed, pending, unknown, or unverifiable required checks.

## Push auto intent
This workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.