### PR TITLE
agent(workflows): require worktrees for parallel execution

### DIFF
--- a/.agents/prompts/workflow-create.md
+++ b/.agents/prompts/workflow-create.md
@@ -80,7 +80,11 @@ git branch --show-current
     matches the workflow branch.
 16. Create or regenerate workflow artifacts only after successful branch verification.
 17. Build slices, role ownership, quality gates and stop conditions through the workflow-authoring skill.
-18. Validate that `documentation/workflow/workflow.md` and checked or updated `documentation/arc42/**` documentation exist before releasing `workflow execute`.
+18. Add the required `## Parallel Execution` workflow section. Default every
+    workflow to a required isolated Git worktree, allow parallel execution only
+    after Three Amigos confirms independence, and serialize live validation
+    unless isolated infrastructure is available.
+19. Validate that `documentation/workflow/workflow.md` and checked or updated `documentation/arc42/**` documentation exist before releasing `workflow execute`.
 
 For microservice migration workflows, record the Three Amigos decision before
 workflow authoring continues. The decision must include scope, non-scope,

--- a/.agents/skills/git-clean/SKILL.md
+++ b/.agents/skills/git-clean/SKILL.md
@@ -43,6 +43,12 @@ Also use it when the user explicitly asks to clean up after a merged PR.
 
 Also use it when `.agents/skills/git-commit-preparation/SKILL.md` invokes cleanup after a successful `push auto` merge.
 
+For parallel workflow cleanup, this skill may remove the completed workflow
+worktree only after the pull request was verified merged, the integration
+branch was updated locally, no uncommitted changes remain in that worktree,
+evidence was documented, and workflow status was updated. Do not remove a
+worktree with uncommitted changes or unclear ownership.
+
 Do not treat Gradle's `clean` task as this workflow unless the request is about Git or PR cleanup.
 
 ## Mandatory Behavior
@@ -58,6 +64,8 @@ You must:
 - delete only local branches proven merged and unnecessary,
 - keep branches with unclear ownership, unmerged commits, active worktrees, or missing merge evidence,
 - report every deleted, kept, and blocked branch.
+- report every removed, kept, and blocked workflow worktree when parallel
+  workflow cleanup is in scope.
 
 Remote branch deletion is not part of this skill unless the user explicitly requests remote deletion in addition to `clean`. The `push auto` workflow may delete the merged pull request's remote head branch before invoking this skill.
 
@@ -75,6 +83,14 @@ git switch main
 git pull --ff-only origin main
 git branch --merged main
 git branch --no-merged main
+```
+
+For parallel workflow worktree cleanup, inspect the candidate worktree before
+removal:
+
+```bash
+git -C <workflow-worktree> status --short --branch
+git worktree remove <workflow-worktree>
 ```
 
 When a candidate branch is known, verify it before deletion:
@@ -150,6 +166,22 @@ Never use `git branch -D` as part of this skill.
 
 Keep and report any branch that needs force deletion, has unclear ownership, has unmerged commits, is attached to another worktree, or cannot be matched to a completed PR.
 
+### Phase 5b: Remove Only Safe Workflow Worktrees
+
+Remove a workflow worktree only when all are true:
+
+- the cleanup follows a verified merged workflow PR;
+- the worktree belongs to that completed workflow;
+- the integration branch is updated locally;
+- `git -C <workflow-worktree> status --short --branch` shows no uncommitted
+  changes;
+- evidence and workflow status were documented;
+- `git worktree remove <workflow-worktree>` succeeds without force.
+
+Keep and report any worktree with uncommitted changes, unclear ownership,
+missing merge evidence, missing status evidence, or a removal that would require
+force.
+
 ### Phase 6: Final Verification
 
 Run:
@@ -173,6 +205,7 @@ PR merge status:
 
 Branch cleanup:
 - <branch>: <deleted / kept / blocked and reason>
+- <workflow worktree>: <removed / kept / blocked and reason>
 
 Main status:
 - <branch, commit, tracking status>
@@ -197,6 +230,8 @@ Stop if:
 - `main` cannot be fast-forwarded,
 - a candidate branch is used by another worktree,
 - deleting a branch would require `git branch -D`,
+- a workflow worktree has uncommitted changes, unclear ownership, missing merge
+  evidence, or would require forced removal,
 - remote branch deletion would be needed but was not explicitly requested,
 - credentials, tokens, or unrelated local files appear during cleanup.
 
@@ -208,7 +243,8 @@ Do not:
 - delete the current branch,
 - force-delete branches,
 - delete remote branches unless explicitly requested,
-- remove worktrees,
+- remove worktrees unless this is verified parallel workflow cleanup after a
+  successful merge and clean-state verification,
 - discard uncommitted changes,
 - run `git reset --hard`,
 - run `git clean`,

--- a/.agents/skills/git-commit-preparation/SKILL.md
+++ b/.agents/skills/git-commit-preparation/SKILL.md
@@ -101,6 +101,34 @@ Stop and report only when the required branch cannot be created, the branch stat
 
 Never push directly to `main`.
 
+## Parallel Workflow Publication Rule
+
+When multiple independent workflows are selected for parallel execution, each
+workflow must have one dedicated Git worktree, branch, isolated working
+directory, focused pull request and quality-gate lifecycle. Do not execute or
+publish multiple parallel workflows from the same worktree.
+
+Before parallel publication, verify that the workflows do not modify the same
+files, tests, package structures, workflow templates, governance files, skill
+files, agent files, shared architecture decisions or shared live infrastructure
+state. Conflicting workflows must be serialized.
+
+For each parallel workflow PR:
+
+- run commit readiness, verification, CI and SonarQube checks independently;
+- keep evidence separate per workflow branch and worktree;
+- merge completed PRs one at a time after refreshing the integration branch;
+- update or rebase the workflow branch when policy requires it and rerun
+  affected tests;
+- delete only the verified merged remote head branch;
+- remove the workflow worktree only after the PR is verified merged, the
+  integration branch is updated locally, the worktree is clean, evidence is
+  documented and workflow status is updated.
+
+Live infrastructure validation must be serialized unless the workflow proves
+isolated LXD, LXC, Docker, Docker Swarm, networking, firewall, service
+bootstrap, secrets-management, install, reset or reinstall infrastructure.
+
 ## Workflow
 
 ### Phase 0: Preconditions
@@ -372,8 +400,8 @@ Execute this order:
 11. Merge the pull request through GitHub.
 12. Re-fetch the pull request and verify `merged: true` before any branch deletion.
 13. Delete only the merged pull request's remote head branch.
-14. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward it, and delete the local merged branch.
-15. Report the merge commit, required-check and SonarQube status, remote branch deletion result, clean result, and final `main` status.
+14. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward it, delete the local merged branch, and remove a workflow worktree only when the parallel workflow cleanup rule allows it.
+15. Report the merge commit, required-check and SonarQube status, remote branch deletion result, clean result, any worktree cleanup result, and final `main` status.
 
 For `push auto`, the pull request body must include the same content as the `push` workflow plus an explicit note that the workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged PR head branch, and run clean after merge verification.
 
@@ -472,6 +500,10 @@ Stop if:
 - `.codex/agents/git_commit_operator.toml` cannot be read when commit, push, or pull-request execution is requested,
 - branch or worktree is unclear,
 - the worktree is detached,
+- parallel workflow publication cannot prove one branch, one worktree, one PR
+  and one quality lifecycle per workflow,
+- parallel workflow scopes overlap or merge order cannot be determined safely,
+- shared live infrastructure validation would run concurrently,
 - the current branch is `main` and a work branch cannot be created safely,
 - staged and unstaged changes conflict,
 - unexpected files exist,

--- a/.agents/skills/quality-gate/SKILL.md
+++ b/.agents/skills/quality-gate/SKILL.md
@@ -15,9 +15,17 @@ Identifies and executes the repository quality gate without weakening existing v
 4. Identify test, lint, typecheck, architecture, and validation commands.
 5. Execute commands in the host-appropriate shell environment: use WSL on Windows hosts and native shell access on Linux hosts.
 6. Stop and report if WSL is unavailable on Windows or cannot access the worktree.
-7. Run checks where feasible.
-8. Summarize pass/fail results.
-9. Report exact failing commands.
+7. For workflow execution, evaluate quality gates per workflow branch and per
+   worktree; do not reuse evidence from another parallel workflow.
+8. Keep test output and evidence files separate per workflow worktree unless
+   the workflow explicitly defines a shared evidence artifact.
+9. Serialize live validation when infrastructure is shared. Live LXD, LXC,
+   Docker, Docker Swarm, networking, firewall, Portainer, Jenkins, SonarQube,
+   Nexus, secrets-management, install, reset or reinstall validation may run in
+   parallel only with an explicitly isolated live environment.
+10. Run checks where feasible.
+11. Summarize pass/fail results.
+12. Report exact failing commands.
 
 ## Expected Inputs
 - QUALITY.md
@@ -42,3 +50,6 @@ Stop if:
 - required tooling is missing
 - thresholds would need to be changed
 - architecture or test verification would need to be weakened
+- quality evidence is shared across parallel workflow worktrees without an
+  explicit workflow design
+- live validation would mutate shared infrastructure concurrently

--- a/.agents/skills/release-branch-governance/push-rules.md
+++ b/.agents/skills/release-branch-governance/push-rules.md
@@ -42,6 +42,23 @@ There are three separate publication modes:
    - may merge the PR and clean up only after required checks are green,
      including SonarQube when configured.
 
+## Parallel Workflow Publication
+
+Parallel workflow publication handles one PR per workflow worktree. Each PR
+must be tied to exactly one workflow branch, one isolated worktree and one
+quality lifecycle. CI and SonarQube status are observed independently for each
+PR.
+
+Completed PRs must be merged one at a time. Before each merge, refresh the
+integration branch state, check whether another workflow merged first, update
+or rebase the workflow branch when repository policy requires it, rerun affected
+tests, and re-check CI plus SonarQube. Do not batch-merge multiple PRs.
+
+After a successful merge, delete only the merged PR head branch and remove a
+workflow worktree only after the PR is verified merged, the integration branch
+is updated locally, the worktree has no uncommitted changes, evidence is
+documented, and workflow status is updated.
+
 ## Rules
 
 - Do not push when required gates failed.
@@ -54,6 +71,10 @@ There are three separate publication modes:
 - `push auto` must create or reuse a pull request, wait or retry until required
   checks are green including SonarQube when configured, merge only after green
   checks, delete the merged remote head branch and run local cleanup.
+- For parallel workflows, keep one branch, one worktree, one PR and one
+  quality lifecycle per workflow.
+- Re-check integration branch state and affected tests before merging each PR
+  when another parallel workflow merged first.
 
 ## STOP Rules
 
@@ -70,3 +91,8 @@ Stop when:
   unclassified or out-of-task files;
 - required checks, SonarQube status when configured, mergeability, merge
   result, remote branch deletion or local cleanup cannot be verified.
+- a workflow worktree is dirty before publication or cleanup;
+- a PR cannot be tied to exactly one workflow branch and worktree;
+- merge order matters and cannot be determined safely;
+- rebasing or updating after another parallel workflow merged creates
+  conflicts or requires changes outside the workflow boundary.

--- a/.agents/skills/workflow-authoring/SKILL.md
+++ b/.agents/skills/workflow-authoring/SKILL.md
@@ -133,6 +133,7 @@ Every workflow should include:
 - resilience requirements
 - ordered slices
 - slice dependency graph
+- Parallel Execution
 - parallelization opportunities
 - role or subagent ownership map
 - quality-gate expectations from `QUALITY.md`
@@ -188,6 +189,13 @@ For each slice define:
 - allowed write scope
 - dependencies
 - parallel group
+- parallel execution eligibility
+- conflicting workflows
+- shared files
+- shared infrastructure
+- isolated worktree requirement
+- serialized live validation requirement
+- merge-order constraints
 - file, contract and architecture locks
 - parallelization status
 - done criteria
@@ -222,7 +230,31 @@ Use empty arrays for none. Dependencies must be concrete slice IDs, not ranges
 or prose. Missing metadata blocks future `workflow execute` until the workflow
 is corrected.
 
-Parallelize only when write scopes are disjoint, shared contracts are stable and verification can be run independently.
+Every executable workflow must include this section:
+
+```markdown
+## Parallel Execution
+
+- Can this workflow run in parallel?
+- Conflicting workflows:
+- Shared files:
+- Shared infrastructure:
+- Requires isolated worktree:
+- Requires serialized live validation:
+- Merge-order constraints:
+```
+
+Default policy:
+
+- Every workflow requires its own Git worktree.
+- Parallel execution is allowed only after Three Amigos confirms
+  independence.
+- Live validation is serialized unless isolated infrastructure is available.
+
+Parallelize only when write scopes are disjoint, shared contracts are stable,
+workflow templates, governance files, skill files, agent files, tests, package
+structures and architecture decisions do not overlap, and verification can be
+run independently. Conflicting workflows must be executed sequentially.
 
 ## Subagent Assignment
 

--- a/.agents/skills/workflow-executor/SKILL.md
+++ b/.agents/skills/workflow-executor/SKILL.md
@@ -138,6 +138,40 @@ architecture-boundary locks before any write-capable worker starts. Parallel
 execution is allowed only when locks are disjoint and quality gates can be
 attributed independently.
 
+## Parallel Worktree Execution
+
+Parallel workflow execution is supported only for workflows that S3D and Three
+Amigos confirm as independent. Independence requires disjoint changed files,
+tests, package structures, governance files, workflow templates, skill files,
+agent files, architecture decisions, and live infrastructure state.
+
+Each parallel workflow must run in its own Git worktree, branch, working
+directory, pull request and quality-gate lifecycle. Never execute multiple
+parallel workflows inside the same worktree. Use the preferred worktree parent
+`../Tiny-Swarm-World-worktrees/` and create each worktree from the current
+integration branch defined by repository governance.
+
+For every parallel workflow worktree:
+
+1. Create a dedicated worktree and branch before write-capable work.
+2. Run Three Amigos Gate inside that worktree.
+3. Execute exactly one workflow.
+4. Run validation, commit, push, PR, CI, SonarQube remediation, and merge
+   lifecycle independently for that worktree.
+5. Merge completed PRs one at a time after checking the latest integration
+   branch, rebasing or updating when policy requires it, and rerunning affected
+   tests.
+6. Remove the worktree only after the PR is verified merged, the integration
+   branch is updated locally, the worktree is clean, evidence is documented,
+   and workflow status is updated.
+
+Serialize workflows when file locks, tests, package structures, architecture
+decisions, governance artifacts, skill files, agent files, or live
+infrastructure state overlap. Live LXD, LXC, Docker, Docker Swarm, networking,
+firewall, Portainer, Jenkins, SonarQube, Nexus, secrets-management, install,
+reset or reinstall validation must be serialized unless the workflow proves an
+isolated live environment.
+
 Route lock conflicts as `LOCK_CONFLICT` through the Typed Error Router. S3D may
 stop, report, escalate or recommend manual workflow refinement, but it must not
 call `workflow create`, rewrite the active workflow from S3 or expand scope
@@ -286,6 +320,12 @@ Stop and report if:
 - `S3_CLASSIFY` cannot classify the slice and routes to `S3_UNCLASSIFIED`
 - S3D cannot verify required slice metadata, a dependency graph, topological order or disjoint locks
 - S3D detects a file, contract, module or architecture-boundary lock conflict
+- parallel workflow worktrees cannot be created or are dirty before execution
+- two parallel workflows unexpectedly modify the same file, test, governance
+  artifact, skill file, agent file, package structure or architecture decision
+- shared live infrastructure would be modified concurrently
+- merge order matters and cannot be determined safely
+- a rebase or merge conflict occurs after another parallel workflow merged
 - a quality or validation failure cannot be classified except as `UNKNOWN_FAILURE`
 - the typed error owner cannot be mapped to a verified role, skill or documented interim owner
 - typed-router retries exceed `maxRetries = 3`

--- a/.codex/agents/architecture_reviewer.toml
+++ b/.codex/agents/architecture_reviewer.toml
@@ -6,6 +6,11 @@ You are a strict architecture reviewer for Tiny Swarm World.
 Do not modify files.
 Check whether changes follow AGENTS.md, QUALITY.md, and the verified package layout.
 Pay special attention to hexagonal architecture, dependency direction, domain purity, application ports, adapter boundaries, graph/replay/LLM provider isolation, and technical API leakage.
+For parallel workflow planning, decide whether workflows are independent enough
+to run concurrently. Block parallel execution when workflows touch overlapping
+files, shared tests, shared module boundaries, package structure, workflow
+templates, governance files, skill files, agent files, architecture decisions,
+contract locks, or live infrastructure state.
 Report violations with file paths, affected symbols, severity, and concrete remediation proposals.
 Do not invent architecture rules that are not present in repository instructions.
 """

--- a/.codex/agents/git_commit_operator.toml
+++ b/.codex/agents/git_commit_operator.toml
@@ -78,6 +78,17 @@ For push auto, first verify that the diff is task-scoped and contains no unrelat
 - the remote branch deletion target is exactly the merged pull request head branch,
 - the git-clean skill can switch to main, fast-forward main, and delete the local merged branch.
 
+For parallel workflow publication, manage one PR per workflow worktree. Each
+workflow must have its own branch, worktree, working directory and quality
+lifecycle. Observe CI and SonarQube independently for each PR. Merge completed
+PRs one at a time after refreshing the integration branch, checking whether
+another workflow merged first, updating or rebasing when policy requires it,
+rerunning affected tests, and rechecking CI plus SonarQube.
+
+Remove a workflow worktree only after the PR is verified merged, the
+integration branch is updated locally, the worktree has no uncommitted changes,
+evidence is documented, and workflow status is updated.
+
 If required checks fail because of an in-scope defect that can be safely fixed, repair it, commit it, push the branch, and repeat the required-check loop. Stop if checks remain failed, pending indefinitely, missing, unknown, unverifiable, or require out-of-scope or unsafe changes.
 
 The pull request must target main.
@@ -101,6 +112,9 @@ You must not:
 - retarget the pull request away from main,
 - delete remote branches unless the user entered exactly push auto and the pull request was verified as merged,
 - delete local branches directly instead of using the git-clean workflow after push auto,
+- remove a workflow worktree before merge and clean-state verification,
+- batch-merge parallel workflow PRs without checking each PR's quality gates
+  independently,
 - bypass failed verification,
 - bypass failed, pending, or unknown required checks,
 - stage unrelated files,

--- a/.codex/agents/quality_reviewer.toml
+++ b/.codex/agents/quality_reviewer.toml
@@ -8,5 +8,9 @@ Read QUALITY.md and relevant Python tooling files before making claims.
 Identify the exact commands required to verify the project.
 Check whether documented quality commands match tools/quality_gate.py, .importlinter, requirements.txt, setup.py, and the test layout.
 Report missing tests, weak assertions, stale commands, coverage gaps, architecture-rule risks, and verification blockers.
+For parallel workflows, determine whether live validation can run in parallel or
+must be serialized. Require separate test evidence per workflow worktree unless
+the workflow explicitly defines shared evidence. Require re-validation when a
+parallel workflow branch is rebased or updated after another workflow merged.
 Do not weaken quality gates, coverage thresholds, architecture rules, or test expectations.
 """

--- a/.codex/skills/workflow-executor/SKILL.md
+++ b/.codex/skills/workflow-executor/SKILL.md
@@ -35,7 +35,8 @@ Read, when present:
 4. Run the S3 safety preflight when project governance defines it: check working tree status, active execution branch, local branch ref and active workflow scope before classifying a slice. Project-defined S3 classification must include a default unclassified STOP and escalation path; unclassifiable slices must not execute automatically.
 5. Identify slices, dependencies, write scopes, and verification commands.
 6. Route each slice to the smallest suitable set of subagents or role reviews.
-7. Execute one slice at a time.
+7. Execute one slice at a time unless project governance explicitly approves
+   independent parallel workflow execution in isolated Git worktrees.
 8. Run required targeted checks and quality gates after each slice.
 9. Inspect `git diff` and `git diff --check`.
 10. When the active project workflow permits slice checkpoint pushes, stage only current-slice files, run `git diff --cached --check`, create the slice-scoped checkpoint commit, push only the current workflow branch to `origin`, and record the commit SHA and push result.
@@ -46,6 +47,18 @@ A later explicit `push auto` may publish any task-scoped repository change from
 workflow execution only through the guarded commit, pull request, green
 required-checks, SonarQube when configured, merge and cleanup lifecycle.
 
+Parallel workflow execution requires one dedicated worktree, branch, working
+directory, PR and quality lifecycle per workflow. Do not execute multiple
+parallel workflows in the same worktree. Serialize overlapping workflows and
+shared live infrastructure validation unless isolated infrastructure is
+verified. Merge parallel workflow PRs one at a time after refreshing the
+integration branch, updating the branch when required, rerunning affected tests
+and rechecking CI plus SonarQube.
+
 ## Stop Conditions
 
-Stop when a slice, symbol, module, API, build task, schema, command, architecture rule, quality gate, start artifact, checkpoint target, service boundary, active branch, working-tree status, local branch ref, workflow scope, or slice classification cannot be verified exactly.
+Stop when a slice, symbol, module, API, build task, schema, command,
+architecture rule, quality gate, start artifact, checkpoint target, service
+boundary, active branch, working-tree status, local branch ref, workflow scope,
+parallel worktree isolation, merge order, live infrastructure isolation, or
+slice classification cannot be verified exactly.

--- a/.codex/workflow/workflow-execution-rules.md
+++ b/.codex/workflow/workflow-execution-rules.md
@@ -13,12 +13,18 @@ Root `AGENTS.md` and `QUALITY.md`, when present, remain authoritative for projec
 2. Slice detection
    - Identify the smallest meaningful implementation or documentation slice.
    - Record dependencies, affected files, role owners, verification commands, and stop conditions.
+   - For parallel workflow plans, verify disjoint files, tests, package
+     structures, workflow templates, governance files, skill files, agent
+     files, architecture decisions, dependencies and live infrastructure state.
 
 3. Role assignment
    - Route slices to the smallest suitable set of subagents or role reviews.
    - Prefer project-specific routing rules when the repository provides them.
    - Use callable subagents only when delegated execution is authorized by the active request or workflow command.
    - If callable subagents are unavailable, perform an explicit local review with the matching role file and report that limitation.
+   - When multiple independent workflows are intentionally executed in
+     parallel, use one dedicated Git worktree, branch, working directory, PR
+     and quality-gate lifecycle per workflow.
 
 4. Implementation
    - Apply only the smallest verified change.
@@ -43,6 +49,19 @@ Root `AGENTS.md` and `QUALITY.md`, when present, remain authoritative for projec
    - A later explicit `push auto` may publish any task-scoped repository
      change only through the guarded commit, pull request, green
      required-checks, SonarQube when configured, merge and cleanup lifecycle.
+
+## Parallel Workflow Execution
+
+Parallel workflows may run only when the project-specific governance confirms
+independence. Never execute multiple parallel workflows in the same worktree.
+Serialize workflows with overlapping files, tests, package structures,
+governance artifacts, workflow templates, skill files, agent files,
+architecture decisions, dependencies, or shared live infrastructure.
+
+Quality gates, evidence, CI, SonarQube observation, PR remediation and merge
+are per workflow branch and per worktree. Merge completed PRs one at a time
+after re-checking the latest integration branch state and rerunning affected
+tests when a branch is updated.
 
 ## Workflow Execute Protocol
 
@@ -71,5 +90,9 @@ Stop and report when:
 - source and documentation conflict in a behavior-relevant way;
 - a change would fabricate evidence, test data, runtime facts, analysis output, or user-visible behavior;
 - a slice would violate verified architecture or service-boundary rules;
+- a parallel workflow worktree cannot be created, is dirty, overlaps another
+  workflow, or depends on a workflow that has not merged;
+- shared live infrastructure would be mutated concurrently;
+- merge order matters and cannot be determined safely;
 - a quality command cannot be verified from repository documentation or build files;
 - continuing would require guessing.

--- a/documentation/process/workflow-create.md
+++ b/documentation/process/workflow-create.md
@@ -18,7 +18,8 @@ Use this process when the user requests `workflow create`.
 3. Create or verify the dedicated workflow branch.
 4. Generate or regenerate `documentation/workflow`.
 5. Define slices with owners, dependencies, allowed write scopes, stop conditions, and quality gates from `QUALITY.md`.
-6. Verify that `documentation/workflow/workflow.md` and relevant `documentation/arc42` updates exist before releasing `workflow execute`.
+6. Add the required `## Parallel Execution` section to every executable workflow, including parallel eligibility, conflicting workflows, shared files, shared infrastructure, isolated worktree requirement, serialized live validation requirement, and merge-order constraints.
+7. Verify that `documentation/workflow/workflow.md` and relevant `documentation/arc42` updates exist before releasing `workflow execute`.
 
 ## Stop Conditions
 


### PR DESCRIPTION
## Summary

- Require isolated Git worktrees for independent parallel workflow execution.
- Add per-worktree quality, evidence, PR, CI, SonarQube, merge-order, and cleanup rules.
- Update workflow authoring so executable workflows include a `## Parallel Execution` section.
- Update reviewer and publication agent instructions for independence checks, serialized live validation, and one-at-a-time merges.

## Changed areas

- `.agents/skills/workflow-executor/SKILL.md`
- `.agents/skills/quality-gate/SKILL.md`
- `.agents/skills/git-commit-preparation/SKILL.md`
- `.agents/skills/git-clean/SKILL.md`
- `.agents/skills/release-branch-governance/push-rules.md`
- `.agents/skills/workflow-authoring/SKILL.md`
- `.agents/prompts/workflow-create.md`
- `.codex/agents/*reviewer.toml`
- `.codex/agents/git_commit_operator.toml`
- `.codex/skills/workflow-executor/SKILL.md`
- `.codex/workflow/workflow-execution-rules.md`
- `documentation/process/workflow-create.md`

## Verification

- `git diff --check`: passed
- `wsl -e bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality'`: passed

## Impact

- Governance and workflow execution instructions now require one branch, one worktree, one PR, and one quality lifecycle per parallel workflow.
- Runtime product behavior: none.

## Risks and limitations

- This is an agent/governance documentation change only.
- GitHub CLI is not installed in the local shell, so the PR lifecycle is handled with local `git` plus the GitHub connector.

## Push auto intent

This PR is part of a requested `push auto` flow. The workflow will wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run clean after merge verification.