### PR TITLE
agent(git): clean squash-merged local branches

### DIFF
--- a/.agents/skills/git-clean/SKILL.md
+++ b/.agents/skills/git-clean/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-clean
-description: Use when the user enters exactly `clean`, when `push auto` needs post-merge cleanup, or when Codex is asked to clean up after a GitHub pull request was merged in the repository. Verifies the PR merge, fetches and prunes origin, switches the worktree to main, fast-forwards main, deletes only local branches proven merged and unnecessary, and reports blockers without force deletion.
+description: Use when the user enters exactly `clean`, when `push auto` needs post-merge cleanup, or when Codex is asked to clean up after a GitHub pull request was merged in the repository. Verifies the PR merge, fetches and prunes origin, switches the worktree to main, fast-forwards main, deletes local branches proven merged and the verified local head branch of a squash-merged PR, and reports blockers.
 ---
 
 # Clean Skill
@@ -61,7 +61,9 @@ You must:
 - otherwise verify that the branch tip is an ancestor of `origin/main` or `main`,
 - fetch and prune remote-tracking references before deciding branch status,
 - switch the worktree to `main` and fast-forward it,
-- delete only local branches proven merged and unnecessary,
+- delete local branches proven merged and unnecessary,
+- delete the verified local head branch of a squash-merged PR when `git branch
+  -d` refuses only because the branch tip is not an ancestor of `main`,
 - keep branches with unclear ownership, unmerged commits, active worktrees, or missing merge evidence,
 - report every deleted, kept, and blocked branch.
 - report every removed, kept, and blocked workflow worktree when parallel
@@ -99,6 +101,7 @@ When a candidate branch is known, verify it before deletion:
 git merge-base --is-ancestor <branch> main
 git merge-base --is-ancestor <branch> origin/main
 git branch -d <branch>
+git branch -D <branch>
 ```
 
 Use shell-safe branch names and avoid string-built destructive commands.
@@ -158,13 +161,27 @@ Delete local branches only when all are true:
 - the branch is not `main`,
 - the branch is not the current branch,
 - the branch is not used by another worktree,
-- the branch has no unmerged commits relative to `main` or `origin/main`,
 - the branch belongs to the completed task or is otherwise clearly unnecessary,
-- `git branch -d <branch>` succeeds.
+- either the branch tip is an ancestor of `main` or `origin/main`, or the branch
+  is the verified head branch of a squash-merged pull request,
+- `git branch -d <branch>` succeeds, or the squash-merge fallback below
+  applies.
 
-Never use `git branch -D` as part of this skill.
+Squash-merge fallback:
 
-Keep and report any branch that needs force deletion, has unclear ownership, has unmerged commits, is attached to another worktree, or cannot be matched to a completed PR.
+- Use `git branch -D <branch>` only when GitHub metadata proves the PR is
+  merged, the PR base is `main`, the PR head branch matches `<branch>`, local
+  `main` has been fast-forwarded to `origin/main`, the remote head branch is
+  deleted or already gone, the local branch is not attached to another
+  worktree, and `git branch -d <branch>` refused only because the branch is not
+  fully merged after a squash merge.
+- Do not use `git branch -D` for unclear branch ownership, non-PR branches,
+  active worktree branches, unmerged non-squash work, or failed merge
+  verification.
+
+Keep and report any branch that needs force deletion outside the squash-merge
+fallback, has unclear ownership, has unmerged non-squash work, is attached to
+another worktree, or cannot be matched to a completed PR.
 
 ### Phase 5b: Remove Only Safe Workflow Worktrees
 
@@ -229,7 +246,8 @@ Stop if:
 - `main` cannot be checked out,
 - `main` cannot be fast-forwarded,
 - a candidate branch is used by another worktree,
-- deleting a branch would require `git branch -D`,
+- deleting a branch would require `git branch -D` without satisfying the
+  squash-merge fallback,
 - a workflow worktree has uncommitted changes, unclear ownership, missing merge
   evidence, or would require forced removal,
 - remote branch deletion would be needed but was not explicitly requested,
@@ -241,7 +259,8 @@ Do not:
 
 - delete `main`,
 - delete the current branch,
-- force-delete branches,
+- force-delete branches except for the verified local head branch of a
+  squash-merged PR under the squash-merge fallback,
 - delete remote branches unless explicitly requested,
 - remove worktrees unless this is verified parallel workflow cleanup after a
   successful merge and clean-state verification,

--- a/.agents/skills/git-commit-preparation/SKILL.md
+++ b/.agents/skills/git-commit-preparation/SKILL.md
@@ -400,7 +400,10 @@ Execute this order:
 11. Merge the pull request through GitHub.
 12. Re-fetch the pull request and verify `merged: true` before any branch deletion.
 13. Delete only the merged pull request's remote head branch.
-14. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward it, delete the local merged branch, and remove a workflow worktree only when the parallel workflow cleanup rule allows it.
+14. Run `.agents/skills/git-clean/SKILL.md` to switch to `main`, fast-forward
+    it, delete the local PR branch, use the squash-merge cleanup fallback when
+    the verified PR was squash-merged, and remove a workflow worktree only when
+    the parallel workflow cleanup rule allows it.
 15. Report the merge commit, required-check and SonarQube status, remote branch deletion result, clean result, any worktree cleanup result, and final `main` status.
 
 For `push auto`, the pull request body must include the same content as the `push` workflow plus an explicit note that the workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged PR head branch, and run clean after merge verification.
@@ -531,7 +534,8 @@ Do not:
 - push directly to `main`,
 - merge pull requests unless the user enters exactly `push auto`, the diff is task-scoped, and all required checks including SonarQube when configured are green,
 - delete remote branches unless the user enters exactly `push auto`, the diff is task-scoped, all required checks including SonarQube when configured are green, and the pull request was verified as merged,
-- delete local branches directly instead of using the git-clean workflow after push auto,
+- delete local branches directly instead of using the git-clean workflow after
+  push auto, including the verified squash-merge fallback,
 - force-push,
 - enable GitHub auto-merge,
 - retarget the pull request away from `main`,

--- a/.agents/skills/release-branch-governance/push-rules.md
+++ b/.agents/skills/release-branch-governance/push-rules.md
@@ -70,7 +70,10 @@ documented, and workflow status is updated.
   unrelated, sensitive, generated local or unclassified files.
 - `push auto` must create or reuse a pull request, wait or retry until required
   checks are green including SonarQube when configured, merge only after green
-  checks, delete the merged remote head branch and run local cleanup.
+  checks, delete the merged remote head branch and run local cleanup. When the
+  PR was squash-merged, local cleanup must delete the verified local PR branch
+  with the git-clean squash-merge fallback after merge and remote-branch
+  deletion are verified.
 - For parallel workflows, keep one branch, one worktree, one PR and one
   quality lifecycle per workflow.
 - Re-check integration branch state and affected tests before merging each PR

--- a/.codex/agents/git_commit_operator.toml
+++ b/.codex/agents/git_commit_operator.toml
@@ -76,7 +76,9 @@ For push auto, first verify that the diff is task-scoped and contains no unrelat
 - the merge operation succeeded,
 - the pull request reports merged: true after re-fetching it,
 - the remote branch deletion target is exactly the merged pull request head branch,
-- the git-clean skill can switch to main, fast-forward main, and delete the local merged branch.
+- the git-clean skill can switch to main, fast-forward main, delete the local
+  PR branch, and use the squash-merge cleanup fallback when GitHub merged the
+  PR by squash merge.
 
 For parallel workflow publication, manage one PR per workflow worktree. Each
 workflow must have its own branch, worktree, working directory and quality
@@ -111,7 +113,8 @@ You must not:
 - enable auto-merge,
 - retarget the pull request away from main,
 - delete remote branches unless the user entered exactly push auto and the pull request was verified as merged,
-- delete local branches directly instead of using the git-clean workflow after push auto,
+- delete local branches directly instead of using the git-clean workflow after
+  push auto, including the verified squash-merge fallback,
 - remove a workflow worktree before merge and clean-state verification,
 - batch-merge parallel workflow PRs without checking each PR's quality gates
   independently,


### PR DESCRIPTION
## Summary

- Add a narrowly scoped `git-clean` fallback for local PR branch cleanup after verified squash merges.
- Wire `push auto`, release push rules, and `git_commit_operator` instructions to use that fallback.
- Keep force deletion prohibited outside the verified squash-merge cleanup case.

## Changed areas

- `.agents/skills/git-clean/SKILL.md`
- `.agents/skills/git-commit-preparation/SKILL.md`
- `.agents/skills/release-branch-governance/push-rules.md`
- `.codex/agents/git_commit_operator.toml`

## Verification

- `git diff --check`: passed
- `wsl -e bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality'`: passed

## Impact

- `push auto` cleanup now removes the verified local PR head branch after squash merge, once merge, remote branch deletion, and local main fast-forward are verified.
- Runtime product behavior: none.

## Risks and limitations

- This is a governance and agent-instruction change only.
- The fallback remains blocked for unclear branch ownership, active worktree branches, non-PR branches, failed merge verification, or unmerged non-squash work.

## Push auto intent

This PR is part of a requested `push auto` flow. The workflow will wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, run clean after merge verification, and use the verified squash-merge fallback for local branch cleanup when applicable.