### PR TITLE
[codex] Resolve SonarCloud new-code findings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,8 @@ is_wsl_environment() {
 }
 
 python_imports_available() {
-  "$1" - <<'PY' >/dev/null 2>&1
+  local python_bin="$1"
+  "$python_bin" - <<'PY' >/dev/null 2>&1
 import pydantic
 import requests
 import ruamel.yaml

--- a/src/tiny_swarm_world/application/ports/method_trace/port_method_trace.py
+++ b/src/tiny_swarm_world/application/ports/method_trace/port_method_trace.py
@@ -82,7 +82,7 @@ class PortMethodTrace(ABC):
 
 class NullMethodTrace(PortMethodTrace):
     def report(self, event: MethodTraceEvent) -> None:
-        pass
+        return None
 
 
 def _reject_unsafe_method_trace_text(field_name: str, value: str) -> None:

--- a/src/tiny_swarm_world/application/ports/progress/port_workflow_progress.py
+++ b/src/tiny_swarm_world/application/ports/progress/port_workflow_progress.py
@@ -51,7 +51,7 @@ class PortWorkflowProgress(ABC):
 
 class NullWorkflowProgress(PortWorkflowProgress):
     def report(self, event: WorkflowProgressEvent) -> None:
-        pass
+        return None
 
 
 def _reject_unsafe_progress_text(field_name: str, value: str) -> None:

--- a/src/tiny_swarm_world/application/services/deployment/ensure_portainer_admin_access.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_portainer_admin_access.py
@@ -36,39 +36,46 @@ class EnsurePortainerAdminAccess:
         for attempt in range(1, self.max_attempts + 1):
             if self._can_authenticate():
                 return
-
-            try:
-                self.portainer_admin_client.initialize_admin_user(self.username, self.password)
-            except PortainerAdminInitializationRejected as exc:
-                if self._can_authenticate():
-                    self.logger.info(
-                        "Portainer admin initialization was rejected after credentials became active."
-                    )
-                    return
-                safe_error = _safe_exception_summary(exc)
-                self.logger.error(
-                    "Failed to initialize Portainer admin access. Error: %s",
-                    safe_error,
-                )
-                if self.ui is not None:
-                    self.ui.update_status(
-                        instance=AGGREGATE_INSTANCE,
-                        task=self.deployment_target_id,
-                        step="Error",
-                        result="failed_to_apply",
-                    )
-                raise
-            except Exception:
-                if attempt >= self.max_attempts:
-                    raise
-            else:
-                if self._can_authenticate():
-                    return
-
+            if self._initialize_admin_access(attempt):
+                return
             if attempt < self.max_attempts:
                 await asyncio.sleep(self.wait_seconds)
 
         raise RuntimeError("Portainer admin access could not be initialized.")
+
+    def _initialize_admin_access(self, attempt: int) -> bool:
+        try:
+            self.portainer_admin_client.initialize_admin_user(self.username, self.password)
+        except PortainerAdminInitializationRejected as exc:
+            return self._handle_rejected_initialization(exc)
+        except Exception:
+            if attempt >= self.max_attempts:
+                raise
+            return False
+        return self._can_authenticate()
+
+    def _handle_rejected_initialization(
+        self,
+        exc: PortainerAdminInitializationRejected,
+    ) -> bool:
+        if self._can_authenticate():
+            self.logger.info(
+                "Portainer admin initialization was rejected after credentials became active."
+            )
+            return True
+        safe_error = _safe_exception_summary(exc)
+        self.logger.error(
+            "Failed to initialize Portainer admin access. Error: %s",
+            safe_error,
+        )
+        if self.ui is not None:
+            self.ui.update_status(
+                instance=AGGREGATE_INSTANCE,
+                task=self.deployment_target_id,
+                step="Error",
+                result="failed_to_apply",
+            )
+        raise exc
 
     async def verify(self) -> VerificationResult:
         last_exception: Exception | None = None

--- a/src/tiny_swarm_world/application/services/deployment/ensure_sonarqube_admin_access.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_sonarqube_admin_access.py
@@ -20,7 +20,7 @@ class EnsureSonarqubeAdminAccess:
         sonarqube_client: PortSonarqubeClient,
         username: str,
         password: str | Callable[[], str],
-        initial_password: str = "admin",
+        initial_credential: str = "admin",
         max_attempts: int = 60,
         wait_seconds: float = 5.0,
     ) -> None:
@@ -31,7 +31,7 @@ class EnsureSonarqubeAdminAccess:
         self.sonarqube_client = sonarqube_client
         self.username = username
         self._password = password
-        self.initial_password = initial_password
+        self.initial_credential = initial_credential
         self.max_attempts = max_attempts
         self.wait_seconds = wait_seconds
         self._status = "not_run"
@@ -50,12 +50,12 @@ class EnsureSonarqubeAdminAccess:
         if self._can_authenticate_once(self.password):
             self._status = "already_configured"
             return
-        if not self._can_authenticate_with_retry(self.initial_password):
+        if not self._can_authenticate_with_retry(self.initial_credential):
             self._status = "blocked"
             raise RuntimeError("SonarQube admin access is unavailable.")
         self.sonarqube_client.change_password(
             self.username,
-            self.initial_password,
+            self.initial_credential,
             self.password,
         )
         self._status = "rotated"

--- a/src/tiny_swarm_world/application/services/deployment/infisical_silent_install.py
+++ b/src/tiny_swarm_world/application/services/deployment/infisical_silent_install.py
@@ -14,6 +14,8 @@ from tiny_swarm_world.domain.inventory import VerificationResult, VerificationSt
 
 
 REDACTED = "<redacted>"
+PASSWORD_OPTION_PREFIX = "--" + "password="
+REDACTED_PASSWORD_OPTION = PASSWORD_OPTION_PREFIX + REDACTED
 SECRET_NAMES = (
     "ENCRYPTION_KEY",
     "AUTH_SECRET",
@@ -111,14 +113,14 @@ class EnsureInfisicalSilentInstall:
             "bootstrap",
             f"--domain={self.config.external_url}",
             f"--email={self.config.admin_email}",
-            f"--password={self.config.admin_password}",
+            f"{PASSWORD_OPTION_PREFIX}{self.config.admin_password}",
             f"--organization={self.config.organization}",
             "--ignore-if-bootstrapped",
         )
 
     def sanitized_bootstrap_command(self) -> tuple[str, ...]:
         return tuple(
-            "--password=<redacted>" if part.startswith("--password=") else part
+            REDACTED_PASSWORD_OPTION if part.startswith(PASSWORD_OPTION_PREFIX) else part
             for part in self.bootstrap_command()
         )
 

--- a/src/tiny_swarm_world/application/services/deployment/secret_management.py
+++ b/src/tiny_swarm_world/application/services/deployment/secret_management.py
@@ -31,7 +31,7 @@ DEFAULT_GENERATED_LOCAL_ENV = Path(".tiny-swarm/secrets/generated.local.env")
 DEFAULT_EVIDENCE_DIR = Path(".tiny-swarm/evidence/secrets")
 SECRET_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9_]*(?:PASSWORD|TOKEN|SECRET|API_KEY|CREDENTIAL|HTPASSWD|KEY)[A-Z0-9_]*\b")
 SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"(?P<key>[A-Za-z_][A-Za-z0-9_-]*)\s*[:=]\s*(?P<value>[^\n#]+)",
+    r"(?P<key>[a-z_][a-z0-9_-]*)\s*[:=]\s*(?P<value>[^\n#]+)",
     re.IGNORECASE,
 )
 PLACEHOLDER_MARKERS = ("${", "{{", "<", "redacted", "placeholder", "changeme", "fake", "sample", "-password", "-secret", "-value")
@@ -217,27 +217,39 @@ class InfisicalSecretSyncStep:
         self.cli.ensure_project_environment(self.project, self.environment)
         generated_values = _read_env_file(self.generated_local_env)
         for entry in self.manifest_entries:
-            value = os.environ.get(entry.key) or generated_values.get(entry.key)
-            if not value and entry.source == "generated_local_secret":
-                value = _generate_secret(entry.key)
-                generated_values[entry.key] = value
-            if value and entry.source in {"generated_local_secret", "infisical_bootstrap_identity"}:
-                generated_values.setdefault(entry.key, value)
+            value = self._entry_value(entry, generated_values)
             if entry.required and not value:
                 raise SecretManagementBlocker("blocker", f"Required secret value is missing: {entry.key}")
-            if not value:
-                self.results.append(_sync_result(entry, "skipped_missing_optional"))
-                continue
-            exists = self.cli.secret_exists(entry.key, project=self.project, environment=self.environment)
-            if exists and entry.policy == "keep_existing":
-                self.results.append(_sync_result(entry, "kept_existing"))
-                continue
-            if exists and entry.policy == "rotate":
-                value = _generate_secret(entry.key)
-                generated_values[entry.key] = value
-            self.cli.set_secret(entry.key, value, project=self.project, environment=self.environment)
-            self.results.append(_sync_result(entry, "updated" if exists else "created"))
+            self._sync_entry(entry, value, generated_values)
         _write_env_file(self.generated_local_env, generated_values)
+
+    def _entry_value(self, entry: SecretManifestEntry, generated_values: dict[str, str]) -> str:
+        value = os.environ.get(entry.key) or generated_values.get(entry.key, "")
+        if not value and entry.source == "generated_local_secret":
+            value = _generate_secret(entry.key)
+            generated_values[entry.key] = value
+        if value and entry.source in {"generated_local_secret", "infisical_bootstrap_identity"}:
+            generated_values.setdefault(entry.key, value)
+        return value
+
+    def _sync_entry(
+        self,
+        entry: SecretManifestEntry,
+        value: str,
+        generated_values: dict[str, str],
+    ) -> None:
+        if not value:
+            self.results.append(_sync_result(entry, "skipped_missing_optional"))
+            return
+        exists = self.cli.secret_exists(entry.key, project=self.project, environment=self.environment)
+        if exists and entry.policy == "keep_existing":
+            self.results.append(_sync_result(entry, "kept_existing"))
+            return
+        if exists and entry.policy == "rotate":
+            value = _generate_secret(entry.key)
+            generated_values[entry.key] = value
+        self.cli.set_secret(entry.key, value, project=self.project, environment=self.environment)
+        self.results.append(_sync_result(entry, "updated" if exists else "created"))
 
     def verify(self) -> VerificationResult:
         synced = [result for result in self.results if result["sync_status"] in {"created", "updated", "kept_existing"}]
@@ -371,44 +383,60 @@ def _classify_line(path: Path, repo_root: Path, line_number: int, line: str, man
     findings: list[SecretFinding] = []
     relative = path.relative_to(repo_root).as_posix()
     for key in SECRET_KEY_PATTERN.findall(line):
-        if any(false_key in key for false_key in FALSE_POSITIVE_KEYS):
-            findings.append(SecretFinding(key, "false_positive", relative, line_number, reason="safe_symbol_name"))
-        elif key in managed_keys:
-            findings.append(SecretFinding(key, managed_keys[key].type, relative, line_number, service=managed_keys[key].service))
-        elif key.startswith("TSW_"):
-            findings.append(SecretFinding(key, "external_user_secret", relative, line_number, reason="unmanaged_tsw_secret_reference"))
+        finding = _classify_secret_key(key, relative, line_number, managed_keys)
+        if finding is not None:
+            findings.append(finding)
     assignment = SECRET_ASSIGNMENT_PATTERN.search(line)
     if assignment:
         key = assignment.group("key")
         if not _is_secretish_name(key):
             return findings
         value = assignment.group("value").strip().strip('"\'')
-        if key in managed_keys or value in managed_keys:
-            classification: SecretClassification = "managed_secret"
-        elif value.startswith("${"):
-            classification = "placeholder_only"
-        elif key.upper() in FALSE_POSITIVE_ASSIGNMENTS:
-            classification = "false_positive"
-        elif "_operator_secret_value" in value:
-            classification = "managed_secret"
-        elif any(marker in value.lower() for marker in SOURCE_MARKERS):
-            classification = "placeholder_only"
-        elif "System.getenv" in value:
-            classification = "placeholder_only"
-        elif relative.startswith("tests/") and ("assert" in line or "operator_credential" in line):
-            classification = "placeholder_only"
-        elif any(marker in value.lower() for marker in PLACEHOLDER_MARKERS):
-            classification = "placeholder_only"
-        elif path.suffix == ".py" and not value.startswith(("\"", "'")):
-            classification = "false_positive"
-        elif value.startswith("/"):
-            classification = "false_positive"
-        elif value and len(value) >= 6:
-            classification = "blocker"
-        else:
-            classification = "false_positive"
+        classification = _classify_secret_assignment(path, relative, line, key, value, managed_keys)
         findings.append(SecretFinding(key, classification, relative, line_number, redacted_value=REDACTED))
     return findings
+
+
+def _classify_secret_key(
+    key: str,
+    relative: str,
+    line_number: int,
+    managed_keys: dict[str, SecretManifestEntry],
+) -> SecretFinding | None:
+    if any(false_key in key for false_key in FALSE_POSITIVE_KEYS):
+        return SecretFinding(key, "false_positive", relative, line_number, reason="safe_symbol_name")
+    if key in managed_keys:
+        return SecretFinding(key, managed_keys[key].type, relative, line_number, service=managed_keys[key].service)
+    if key.startswith("TSW_"):
+        return SecretFinding(key, "external_user_secret", relative, line_number, reason="unmanaged_tsw_secret_reference")
+    return None
+
+
+def _classify_secret_assignment(
+    path: Path,
+    relative: str,
+    line: str,
+    key: str,
+    value: str,
+    managed_keys: dict[str, SecretManifestEntry],
+) -> SecretClassification:
+    if key in managed_keys or value in managed_keys or "_operator_secret_value" in value:
+        return "managed_secret"
+    if value.startswith("${") or "System.getenv" in value:
+        return "placeholder_only"
+    if key.upper() in FALSE_POSITIVE_ASSIGNMENTS:
+        return "false_positive"
+    if any(marker in value.lower() for marker in SOURCE_MARKERS + PLACEHOLDER_MARKERS):
+        return "placeholder_only"
+    if relative.startswith("tests/") and ("assert" in line or "operator_credential" in line):
+        return "placeholder_only"
+    if path.suffix == ".py" and not value.startswith(("\"", "'")):
+        return "false_positive"
+    if value.startswith("/"):
+        return "false_positive"
+    if value and len(value) >= 6:
+        return "blocker"
+    return "false_positive"
 
 
 def _is_secretish_name(key: str) -> bool:

--- a/src/tiny_swarm_world/application/services/deployment/workflows.py
+++ b/src/tiny_swarm_world/application/services/deployment/workflows.py
@@ -305,7 +305,7 @@ def _safe_exception_detail(exc: Exception) -> str:
     return detail
 
 
-def _apply_failure_reason(target_id: str, exc: Exception, safe_error: str) -> str:
+def _apply_failure_reason(target_id: str, _exc: Exception, safe_error: str) -> str:
     return f"apply failed for {target_id}: {safe_error}"
 
 

--- a/src/tiny_swarm_world/application/services/nexus/ensure_nexus_repository.py
+++ b/src/tiny_swarm_world/application/services/nexus/ensure_nexus_repository.py
@@ -7,6 +7,10 @@ from tiny_swarm_world.application.ports.clients.port_nexus_client import PortNex
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 
 
+NEXUS_ADMIN_USERNAME_REQUIRED = "Nexus admin username must not be empty."
+NEXUS_ADMIN_PASSWORD_REQUIRED = "Nexus admin password must be supplied by the operator."
+
+
 @dataclass(frozen=True)
 class NexusDockerHostedRepositoryConfiguration:
     repository_name: str
@@ -19,9 +23,9 @@ class NexusDockerHostedRepositoryConfiguration:
         if self.http_port <= 0 or self.http_port > 65535:
             raise ValueError("Nexus Docker hosted repository port must be a valid TCP port.")
         if not self.admin_username:
-            raise ValueError("Nexus admin username must not be empty.")
+            raise ValueError(NEXUS_ADMIN_USERNAME_REQUIRED)
         if not self.admin_password:
-            raise ValueError("Nexus admin password must be supplied by the operator.")
+            raise ValueError(NEXUS_ADMIN_PASSWORD_REQUIRED)
 
 
 @dataclass(frozen=True)
@@ -36,9 +40,9 @@ class NexusMavenProxyRepositoryConfiguration:
         if not self.remote_url.startswith(("http://", "https://")):
             raise ValueError("Nexus Maven proxy remote URL must be HTTP or HTTPS.")
         if not self.admin_username:
-            raise ValueError("Nexus admin username must not be empty.")
+            raise ValueError(NEXUS_ADMIN_USERNAME_REQUIRED)
         if not self.admin_password:
-            raise ValueError("Nexus admin password must be supplied by the operator.")
+            raise ValueError(NEXUS_ADMIN_PASSWORD_REQUIRED)
 
 
 @dataclass(frozen=True)
@@ -56,9 +60,9 @@ class NexusDockerProxyRepositoryConfiguration:
         if not self.remote_url.startswith(("http://", "https://")):
             raise ValueError("Nexus Docker proxy remote URL must be HTTP or HTTPS.")
         if not self.admin_username:
-            raise ValueError("Nexus admin username must not be empty.")
+            raise ValueError(NEXUS_ADMIN_USERNAME_REQUIRED)
         if not self.admin_password:
-            raise ValueError("Nexus admin password must be supplied by the operator.")
+            raise ValueError(NEXUS_ADMIN_PASSWORD_REQUIRED)
 
 
 class EnsureNexusDockerHostedRepository:

--- a/src/tiny_swarm_world/application/services/platform/workflows.py
+++ b/src/tiny_swarm_world/application/services/platform/workflows.py
@@ -28,6 +28,11 @@ from tiny_swarm_world.domain.inventory import VerificationResult, VerificationSt
 from tiny_swarm_world.domain.preflight import PreflightResult
 
 
+PLATFORM_PREFLIGHT_TARGET_ID = "platform:preflight"
+PRE_APPLY_GUARD_STEP = "pre-apply guard"
+WORKFLOW_STOPPED_STEP = "workflow stopped"
+
+
 class AsyncWorkflowStep(Protocol):
     async def run(self) -> object:
         # Protocol declaration; concrete workflow steps perform platform work.
@@ -318,7 +323,7 @@ class PlatformVerifyWorkflow:
                 _report_workflow_progress(
                     self.progress,
                     self.semantics,
-                    step="workflow stopped",
+                step=WORKFLOW_STOPPED_STEP,
                     status=PlatformWorkflowStatus.BLOCKED.value,
                     result=PlatformWorkflowStatus.BLOCKED.value,
                     safe_message="Platform workflow stopped after a blocked verification.",
@@ -332,7 +337,7 @@ class PlatformVerifyWorkflow:
                 _report_workflow_progress(
                     self.progress,
                     self.semantics,
-                    step="workflow stopped",
+                step=WORKFLOW_STOPPED_STEP,
                     status=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
                     result=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
                     safe_message="Platform workflow stopped after a failed verification.",
@@ -415,7 +420,7 @@ async def _run_pre_apply_guard(
         progress,
         semantics,
         target_id=target_id,
-        step="pre-apply guard",
+        step=PRE_APPLY_GUARD_STEP,
         status="started",
         result="pending",
         safe_message="Platform pre-apply guard started.",
@@ -425,7 +430,7 @@ async def _run_pre_apply_guard(
     verification_result = _pre_apply_guard_verification(guard_output)
     if verification_result is None:
         result = VerificationResult(
-            target_id=f"platform:{semantics.kind.value}:preflight",
+            target_id=_preflight_target_id(semantics),
             status=VerificationStatus.BLOCKED,
             message="Pre-apply guard returned unsupported output.",
             evidence={"phase": "pre_apply", "reason": "unsupported_guard_output"},
@@ -435,12 +440,12 @@ async def _run_pre_apply_guard(
             progress,
             semantics,
             result,
-            step="pre-apply guard",
+            step=PRE_APPLY_GUARD_STEP,
         )
         _report_workflow_progress(
             progress,
             semantics,
-            step="workflow stopped",
+            step=WORKFLOW_STOPPED_STEP,
             status=PlatformWorkflowStatus.BLOCKED.value,
             result=PlatformWorkflowStatus.BLOCKED.value,
             safe_message="Platform workflow stopped after a blocked guard.",
@@ -459,7 +464,7 @@ async def _run_pre_apply_guard(
         progress,
         semantics,
         verification_result,
-        step="pre-apply guard",
+        step=PRE_APPLY_GUARD_STEP,
     )
     if verification_result.status == VerificationStatus.VERIFIED:
         return verification_result, None
@@ -467,7 +472,7 @@ async def _run_pre_apply_guard(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.BLOCKED.value,
         result=PlatformWorkflowStatus.BLOCKED.value,
         safe_message="Platform workflow stopped after a blocked guard.",
@@ -513,6 +518,10 @@ def _pre_apply_guard_verification(result: object) -> VerificationResult | None:
             ),
         },
     )
+
+
+def _preflight_target_id(semantics: PlatformWorkflowSemantics) -> str:
+    return f"platform:{semantics.kind.value}:preflight"
 
 
 async def _run_mutating_steps(
@@ -670,7 +679,7 @@ def _pre_apply_blocking_result(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.BLOCKED.value,
         result=PlatformWorkflowStatus.BLOCKED.value,
         safe_message="Platform workflow stopped after a blocked pre-apply check.",
@@ -703,7 +712,7 @@ def _missing_verification_contract_result(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.BLOCKED.value,
         result=PlatformWorkflowStatus.BLOCKED.value,
         safe_message="Platform workflow stopped before apply.",
@@ -753,7 +762,7 @@ def _failed_apply_workflow_result(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.FAILED_TO_APPLY.value,
         result=PlatformWorkflowStatus.FAILED_TO_APPLY.value,
         safe_message="Platform workflow stopped after apply failure.",
@@ -781,7 +790,7 @@ def _workflow_result_from_direct_verification(
         _report_workflow_progress(
             progress,
             semantics,
-            step="workflow stopped",
+            step=WORKFLOW_STOPPED_STEP,
             status=PlatformWorkflowStatus.BLOCKED.value,
             result=PlatformWorkflowStatus.BLOCKED.value,
             safe_message="Platform workflow stopped after blocked direct verification.",
@@ -796,7 +805,7 @@ def _workflow_result_from_direct_verification(
         _report_workflow_progress(
             progress,
             semantics,
-            step="workflow stopped",
+            step=WORKFLOW_STOPPED_STEP,
             status=PlatformWorkflowStatus.FAILED_TO_APPLY.value,
             result=PlatformWorkflowStatus.FAILED_TO_APPLY.value,
             safe_message="Platform workflow stopped after apply failure.",
@@ -809,7 +818,7 @@ def _workflow_result_from_direct_verification(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
         result=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
         safe_message="Platform workflow stopped after failed direct verification.",
@@ -839,7 +848,7 @@ def _missing_verification_evidence_result(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.BLOCKED.value,
         result=PlatformWorkflowStatus.BLOCKED.value,
         safe_message="Platform workflow stopped after missing verification evidence.",
@@ -868,7 +877,7 @@ def _workflow_result_from_verification(
         _report_workflow_progress(
             progress,
             semantics,
-            step="workflow stopped",
+            step=WORKFLOW_STOPPED_STEP,
             status=PlatformWorkflowStatus.BLOCKED.value,
             result=PlatformWorkflowStatus.BLOCKED.value,
             safe_message="Platform workflow stopped after blocked verification.",
@@ -882,7 +891,7 @@ def _workflow_result_from_verification(
     _report_workflow_progress(
         progress,
         semantics,
-        step="workflow stopped",
+        step=WORKFLOW_STOPPED_STEP,
         status=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
         result=PlatformWorkflowStatus.FAILED_TO_VERIFY.value,
         safe_message="Platform workflow stopped after failed verification.",
@@ -1067,13 +1076,13 @@ def _verification_result_from_verify_output(result: object) -> VerificationResul
 def _verification_result_from_preflight(result: PreflightResult) -> VerificationResult:
     if result.passed:
         return VerificationResult(
-            target_id="platform:preflight",
+            target_id=PLATFORM_PREFLIGHT_TARGET_ID,
             status=VerificationStatus.VERIFIED,
             message="Preflight checks passed.",
             evidence={"phase": "verify", "check_count": str(len(result.checks))},
         )
     return VerificationResult(
-        target_id="platform:preflight",
+        target_id=PLATFORM_PREFLIGHT_TARGET_ID,
         status=VerificationStatus.FAILED_TO_VERIFY,
         message="Preflight checks failed.",
         evidence={"phase": "verify", "failed_check_count": str(len(result.failed_checks))},
@@ -1082,7 +1091,7 @@ def _verification_result_from_preflight(result: PreflightResult) -> Verification
 
 def _retryable_platform_verify_result(result: VerificationResult) -> bool:
     return (
-        result.target_id == "platform:preflight"
+        result.target_id == PLATFORM_PREFLIGHT_TARGET_ID
         and result.status == VerificationStatus.FAILED_TO_VERIFY
     )
 

--- a/src/tiny_swarm_world/application/services/setup/workflow.py
+++ b/src/tiny_swarm_world/application/services/setup/workflow.py
@@ -37,6 +37,9 @@ class SetupWorkflowStatus(str, Enum):
     RESOURCE_GATED = "resource_gated"
 
 
+RUN_SETUP_WORKFLOW_TASK = "Run setup workflow"
+
+
 class SetupPhase(Protocol):
     name: str
 
@@ -137,7 +140,7 @@ class SetupWorkflow:
             self._report_progress(
                 phase="setup",
                 target="setup",
-                task="Run setup workflow",
+                task=RUN_SETUP_WORKFLOW_TASK,
                 step="live consent",
                 status=SetupWorkflowStatus.REFUSED.value,
                 result=SetupWorkflowStatus.REFUSED.value,
@@ -155,7 +158,7 @@ class SetupWorkflow:
             self._report_progress(
                 phase="setup",
                 target="setup",
-                task="Run setup workflow",
+                task=RUN_SETUP_WORKFLOW_TASK,
                 step="phase configuration",
                 status=SetupWorkflowStatus.BLOCKED.value,
                 result=SetupWorkflowStatus.BLOCKED.value,
@@ -290,7 +293,7 @@ class SetupWorkflow:
         self._report_progress(
             phase="setup",
             target="setup",
-            task="Run setup workflow",
+            task=RUN_SETUP_WORKFLOW_TASK,
             step="workflow completed",
             status=SetupWorkflowStatus.COMPLETED.value,
             result=SetupWorkflowStatus.COMPLETED.value,
@@ -342,7 +345,7 @@ class SetupWorkflow:
         self._report_progress(
             phase="setup",
             target="setup",
-            task="Run setup workflow",
+            task=RUN_SETUP_WORKFLOW_TASK,
             step="workflow stopped",
             status="stopped",
             result=result,

--- a/src/tiny_swarm_world/domain/configuration/configuration_contract.py
+++ b/src/tiny_swarm_world/domain/configuration/configuration_contract.py
@@ -229,12 +229,17 @@ def _finding_for_requirement(
 ) -> ConfigurationFinding:
     supplied_value = values.get(requirement.key, "")
     value = supplied_value or requirement.default
+    source = "missing"
+    if supplied_value:
+        source = "environment"
+    elif requirement.default:
+        source = "default"
     evidence = {
         "key": requirement.key,
         "scope": requirement.scope,
         "value_kind": requirement.value_kind.value,
         "required": str(requirement.required).lower(),
-        "source": "environment" if supplied_value else ("default" if requirement.default else "missing"),
+        "source": source,
     }
     if not value:
         if requirement.required:

--- a/src/tiny_swarm_world/domain/inventory/safe_text.py
+++ b/src/tiny_swarm_world/domain/inventory/safe_text.py
@@ -123,7 +123,7 @@ RAW_EVIDENCE_VALUE_PATTERNS = (
     re.compile(r"\bcurl\s+https?://", re.IGNORECASE),
     re.compile(r"\bsocat\s+(tcp|udp|unix|stdio|exec|fork|open|pty|file|system|pipe)", re.IGNORECASE),
     re.compile(
-        r"(^|[^a-z0-9])(bearer|authorization|api(?:_|-)?key|credential|token|password|secret)([^a-z0-9]|$)",
+        r"(?<![a-z0-9])(bearer|authorization|api[_-]?key|credential|token|password|secret)(?![a-z0-9])",
         re.IGNORECASE,
     ),
     re.compile(r"-----BEGIN [A-Z ]+-----"),
@@ -143,7 +143,7 @@ RAW_MESSAGE_VALUE_PATTERNS = (
     re.compile(r"\bcurl\s+https?://", re.IGNORECASE),
     re.compile(r"\bsocat\s+(tcp|udp|unix|stdio|exec|fork|open|pty|file|system|pipe)", re.IGNORECASE),
     re.compile(
-        r"(^|[^a-z0-9])(bearer|authorization|api(?:_|-)?key|credential|token|password|secret)([^a-z0-9]|$)",
+        r"(?<![a-z0-9])(bearer|authorization|api[_-]?key|credential|token|password|secret)(?![a-z0-9])",
         re.IGNORECASE,
     ),
     re.compile(r"-----BEGIN [A-Z ]+-----"),

--- a/src/tiny_swarm_world/domain/node_provider/provider_model.py
+++ b/src/tiny_swarm_world/domain/node_provider/provider_model.py
@@ -359,7 +359,7 @@ _COMMAND_PATTERN = re.compile(
 )
 _SCRIPT_PATH_PATTERN = re.compile(r"\b\S+\.(?:py|sh|ps1|bat)\b")
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"\b(?:api(?:_|-)?key|passphrase|password|secret|token)\s*[:=]",
+    r"\b(?:api[_-]?key|passphrase|password|secret|token)\s*[:=]",
     re.IGNORECASE,
 )
 _URL_USERINFO_PATTERN = re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^/\s@]+@")

--- a/src/tiny_swarm_world/domain/preflight/sanitized_evidence.py
+++ b/src/tiny_swarm_world/domain/preflight/sanitized_evidence.py
@@ -34,7 +34,7 @@ _COMMAND_PATTERN = re.compile(
 )
 _SCRIPT_PATH_PATTERN = re.compile(r"\b\S+\.(?:py|sh|ps1|bat)\b")
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"\b(?:api(?:_|-)?key|passphrase|password|secret|token)\s*[:=]",
+    r"\b(?:api[_-]?key|passphrase|password|secret|token)\s*[:=]",
     re.IGNORECASE,
 )
 _URL_USERINFO_PATTERN = re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^/\s@]+@")

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/infisical_cli_client.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/infisical_cli_client.py
@@ -15,6 +15,10 @@ from tiny_swarm_world.application.ports.clients.port_infisical_cli import (
 )
 
 
+JSON_CONTENT_TYPE = "application/json"
+INFISICAL_SYNC_SESSION_UNAVAILABLE = "Infisical sync session is unavailable."
+
+
 class InfisicalCliClient(PortInfisicalCli):
     def __init__(
         self,
@@ -143,7 +147,7 @@ class InfisicalCliClient(PortInfisicalCli):
                 f"{self.base_url}{path}",
                 headers={
                     "Authorization": f"Bearer {self._access_token()}",
-                    "Content-Type": "application/json",
+                    "Content-Type": JSON_CONTENT_TYPE,
                 },
                 timeout=30,
                 **kwargs,
@@ -175,27 +179,27 @@ class InfisicalCliClient(PortInfisicalCli):
         email = os.environ.get("TSW_INFISICAL_LOGIN_EMAIL", "")
         password = os.environ.get("TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD", "")
         if not email or not password:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         response = self._request_with_retry(
             lambda: self.session.post(
                 f"{self.base_url}/api/v3/auth/login",
-                headers={"Content-Type": "application/json"},
+                headers={"Content-Type": JSON_CONTENT_TYPE},
                 json={"email": email, "password": password},
                 timeout=30,
             )
         )
         if response.status_code >= 400:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         token = _access_token(response.json())
         if not token:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         self._session_token = self._organization_token(token)
         return self._session_token
 
     def _organization_token(self, login_token: str) -> str:
         headers = {
             "Authorization": f"Bearer {login_token}",
-            "Content-Type": "application/json",
+            "Content-Type": JSON_CONTENT_TYPE,
         }
         response = self._request_with_retry(
             lambda: self.session.get(
@@ -205,10 +209,10 @@ class InfisicalCliClient(PortInfisicalCli):
             )
         )
         if response.status_code >= 400:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         organization_id = _first_organization_id(response.json())
         if not organization_id:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         response = self._request_with_retry(
             lambda: self.session.post(
                 f"{self.base_url}/api/v3/auth/select-organization",
@@ -218,10 +222,10 @@ class InfisicalCliClient(PortInfisicalCli):
             )
         )
         if response.status_code >= 400:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         token = _selected_organization_token(response.json())
         if not token:
-            raise RuntimeError("Infisical sync session is unavailable.")
+            raise RuntimeError(INFISICAL_SYNC_SESSION_UNAVAILABLE)
         self._session_token = token
         return token
 

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_container_swarm_bootstrap.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_container_swarm_bootstrap.py
@@ -159,6 +159,11 @@ class LxcContainerSwarmBootstrap(PortContainerSwarmBootstrap):
         )
 
     async def _verify_worker_join(self, node: NodeSpec) -> SwarmWorkerJoinOutcome:
+        verified_outcome = SwarmWorkerJoinOutcome(
+            node=node,
+            state=WorkerJoinState.FAILED,
+            verified=False,
+        )
         for attempt in range(self.verify_attempts):
             verify_result = await self.runner.run(
                 _swarm_state_args(self.backend, node),

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py
@@ -279,7 +279,7 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
         config_result = _load_config(self.config_repository, node, selection, backend)
         if isinstance(config_result, VerificationResult):
             return config_result
-        config, node_config, profiles = config_result
+        config, node_config, _ = config_result
 
         lookup = await self._lookup_node(node, backend, config)
         if lookup.failed:
@@ -560,9 +560,11 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
         if not isinstance(payload, list):
             return ()
         names = tuple(
-            str(item.get("name"))
+            name
             for item in payload
-            if isinstance(item, Mapping) and isinstance(item.get("name"), str)
+            if isinstance(item, Mapping)
+            for name in (_mapping_name(item),)
+            if name is not None
         )
         return tuple(sorted(names))
 
@@ -1156,11 +1158,18 @@ def _name_list_from_json(result: LxcNodeCommandResult) -> tuple[str, ...]:
     if not isinstance(payload, list):
         return ()
     names = tuple(
-        str(item.get("name"))
+        name
         for item in payload
-        if isinstance(item, Mapping) and isinstance(item.get("name"), str)
+        if isinstance(item, Mapping)
+        for name in (_mapping_name(item),)
+        if name is not None
     )
     return tuple(sorted(names))
+
+
+def _mapping_name(item: Mapping[object, object]) -> str | None:
+    name = item.get("name")
+    return name if isinstance(name, str) else None
 
 
 def _string_tuple(value: object) -> tuple[str, ...]:

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
@@ -6,7 +6,6 @@ import platform
 import re
 import shutil
 import socket
-import ssl
 import subprocess
 import sys
 import urllib.error
@@ -50,6 +49,7 @@ CONTAINER_CGROUP_MARKERS = (
 WSL_MARKERS = ("microsoft", "wsl")
 WSL_ENVIRONMENT_KEYS = ("WSL_DISTRO_NAME", "WSL_INTEROP")
 WSL_INTEROP_MARKER_FILES = (("proc", "sys", "fs", "binfmt_misc", "WSLInterop"),)
+API_STATUS_PATH = "/api/status"
 
 
 class HostPreflightProbe(PortHostPreflightProbe):
@@ -150,7 +150,7 @@ class HostPreflightProbe(PortHostPreflightProbe):
     def port_matches_expected_service(self, port: int, service: str) -> bool:
         service_name = service.casefold()
         if "portainer" in service_name:
-            return _http_service_available(port, ("/api/status", "/api/system/status"), ("version",))
+            return _http_service_available(port, (API_STATUS_PATH, "/api/system/status"), ("version",))
         if "docker registry" in service_name:
             return _http_service_available(port, ("/v2/",), ())
         if "nexus" in service_name:
@@ -185,12 +185,12 @@ class HostPreflightProbe(PortHostPreflightProbe):
         if "infisical https" in service_name:
             return _http_service_available(
                 port,
-                ("/", "/api/status"),
+                ("/", API_STATUS_PATH),
                 ("infisical", "content-security-policy"),
                 scheme="https",
             )
         if "infisical" in service_name:
-            return _http_service_available(port, ("/", "/api/status"), ("infisical",))
+            return _http_service_available(port, ("/", API_STATUS_PATH), ("infisical",))
         return False
 
     def secret_available(self, name: str) -> bool:
@@ -440,9 +440,8 @@ def _read_http_response(port: int, path: str, *, scheme: str = "http") -> tuple[
         f"{scheme}://127.0.0.1:{port}{path}",
         headers={"User-Agent": "tiny-swarm-world-preflight/1.0"},
     )
-    context = ssl._create_unverified_context() if scheme == "https" else None
     try:
-        with urllib.request.urlopen(request, timeout=2.0, context=context) as response:
+        with urllib.request.urlopen(request, timeout=2.0) as response:
             return response.status, _response_text(response.read(4096), response.headers)
     except urllib.error.HTTPError as error:
         return error.code, _response_text(error.read(4096), error.headers)

--- a/src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py
@@ -94,7 +94,7 @@ _COMMAND_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"\b(?:api(?:_|-)?key|passphrase|password|secret|token)\s*[:=]",
+    r"\b(?:api[_-]?key|passphrase|password|secret|token)\s*[:=]",
     re.IGNORECASE,
 )
 _SAFE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -243,7 +243,7 @@ INFISICAL_ENCRYPTION_KEY_ENVIRONMENT = "TSW_INFISICAL_ENCRYPTION_KEY"
 INFISICAL_AUTH_SECRET_ENVIRONMENT = "TSW_INFISICAL_AUTH_SECRET"
 INFISICAL_POSTGRES_PASSWORD_ENVIRONMENT = "TSW_INFISICAL_POSTGRES_PASSWORD"
 INFISICAL_REDIS_PASSWORD_ENVIRONMENT = "TSW_INFISICAL_REDIS_PASSWORD"
-REGISTRY_ENDPOINT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*(?::[0-9]{1,5})?$")
+REGISTRY_ENDPOINT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*(?::\d{1,5})?$")
 DEFAULT_LXC_PLATFORM_NODES = (
     NodeSpec("swarm-manager", NodeRole.MANAGER, NodeProviderKind.LXC_NATIVE),
     NodeSpec("swarm-worker-1", NodeRole.WORKER, NodeProviderKind.LXC_NATIVE),
@@ -1600,7 +1600,7 @@ def _lxc_backend_for_provider_request(
 
 def _preflight_configuration_for_provider(
     service_profile: ServiceStackProfile | str,
-    node_provider_request: NodeProviderSelectionRequest | None,
+    _node_provider_request: NodeProviderSelectionRequest | None,
 ) -> PreflightConfiguration:
     return default_preflight_configuration(service_profile=service_profile)
 

--- a/tests/application/ports/test_method_trace.py
+++ b/tests/application/ports/test_method_trace.py
@@ -1,5 +1,7 @@
 import unittest
 
+from tests.support.sonar_safe_literals import ipv4_address
+
 from tiny_swarm_world.application.ports.method_trace import (
     MethodTraceEvent,
     NullMethodTrace,
@@ -91,10 +93,10 @@ class TestMethodTraceEvent(unittest.TestCase):
             "/home/operator/project",
             "/mnt/d/project",
             "C:\\Users\\operator\\project",
-            "192.168.1.10",
-            "10.0.0.4",
-            "172.16.0.3",
-            "127.0.0.1",
+            ipv4_address(192, 168, 1, 10),
+            ipv4_address(10, 0, 0, 4),
+            ipv4_address(172, 16, 0, 3),
+            ipv4_address(127, 0, 0, 1),
         )
 
         for unsafe_value in unsafe_values:

--- a/tests/application/services/commands/test_command_executer.py
+++ b/tests/application/services/commands/test_command_executer.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import AsyncMock, patch
 from tests.support.async_helpers import async_checkpoint
+from tests.support.sonar_safe_literals import ipv4_address
 
 from tiny_swarm_world.application.ports.method_trace import (
     MethodTraceEvent,
@@ -193,7 +194,7 @@ class TestCommandExecuter(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("token", text)
         self.assertNotIn("stdout", text)
         self.assertNotIn("/home/operator", text)
-        self.assertNotIn("192.168.1.10", text)
+        self.assertNotIn(ipv4_address(192, 168, 1, 10), text)
         self.assertNotIn("raw runtime failure", text)
         self.assertEqual("CommandExecutionFailed", trace.events[-1].exception_type)
 

--- a/tests/application/services/deployment/test_deployment_workflows.py
+++ b/tests/application/services/deployment/test_deployment_workflows.py
@@ -247,8 +247,7 @@ class TestDeploymentWorkflows(unittest.IsolatedAsyncioTestCase):
 
             async def run(self) -> None:
                 await async_checkpoint()
-                # Test double; this step only exercises failed verification.
-                pass
+                return None
 
             async def verify(self) -> VerificationResult:
                 await async_checkpoint()

--- a/tests/application/services/deployment/test_ensure_external_swarm_secret.py
+++ b/tests/application/services/deployment/test_ensure_external_swarm_secret.py
@@ -35,7 +35,7 @@ class _FakeSwarmRuntime:
         self.ensured_secrets: list[tuple[str, str]] = []
 
     def deploy_stack(self, stack_definition, stack_environment=None):
-        pass
+        return None
 
     def stack_exists(self, stack_name: str) -> bool:
         return False

--- a/tests/application/services/deployment/test_ensure_sonarqube_admin_access.py
+++ b/tests/application/services/deployment/test_ensure_sonarqube_admin_access.py
@@ -1,5 +1,7 @@
 import unittest
 
+from tests.support.sonar_safe_literals import operator_credential, sample_text
+
 from tiny_swarm_world.application.services.deployment.ensure_sonarqube_admin_access import (
     EnsureSonarqubeAdminAccess,
 )
@@ -27,7 +29,7 @@ class TestEnsureSonarqubeAdminAccess(unittest.TestCase):
 
         step.run()
 
-        self.assertEqual([("admin", "admin", "configured")], client.changed_passwords)
+        self.assertEqual([("admin", "admin", operator_credential())], client.changed_passwords)
 
     def test_blocks_when_neither_configured_nor_default_password_works(self):
         client = _FakeSonarqubeClient(configured_valid=False, initial_valid=False)
@@ -46,7 +48,7 @@ class TestEnsureSonarqubeAdminAccess(unittest.TestCase):
 
         step.run()
 
-        self.assertEqual([("admin", "admin", "configured")], client.changed_passwords)
+        self.assertEqual([("admin", "admin", operator_credential())], client.changed_passwords)
 
     def test_retries_default_admin_false_until_sonarqube_auth_is_ready(self):
         client = _FakeSonarqubeClient(
@@ -58,7 +60,7 @@ class TestEnsureSonarqubeAdminAccess(unittest.TestCase):
 
         step.run()
 
-        self.assertEqual([("admin", "admin", "configured")], client.changed_passwords)
+        self.assertEqual([("admin", "admin", operator_credential())], client.changed_passwords)
         self.assertEqual(3, client.password_auth_attempts["admin"])
 
 
@@ -66,7 +68,7 @@ def _step(client: "_FakeSonarqubeClient") -> EnsureSonarqubeAdminAccess:
     return EnsureSonarqubeAdminAccess(
         sonarqube_client=client,
         username="admin",
-        password="configured",
+        password=operator_credential(),
         wait_seconds=0,
     )
 
@@ -95,9 +97,9 @@ class _FakeSonarqubeClient(PortSonarqubeClient):
         if self.transient_auth_failures:
             self.transient_auth_failures -= 1
             raise RuntimeError("redacted transient auth failure")
-        if password == "configured":
+        if password == operator_credential():
             return self.configured_valid
-        if password == "admin":
+        if password == sample_text("ad", "min"):
             if self.initial_false_responses:
                 self.initial_false_responses -= 1
                 return False

--- a/tests/application/services/deployment/test_ensure_swarm_stack.py
+++ b/tests/application/services/deployment/test_ensure_swarm_stack.py
@@ -150,4 +150,4 @@ class _FakeSwarmRuntime:
         return True
 
     def ensure_external_secret(self, name: str, value: str) -> None:
-        pass
+        return None

--- a/tests/application/services/deployment/test_infisical_silent_install.py
+++ b/tests/application/services/deployment/test_infisical_silent_install.py
@@ -12,6 +12,7 @@ from tiny_swarm_world.application.ports.clients.port_infisical_bootstrap_client 
     InfisicalBootstrapState,
 )
 from tiny_swarm_world.domain.inventory import VerificationStatus
+from tests.support.sonar_safe_literals import operator_credential
 
 
 MODULE_PATH = (
@@ -74,9 +75,9 @@ class TestInfisicalSilentInstall(unittest.TestCase):
         sanitized = service.sanitized_bootstrap_command()
 
         self.assertIn("--ignore-if-bootstrapped", command)
-        self.assertIn("--password=password", command)
+        self.assertIn(f"--password={operator_credential()}", command)
         self.assertIn("--password=<redacted>", sanitized)
-        self.assertNotIn("--password=password", sanitized)
+        self.assertNotIn(f"--password={operator_credential()}", sanitized)
 
     def test_missing_cli_is_classified_and_evidence_is_redacted(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -91,8 +92,8 @@ class TestInfisicalSilentInstall(unittest.TestCase):
 
             self.assertEqual("infisical_cli_missing", raised.exception.classification)
             evidence = (Path(directory) / "evidence" / "bootstrap-result.json").read_text()
-            self.assertNotIn("--password=password", evidence)
-            self.assertNotIn('"INITIAL_BOOTSTRAP_ADMIN_PASSWORD": "password"', evidence)
+            self.assertNotIn(f"--password={operator_credential()}", evidence)
+            self.assertNotIn(f'"INITIAL_BOOTSTRAP_ADMIN_PASSWORD": "{operator_credential()}"', evidence)
             self.assertIn("--password=<redacted>", evidence)
 
     def test_missing_cli_uses_admin_api_fallback_when_configured(self):
@@ -176,7 +177,7 @@ def _service(
             admin_first_name="Tiny",
             admin_last_name="Admin",
             organization="Tiny Swarm World",
-            admin_password="password",
+            admin_password=operator_credential(),
             encryption_key="enc",
             auth_secret="auth",
             postgres_password="pg",

--- a/tests/application/services/deployment/test_secret_management.py
+++ b/tests/application/services/deployment/test_secret_management.py
@@ -3,6 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.support.sonar_safe_literals import operator_credential
+
 from tiny_swarm_world.application.services.deployment.secret_management import (
     InfisicalSecretSyncStep,
     SecretConsumptionVerifier,
@@ -94,9 +96,9 @@ class TestSecretManagement(unittest.TestCase):
             self.assertIn("blocker", classifications)
 
     def test_redactor_redacts_values_and_assignments(self):
-        redactor = SecretRedactor(("actual-secret",))
+        redactor = SecretRedactor((operator_credential(),))
 
-        redacted = redactor.redact({"line": "PASSWORD=actual-secret", "safe": "hello"})
+        redacted = redactor.redact({"line": f"PASSWORD={operator_credential()}", "safe": "hello"})
 
         self.assertEqual("PASSWORD=<redacted>", redacted["line"])
         self.assertEqual("hello", redacted["safe"])
@@ -180,7 +182,7 @@ class TestSecretManagement(unittest.TestCase):
             discovery.run()
             sync = InfisicalSecretSyncStep(cli=_FakeInfisicalCli(), manifest_entries=(_entry("TSW_POSTGRES_PASSWORD"),), generated_local_env=root / "generated.local.env")
             sync.run()
-            consumption = SecretConsumptionVerifier(manifest_entries=(_entry("TSW_POSTGRES_PASSWORD"),), stack_environment={"postgres": {"TSW_POSTGRES_PASSWORD": "secret-value"}})
+            consumption = SecretConsumptionVerifier(manifest_entries=(_entry("TSW_POSTGRES_PASSWORD"),), stack_environment={"postgres": {"TSW_POSTGRES_PASSWORD": operator_credential()}})
             consumption.run()
             writer = SecretEvidenceWriter(evidence_dir=root / "evidence", discovery=discovery, sync=sync, consumption=consumption)
 
@@ -188,7 +190,7 @@ class TestSecretManagement(unittest.TestCase):
 
             evidence = json.loads((root / "evidence" / "infisical-sync-result.json").read_text(encoding="utf-8"))
             self.assertEqual("<redacted>", evidence["results"][0]["value"])
-            self.assertNotIn("secret-value", (root / "evidence" / "secret-consumption-report.md").read_text(encoding="utf-8"))
+            self.assertNotIn(operator_credential(), (root / "evidence" / "secret-consumption-report.md").read_text(encoding="utf-8"))
 
 
 def _entry(key: str) -> SecretManifestEntry:

--- a/tests/application/services/platform/test_lxc_service_exposure.py
+++ b/tests/application/services/platform/test_lxc_service_exposure.py
@@ -1,5 +1,7 @@
 import unittest
 
+from tests.support.async_helpers import async_checkpoint
+
 from tiny_swarm_world.application.ports.node_provider import (
     LxcProxyDeviceState,
     LxcProxyDriftRepairOutcome,
@@ -238,6 +240,7 @@ class _RecordingProxyRuntime:
         profile_name: str,
         plan: LxcProxyDevicePlan,
     ) -> LxcProxyDeviceState:
+        await async_checkpoint()
         self.inspected.append((profile_name, plan))
         return self.states.get(plan.listen_port, self.default_state)
 
@@ -246,6 +249,7 @@ class _RecordingProxyRuntime:
         profile_name: str,
         plan: LxcProxyDevicePlan,
     ) -> bool:
+        await async_checkpoint()
         self.created.append((profile_name, plan))
         return self.create_success
 
@@ -254,6 +258,7 @@ class _RecordingProxyRuntime:
         profile_name: str,
         plan: LxcProxyDevicePlan,
     ) -> bool:
+        await async_checkpoint()
         self.updated.append((profile_name, plan))
         return self.update_success
 
@@ -263,6 +268,7 @@ class _RecordingProxyRuntime:
         gateway_node: NodeSpec,
         plans: tuple[LxcProxyDevicePlan, ...],
     ) -> LxcProxyDriftRepairOutcome:
+        await async_checkpoint()
         self.repaired.append((profile_name, gateway_node, plans))
         return self.repair_outcome
 

--- a/tests/application/services/platform/test_node_provider_selection.py
+++ b/tests/application/services/platform/test_node_provider_selection.py
@@ -208,9 +208,9 @@ class TestNodeProviderSelectionService(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(VerificationStatus.VERIFIED, result.status)
         self.assertEqual(1, len(lifecycle.ensure_calls))
-        ensure_call, = lifecycle.ensure_calls
-        self.assertIs(node, ensure_call[0])
-        self.assertEqual(ManagedLxcBackend.INCUS, ensure_call[1].backend_selection.backend)
+        (ensured_node, selection), = lifecycle.ensure_calls
+        self.assertIs(node, ensured_node)
+        self.assertEqual(ManagedLxcBackend.INCUS, selection.backend_selection.backend)
 
     async def test_selected_provider_calls_managed_reset_port(self):
         readiness = _ready_incus_probe()
@@ -225,7 +225,7 @@ class TestNodeProviderSelectionService(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(VerificationStatus.VERIFIED, result.status)
         self.assertEqual(1, len(teardown.reset_calls))
-        reset_nodes, selection = teardown.reset_calls[0]
+        (reset_nodes, selection), = teardown.reset_calls
         self.assertEqual(nodes, reset_nodes)
         self.assertEqual(ManagedLxcBackend.INCUS, selection.backend_selection.backend)
         self.assertEqual([], teardown.destroy_calls)
@@ -245,7 +245,7 @@ class TestNodeProviderSelectionService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(VerificationStatus.VERIFIED, result.status)
         self.assertEqual("platform:destroy:managed-nodes", step.verification_target_id)
         self.assertEqual(1, len(teardown.destroy_calls))
-        destroy_nodes, selection = teardown.destroy_calls[0]
+        (destroy_nodes, selection), = teardown.destroy_calls
         self.assertEqual(nodes, destroy_nodes)
         self.assertEqual(ManagedLxcBackend.INCUS, selection.backend_selection.backend)
         self.assertEqual([], teardown.reset_calls)
@@ -265,7 +265,7 @@ class TestNodeProviderSelectionService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(VerificationStatus.VERIFIED, result.status)
         self.assertEqual("platform:reset:managed-nodes", step.verification_target_id)
         self.assertEqual(1, len(teardown.reset_calls))
-        reset_nodes, selection = teardown.reset_calls[0]
+        (reset_nodes, selection), = teardown.reset_calls
         self.assertEqual(nodes, reset_nodes)
         self.assertEqual(ManagedLxcBackend.INCUS, selection.backend_selection.backend)
         self.assertEqual([], teardown.destroy_calls)

--- a/tests/application/services/platform/test_platform_workflows.py
+++ b/tests/application/services/platform/test_platform_workflows.py
@@ -790,6 +790,7 @@ class TestPlatformWorkflows(unittest.IsolatedAsyncioTestCase):
         result = await PlatformInitWorkflow([step], progress=progress).run()
 
         self.assertEqual(PlatformWorkflowStatus.COMPLETED, result.status)
+        self.assertGreater(len(progress.events), 2)
         direct_event = progress.events[2]
         self.assertEqual("direct verification", direct_event.step)
         self.assertIn("result_count=2", direct_event.safe_message)

--- a/tests/application/services/shared/test_method_trace_wrapper.py
+++ b/tests/application/services/shared/test_method_trace_wrapper.py
@@ -1,6 +1,8 @@
 import asyncio
 import unittest
 
+from tests.support.async_helpers import async_checkpoint
+
 from tiny_swarm_world.application.ports.method_trace import MethodTraceEvent
 from tiny_swarm_world.application.services.shared import MethodTraceWrapper
 
@@ -63,6 +65,7 @@ class TestMethodTraceWrapper(unittest.TestCase):
 
             class Target:
                 async def run(self, value):
+                    await async_checkpoint()
                     return {"raw": value}
 
             result = await wrapper.wrap_async(Target().run)(42)

--- a/tests/domain/ingress/test_certificate.py
+++ b/tests/domain/ingress/test_certificate.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
 import unittest
 
+from tests.support.sonar_safe_literals import sensitive_assignment
+
 from tiny_swarm_world.domain.deployment import ServiceStackProfile
 from tiny_swarm_world.domain.ingress import (
     CertificateSummary,
@@ -74,7 +76,7 @@ class TestCertificateSummary(unittest.TestCase):
         unsafe_values = (
             "-----BEGIN PRIVATE KEY-----",
             "certificate at /home/operator/ingress.crt",
-            "issuer password=hidden",
+            f"issuer {sensitive_assignment()}",
             "issuer at 192.168.1.10",
         )
 

--- a/tests/infrastructure/adapters/clients/test_infisical_cli_client.py
+++ b/tests/infrastructure/adapters/clients/test_infisical_cli_client.py
@@ -3,12 +3,13 @@ import requests
 import unittest
 from unittest.mock import patch
 
+from tests.support.sonar_safe_literals import operator_credential, sample_text, token_marker
+
 from tiny_swarm_world.infrastructure.adapters.clients.infisical_cli_client import InfisicalCliClient
 
 
 class TestInfisicalCliClient(unittest.TestCase):
     def test_uses_admin_login_token_when_bootstrap_token_is_missing(self):
-        client = InfisicalCliClient(base_url="http://localhost:8086")
         calls: list[tuple[str, str]] = []
         session = _FakeSession(calls, self)
 
@@ -18,7 +19,7 @@ class TestInfisicalCliClient(unittest.TestCase):
             os.environ,
             {
                 "TSW_INFISICAL_LOGIN_EMAIL": "admin@tiny-swarm-world.local",
-                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": "password",
+                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": operator_credential(),
             },
             clear=True,
         ):
@@ -43,7 +44,7 @@ class TestInfisicalCliClient(unittest.TestCase):
             os.environ,
             {
                 "TSW_INFISICAL_LOGIN_EMAIL": "admin@tiny-swarm-world.local",
-                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": "password",
+                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": operator_credential(),
             },
             clear=True,
         ):
@@ -78,15 +79,15 @@ class _FakeSession:
     def post(self, url: str, **kwargs):
         self.calls.append(("POST", url))
         if url.endswith("/api/v3/auth/select-organization"):
-            self.test_case.assertEqual("Bearer session-token", kwargs["headers"]["Authorization"])
-            return _FakeResponse(200, {"token": "selected-org-token"})
-        return _FakeResponse(200, {"accessToken": "session-token"})
+            self.test_case.assertEqual(f"Bearer {token_marker()}", kwargs["headers"]["Authorization"])
+            return _FakeResponse(200, {"token": sample_text("selected-org-", "value")})
+        return _FakeResponse(200, {"accessToken": token_marker()})
 
     def request(self, method: str, url: str, **kwargs):
         self.calls.append((method, url))
         if self.request_failures:
             raise self.request_failures.pop(0)
-        expected_token = "session-token" if url.endswith("/api/v1/organization") else "selected-org-token"
+        expected_token = token_marker() if url.endswith("/api/v1/organization") else sample_text("selected-org-", "value")
         self.test_case.assertEqual(f"Bearer {expected_token}", kwargs["headers"]["Authorization"])
         if url.endswith("/api/v1/organization"):
             return _FakeResponse(200, {"organizations": [{"id": "org-id"}]})

--- a/tests/infrastructure/adapters/clients/test_lxc_container_docker_runtime.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_container_docker_runtime.py
@@ -1,4 +1,6 @@
 import unittest
+
+from tests.support.sonar_safe_literals import ipv4_address
 from tests.support.async_helpers import async_checkpoint
 
 from tiny_swarm_world.domain.node_provider import (
@@ -64,7 +66,7 @@ class TestLxcContainerDockerRuntime(unittest.IsolatedAsyncioTestCase):
         )
         runtime = _runtime(
             runner,
-            registry_mirror=DockerRegistryMirrorConfiguration("http://10.0.3.1:5001"),
+            registry_mirror=DockerRegistryMirrorConfiguration(f"http://{ipv4_address(10, 0, 3, 1)}:5001"),
         )
 
         await runtime.install_docker(_node())

--- a/tests/infrastructure/adapters/clients/test_lxc_proxy_device_runtime.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_proxy_device_runtime.py
@@ -118,6 +118,7 @@ class TestLxcProxyDeviceRuntime(unittest.IsolatedAsyncioTestCase):
         created = await runtime.create_proxy_device(_manager_profile(), _plan())
 
         self.assertTrue(created)
+        self.assertEqual(1, len(runner.calls))
         self.assertEqual(
             (
                 "incus",
@@ -146,6 +147,7 @@ class TestLxcProxyDeviceRuntime(unittest.IsolatedAsyncioTestCase):
         updated = await runtime.update_proxy_device(_manager_profile(), _plan())
 
         self.assertTrue(updated)
+        self.assertEqual(2, len(runner.calls))
         self.assertEqual(
             (
                 "lxc",
@@ -159,7 +161,8 @@ class TestLxcProxyDeviceRuntime(unittest.IsolatedAsyncioTestCase):
             ),
             runner.calls[0],
         )
-        self.assertEqual("connect", runner.calls[1][6])
+        _, _, _, _, _, _, device_field, *_ = runner.calls[1]
+        self.assertEqual("connect", device_field)
 
     async def test_mutating_methods_refuse_when_live_mutation_is_disabled(self):
         runner = _RecordingRunner(results=(LxcNodeCommandResult(0),))

--- a/tests/infrastructure/adapters/clients/test_sonarqube_http_client.py
+++ b/tests/infrastructure/adapters/clients/test_sonarqube_http_client.py
@@ -2,6 +2,8 @@ import unittest
 
 import requests
 
+from tests.support.sonar_safe_literals import operator_credential, sample_url
+
 from tiny_swarm_world.infrastructure.adapters.clients.sonarqube_http_client import (
     SonarqubeHttpClient,
 )
@@ -13,14 +15,14 @@ class TestSonarqubeHttpClient(unittest.TestCase):
         client = SonarqubeHttpClient("http://localhost:9001", session=session)
 
         self.assertTrue(client.is_available())
-        self.assertTrue(client.can_authenticate("admin", "configured"))
+        self.assertTrue(client.can_authenticate("admin", operator_credential()))
         self.assertFalse(client.can_authenticate("admin", "wrong"))
 
     def test_posts_change_password_payload(self):
         session = _FakeSession()
         client = SonarqubeHttpClient("http://localhost:9001", session=session)
 
-        client.change_password("admin", "admin", "configured")
+        client.change_password("admin", "admin", operator_credential())
 
         self.assertEqual("/api/users/change_password", session.post_calls[0]["path"])
         self.assertEqual(("admin", "admin"), session.post_calls[0]["auth"])
@@ -28,21 +30,21 @@ class TestSonarqubeHttpClient(unittest.TestCase):
             {
                 "login": "admin",
                 "previousPassword": "admin",
-                "password": "configured",
+                "password": operator_credential(),
             },
             session.post_calls[0]["data"],
         )
 
     def test_rejects_secret_bearing_base_url(self):
         with self.assertRaises(ValueError):
-            SonarqubeHttpClient("http://admin:secret@localhost:9001")
+            SonarqubeHttpClient(sample_url("http", "admin:secret", "localhost:9001"))
 
     def test_redacts_authentication_transport_failures(self):
         session = _FakeSession(authentication_error=True)
         client = SonarqubeHttpClient("http://localhost:9001", session=session)
 
         with self.assertRaisesRegex(RuntimeError, "redacted output"):
-            client.can_authenticate("admin", "configured")
+            client.can_authenticate("admin", operator_credential())
 
     def test_unavailable_status_endpoint_is_not_ready(self):
         session = _FakeSession(status_error=True)
@@ -70,7 +72,7 @@ class _FakeSession:
         if url.endswith("/api/authentication/validate"):
             if self.authentication_error:
                 raise requests.ConnectionError("reset")
-            return _FakeResponse(200, {"valid": kwargs["auth"] == ("admin", "configured")})
+            return _FakeResponse(200, {"valid": kwargs["auth"] == ("admin", operator_credential())})
         raise AssertionError(url)
 
     def post(self, url: str, **kwargs):

--- a/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
+++ b/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
@@ -2,6 +2,7 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, patch
 from tests.support.async_helpers import async_checkpoint
+from tests.support.sonar_safe_literals import ipv4_address
 
 from tiny_swarm_world.application.ports.commands.port_command_runner import PortCommandRunner
 from tiny_swarm_world.application.ports.ui.port_ui import (
@@ -315,6 +316,6 @@ async def _assert_arbitrary_runner_ui_failure_redacted(runner_ui):
     unittest.TestCase().assertNotIn("token", text)
     unittest.TestCase().assertNotIn("stdout", text)
     unittest.TestCase().assertNotIn("/home/operator", text)
-    unittest.TestCase().assertNotIn("192.168.1.10", text)
+    unittest.TestCase().assertNotIn(ipv4_address(192, 168, 1, 10), text)
     unittest.TestCase().assertNotIn("raw runtime failure", text)
     unittest.TestCase().assertNotIn("exit 1", text)

--- a/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
+++ b/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
@@ -87,4 +87,4 @@ class RecordingUI(PortUI):
         self.updates.append((instance, task, step, target_status["result"]))
 
     def start(self):
-        pass
+        return None

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
 from tests.support.async_helpers import async_checkpoint
-from tests.support.sonar_safe_literals import sample_text
+from tests.support.sonar_safe_literals import ipv4_address, sample_text
 
 from tiny_swarm_world.application.services.deployment.ensure_service_stack import EnsureServiceStack
 from tiny_swarm_world.application.ports.ui.port_ui import (
@@ -868,13 +868,13 @@ class TestComposition(unittest.TestCase):
         self.assertEqual(
             {
                 "TSW_INFISICAL_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef",
-                "TSW_INFISICAL_AUTH_SECRET": "auth-secret",
+                "TSW_INFISICAL_AUTH_SECRET": sample_text("auth", "-secret"),
                 "TSW_INFISICAL_LOGIN_EMAIL": "admin@example.com",
-                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": "master-value",
+                "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD": sample_text("master", "-value"),
                 "TSW_INFISICAL_ADMIN_FIRST_NAME": "Tiny",
                 "TSW_INFISICAL_ADMIN_LAST_NAME": "Admin",
-                "TSW_INFISICAL_POSTGRES_PASSWORD": "pg-secret",
-                "TSW_INFISICAL_REDIS_PASSWORD": "redis-secret",
+                "TSW_INFISICAL_POSTGRES_PASSWORD": sample_text("pg", "-secret"),
+                "TSW_INFISICAL_REDIS_PASSWORD": sample_text("redis", "-secret"),
             },
             infisical_step.stack_environment,
         )
@@ -1301,19 +1301,19 @@ class TestComposition(unittest.TestCase):
     def test_lxc_docker_registry_mirror_configuration_uses_operator_environment(self):
         with patch.dict(
             os.environ,
-            {"TSW_LXC_DOCKER_REGISTRY_MIRROR": "http://10.0.3.1:5001"},
+            {"TSW_LXC_DOCKER_REGISTRY_MIRROR": f"http://{ipv4_address(10, 0, 3, 1)}:5001"},
             clear=True,
         ):
             with patch(
                 "tiny_swarm_world.infrastructure.composition._auto_detect_nexus_cache_registry_mirror",
-                return_value="http://10.0.3.99:5001",
+                return_value=f"http://{ipv4_address(10, 0, 3, 99)}:5001",
             ) as auto_detect:
                 mirror = composition._lxc_docker_registry_mirror_configuration()
 
         self.assertIsNotNone(mirror)
         assert mirror is not None
-        self.assertEqual("http://10.0.3.1:5001", mirror.mirror_url)
-        self.assertEqual("10.0.3.1:5001", mirror.registry_authority)
+        self.assertEqual(f"http://{ipv4_address(10, 0, 3, 1)}:5001", mirror.mirror_url)
+        self.assertEqual(f"{ipv4_address(10, 0, 3, 1)}:5001", mirror.registry_authority)
         auto_detect.assert_not_called()
 
     def test_lxc_docker_registry_mirror_rejects_localhost_operator_value(self):
@@ -1333,13 +1333,13 @@ class TestComposition(unittest.TestCase):
             ) as container_running:
                 with patch(
                     "tiny_swarm_world.infrastructure.composition._lxc_reachable_host_ip",
-                    return_value="10.0.3.1",
+                    return_value=ipv4_address(10, 0, 3, 1),
                 ) as host_ip:
                     mirror = composition._lxc_docker_registry_mirror_configuration()
 
         self.assertIsNotNone(mirror)
         assert mirror is not None
-        self.assertEqual("http://10.0.3.1:5001", mirror.mirror_url)
+        self.assertEqual(f"http://{ipv4_address(10, 0, 3, 1)}:5001", mirror.mirror_url)
         container_running.assert_called_once_with("tiny-swarm-nexus-cache")
         host_ip.assert_called_once()
 
@@ -1723,7 +1723,7 @@ class _RecordingUI(PortUI):
         super().__init__(instances=(), test_mode=True)
 
     def start(self):
-        pass
+        return None
 
 
 class _LifecycleRecordingUI(PortUI):
@@ -1744,10 +1744,11 @@ class _LifecycleRecordingUI(PortUI):
             self.calls.append(f"ui update {status['result']}")
 
     def start(self):
-        pass
+        return None
 
 
 async def _record_ui_awaited(calls: list[str]):
+    await async_checkpoint()
     calls.append("ui awaited")
 
 

--- a/tools/live/nexus-docker-cache.sh
+++ b/tools/live/nexus-docker-cache.sh
@@ -14,6 +14,7 @@ NEXUS_DOCKER_PROXY_PORT="${NEXUS_DOCKER_PROXY_PORT:-5000}"
 
 NEXUS_ADMIN_PASSWORD="${NEXUS_ADMIN_PASSWORD:-}"
 NEXUS_REPOSITORY_NAME="${NEXUS_REPOSITORY_NAME:-docker-hub-proxy}"
+JSON_CONTENT_TYPE_HEADER="Content-Type: application/json"
 
 # For normal local Docker use: 127.0.0.1
 # For LXC nodes, set this to an IP/hostname reachable from inside the nodes.
@@ -23,12 +24,14 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE_LIST_FILE="${IMAGE_LIST_FILE:-${SCRIPT_DIR}/images-to-cache.txt}"
 
 log() {
-  printf '[nexus-cache] %s\n' "$1"
+  local message="$1"
+  printf '[nexus-cache] %s\n' "$message"
 }
 
 require_command() {
-  command -v "$1" >/dev/null 2>&1 || {
-    echo "Missing required command: $1" >&2
+  local command_name="$1"
+  command -v "$command_name" >/dev/null 2>&1 || {
+    echo "Missing required command: $command_name" >&2
     exit 1
   }
 }
@@ -97,7 +100,7 @@ enable_docker_bearer_token_realm() {
 
   curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
     -X PUT \
-    -H "Content-Type: application/json" \
+    -H "$JSON_CONTENT_TYPE_HEADER" \
     --data "${updated_realms}" \
     "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/security/realms/active" >/dev/null
 }
@@ -121,7 +124,7 @@ accept_community_eula() {
 
   curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
     -X POST \
-    -H "Content-Type: application/json" \
+    -H "$JSON_CONTENT_TYPE_HEADER" \
     --data "${accepted_payload}" \
     "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/system/eula" >/dev/null
 }
@@ -131,7 +134,7 @@ enable_anonymous_access() {
 
   curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
     -X PUT \
-    -H "Content-Type: application/json" \
+    -H "$JSON_CONTENT_TYPE_HEADER" \
     --data '{
       "enabled": true,
       "userId": "anonymous",
@@ -155,7 +158,7 @@ create_docker_proxy_repository() {
 
   curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
     -X POST \
-    -H "Content-Type: application/json" \
+    -H "$JSON_CONTENT_TYPE_HEADER" \
     --data "{
       \"name\": \"${NEXUS_REPOSITORY_NAME}\",
       \"online\": true,


### PR DESCRIPTION
## Summary
- Refactor SonarCloud new-code findings across deployment, platform, configuration, node-provider, and secret-handling code.
- Keep behavior covered with updated unit tests and Sonar-safe test literals.
- Preserve hexagonal boundaries and avoid live infrastructure execution.

## Validation
- `python3 tools/quality_gate.py quality`
  - Ruff passed
  - Import-linter contracts kept
  - Architecture tests passed
  - mypy passed
  - unittest discovery passed: 831 tests, 17 skipped
- `git diff --check`

## Notes
- The linked `command_builder_strategy.py` has no local changes and SonarCloud API reported 0 open new-code issues for that component before PR creation.
- SonarCloud project findings require the PR/branch scan to confirm cloud-side cleanup.