### PR TITLE
ci(sonar): run SonarCloud workflow on Python 3.13

### DIFF
--- a/.github/workflows/sonar_check.yml
+++ b/.github/workflows/sonar_check.yml
@@ -10,10 +10,14 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     name: Python Quality And SonarCloud
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN || secrets.SONAR_CLOUD_TOKEN }}
     steps:
@@ -25,7 +29,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
           cache-dependency-path: requirements.txt
 
@@ -38,16 +42,16 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-          python -m pip install coverage import-linter mypy pytest ruff types-PyYAML types-requests
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install coverage import-linter mypy pytest ruff types-PyYAML types-requests
 
       - name: Quality Gate
-        run: python tools/quality_gate.py quality
+        run: python3 tools/quality_gate.py quality
 
       - name: Generate Coverage Report
         run: |
-          PYTHONPATH=src coverage run --branch -m unittest discover -s tests -t .
+          PYTHONPATH=src python3 -m coverage run --branch -m unittest discover -s tests -t .
           coverage xml -o coverage.xml
 
       - name: SonarCloud Scan

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,6 @@ sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src
 sonar.tests=tests
-sonar.python.version=3.12
+sonar.python.version=3.12, 3.13
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- Run the SonarCloud workflow on Python 3.13.
- Keep CI commands aligned with `QUALITY.md` by using `python3` explicitly.
- Add read-only workflow permissions and a bounded SonarCloud job timeout.
- Update Sonar Python analysis metadata to `3.12, 3.13`.

## Changed Files
- `.github/workflows/sonar_check.yml`
- `sonar-project.properties`

## Verification
- `wsl python3 -c YAML parse for .github/workflows/sonar_check.yml` passed.
- `wsl git diff --check -- .github/workflows/sonar_check.yml sonar-project.properties` passed.
- `wsl env PATH=/tmp/tsw-quality-venv/bin:... /tmp/tsw-quality-venv/bin/python tools/quality_gate.py quality` passed.

## Impact
- CI/SonarCloud workflow now uses Python 3.13.
- Sonar analysis is configured for both Python 3.12 and 3.13.
- No product runtime, architecture, API, or live infrastructure behavior changes.

## Risks And Limitations
- SonarCloud upload and required checks must be verified in GitHub Actions because they depend on GitHub runtime and repository secrets.

## Push Auto
This `push auto` workflow will wait or retry until required checks are green including SonarCloud when configured, merge the pull request, delete the merged remote head branch, and run local cleanup after merge verification.