### PR TITLE
[codex] Add indexed workflows for open issues

### DIFF
--- a/.agents/skills/workflow-authoring/SKILL.md
+++ b/.agents/skills/workflow-authoring/SKILL.md
@@ -116,6 +116,46 @@ Before creating a new workflow:
 
 Do not partially overwrite old slices. Do not keep stale workflow files unless the user explicitly asks to archive them outside the active workflow.
 
+## Multi-Issue Workflow Index Rule
+
+When a user explicitly asks to create workflows for multiple issues before
+executing any of them, do not overwrite the single active workflow file for
+each issue. Preserve `documentation/workflow/workflow.md` unless the user
+explicitly asks to replace the active workflow.
+
+Use this indexed layout:
+
+```text
+documentation/workflow/workflow.index.md
+documentation/workflow/issues/issue-<number>/workflow.md
+documentation/workflow/issues/issue-<number>/context-pack.md
+documentation/workflow/issues/issue-<number>/context-pack.json
+```
+
+The index must list each included issue, workflow id, workflow path, branch,
+status, dependencies, blockers, and execution order. It must also list excluded
+issues with the reason they were excluded.
+
+Each issue workflow remains executable only after it is promoted to the active
+workflow location or the workflow executor is explicitly extended to accept an
+indexed workflow path. Until then, `workflow execute` must not guess which
+indexed workflow to run.
+
+For multi-issue authoring:
+
+1. Create one dedicated multi-workflow authoring branch unless the user
+   explicitly requests one branch per issue.
+2. Create or update `workflow.index.md` first.
+3. Create one issue-local `workflow.md` per authoring-ready issue.
+4. Keep issue-local context packs beside the issue-local workflow.
+5. Do not execute slices until all requested issue workflows are authored and
+   the execution order is confirmed from `workflow.index.md`.
+6. Use Git worktrees for later parallel execution only when S3D confirms
+   disjoint locks and the workflow index declares the workflows independent.
+
+Issues that fail the requirement clarification gate must be listed in the
+index as excluded or blocked instead of receiving executable workflow plans.
+
 ## Workflow Structure
 
 Every workflow should include:

--- a/documentation/workflow/issues/issue-4/context-pack.json
+++ b/documentation/workflow/issues/issue-4/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-4-swarm-stack-validation-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4",
+  "issue_number": 4,
+  "workflow_path": "documentation/workflow/issues/issue-4/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "infra/config/compose/**",
+    "src/tiny_swarm_world/domain/deployment/**",
+    "src/tiny_swarm_world/application/services/deployment/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-4/context-pack.md
+++ b/documentation/workflow/issues/issue-4/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #4 Validate Docker Swarm stack definitions
+
+- Workflow id: `issue-4-swarm-stack-validation-20260614`
+- Workflow path: `documentation/workflow/issues/issue-4/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-4/workflow.md
+++ b/documentation/workflow/issues/issue-4/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Validate Docker Swarm stack definitions
+
+```yaml
+workflow_id: issue-4-swarm-stack-validation-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4
+issue_number: 4
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-4-swarm-stack-validation-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 75
+dependencies: []
+```
+
+## Executive Summary
+
+Validate compose files as Docker Swarm stack definitions and fail when stack-only requirements such as deploy sections are missing.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #4: Validate Docker Swarm stack definitions.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future deployment configuration validation work.
+
+Affected process strand:
+
+- deployment configuration validation.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `infra/config/compose/**`
+- `src/tiny_swarm_world/domain/deployment/**`
+- `src/tiny_swarm_world/application/services/deployment/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 75 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #4 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-4/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #4.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #4.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-4/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  []
+parallel_group: issue-4-group-1
+file_locks:
+  - documentation/workflow/issues/issue-4/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #4.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S01
+parallel_group: issue-4-group-2
+file_locks:
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #4.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S02
+parallel_group: issue-4-group-3
+file_locks:
+  - tests/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #4.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S03
+parallel_group: issue-4-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: infra/config/compose/**, src/tiny_swarm_world/domain/deployment/**, src/tiny_swarm_world/application/services/deployment/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-4-swarm-stack-validation-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #4 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-63/context-pack.json
+++ b/documentation/workflow/issues/issue-63/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-63-reconcile-semantics-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/63",
+  "issue_number": 63,
+  "workflow_path": "documentation/workflow/issues/issue-63/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-63-reconcile-semantics-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/__main__.py",
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "src/tiny_swarm_world/application/services/platform/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-63/context-pack.md
+++ b/documentation/workflow/issues/issue-63/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #63 Align reconcile workflow semantics
+
+- Workflow id: `issue-63-reconcile-semantics-20260614`
+- Workflow path: `documentation/workflow/issues/issue-63/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-63-reconcile-semantics-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-63/workflow.md
+++ b/documentation/workflow/issues/issue-63/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Align reconcile workflow semantics
+
+```yaml
+workflow_id: issue-63-reconcile-semantics-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/63
+issue_number: 63
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-63-reconcile-semantics-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 82
+dependencies: []
+```
+
+## Executive Summary
+
+Define one authoritative meaning for platform reconcile and align taxonomy, CLI/help, composition wiring, output, tests, and documentation.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #63: Align reconcile workflow semantics.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future platform workflow semantics work.
+
+Affected process strand:
+
+- platform workflow semantics.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/__main__.py`
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/application/services/platform/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 82 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #63 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-63/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #63.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #63.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-63/**
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+affected_modules:
+  - platform workflow semantics
+affected_contracts:
+  - issue_63_reconcile_semantics
+dependencies:
+  []
+parallel_group: issue-63-group-1
+file_locks:
+  - documentation/workflow/issues/issue-63/**
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+contract_locks:
+  - issue_63_reconcile_semantics
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #63.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/application/services/platform/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - platform workflow semantics
+affected_contracts:
+  - issue_63_reconcile_semantics
+dependencies:
+  - S01
+parallel_group: issue-63-group-2
+file_locks:
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/application/services/platform/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_63_reconcile_semantics
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #63.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+affected_modules:
+  - platform workflow semantics
+affected_contracts:
+  - issue_63_reconcile_semantics
+dependencies:
+  - S02
+parallel_group: issue-63-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/infrastructure/composition.py
+contract_locks:
+  - issue_63_reconcile_semantics
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #63.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - platform workflow semantics
+affected_contracts:
+  - issue_63_reconcile_semantics
+dependencies:
+  - S03
+parallel_group: issue-63-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_63_reconcile_semantics
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/__main__.py, src/tiny_swarm_world/infrastructure/composition.py, src/tiny_swarm_world/application/services/platform/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-63-reconcile-semantics-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #63 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-64/context-pack.json
+++ b/documentation/workflow/issues/issue-64/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-64-backend-selection-order-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/64",
+  "issue_number": 64,
+  "workflow_path": "documentation/workflow/issues/issue-64/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-64-backend-selection-order-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "infra/config/node-providers/**",
+    "src/tiny_swarm_world/domain/node_provider/**",
+    "src/tiny_swarm_world/application/services/platform/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-64/context-pack.md
+++ b/documentation/workflow/issues/issue-64/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #64 Honor backend selection order
+
+- Workflow id: `issue-64-backend-selection-order-20260614`
+- Workflow path: `documentation/workflow/issues/issue-64/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-64-backend-selection-order-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-64/workflow.md
+++ b/documentation/workflow/issues/issue-64/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Honor backend selection order
+
+```yaml
+workflow_id: issue-64-backend-selection-order-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/64
+issue_number: 64
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-64-backend-selection-order-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 92
+dependencies: []
+```
+
+## Executive Summary
+
+Make backend selection deterministic: explicit override first, then configured candidate order, with diagnostics for selected and skipped candidates.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #64: Honor backend selection order.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future node-provider selection work.
+
+Affected process strand:
+
+- node-provider selection.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `infra/config/node-providers/**`
+- `src/tiny_swarm_world/domain/node_provider/**`
+- `src/tiny_swarm_world/application/services/platform/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 92 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #64 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-64/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #64.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #64.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-64/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+affected_modules:
+  - node-provider selection
+affected_contracts:
+  - issue_64_backend_selection_order
+dependencies:
+  []
+parallel_group: issue-64-group-1
+file_locks:
+  - documentation/workflow/issues/issue-64/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+contract_locks:
+  - issue_64_backend_selection_order
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #64.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - node-provider selection
+affected_contracts:
+  - issue_64_backend_selection_order
+dependencies:
+  - S01
+parallel_group: issue-64-group-2
+file_locks:
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_64_backend_selection_order
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #64.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+affected_modules:
+  - node-provider selection
+affected_contracts:
+  - issue_64_backend_selection_order
+dependencies:
+  - S02
+parallel_group: issue-64-group-3
+file_locks:
+  - tests/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+contract_locks:
+  - issue_64_backend_selection_order
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #64.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - node-provider selection
+affected_contracts:
+  - issue_64_backend_selection_order
+dependencies:
+  - S03
+parallel_group: issue-64-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_64_backend_selection_order
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: infra/config/node-providers/**, src/tiny_swarm_world/domain/node_provider/**, src/tiny_swarm_world/application/services/platform/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-64-backend-selection-order-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #64 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-65/context-pack.json
+++ b/documentation/workflow/issues/issue-65/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-65-backend-resource-mapping-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65",
+  "issue_number": 65,
+  "workflow_path": "documentation/workflow/issues/issue-65/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "infra/config/node-providers/**",
+    "src/tiny_swarm_world/domain/node_provider/**",
+    "src/tiny_swarm_world/infrastructure/adapters/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-65/context-pack.md
+++ b/documentation/workflow/issues/issue-65/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #65 Make resource mapping backend aware
+
+- Workflow id: `issue-65-backend-resource-mapping-20260614`
+- Workflow path: `documentation/workflow/issues/issue-65/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-65/workflow.md
+++ b/documentation/workflow/issues/issue-65/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Make resource mapping backend aware
+
+```yaml
+workflow_id: issue-65-backend-resource-mapping-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65
+issue_number: 65
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-65-backend-resource-mapping-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 88
+dependencies: []
+```
+
+## Executive Summary
+
+Resolve network, storage, profile, image and related resource names through backend-aware configuration instead of unconditional LXD-specific mappings.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #65: Make resource mapping backend aware.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future provider resource configuration work.
+
+Affected process strand:
+
+- provider resource configuration.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `infra/config/node-providers/**`
+- `src/tiny_swarm_world/domain/node_provider/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 88 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #65 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-65/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #65.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #65.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-65/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+affected_modules:
+  - provider resource configuration
+affected_contracts:
+  - issue_65_backend_resource_mapping
+dependencies:
+  []
+parallel_group: issue-65-group-1
+file_locks:
+  - documentation/workflow/issues/issue-65/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+contract_locks:
+  - issue_65_backend_resource_mapping
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #65.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - provider resource configuration
+affected_contracts:
+  - issue_65_backend_resource_mapping
+dependencies:
+  - S01
+parallel_group: issue-65-group-2
+file_locks:
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_65_backend_resource_mapping
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #65.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+affected_modules:
+  - provider resource configuration
+affected_contracts:
+  - issue_65_backend_resource_mapping
+dependencies:
+  - S02
+parallel_group: issue-65-group-3
+file_locks:
+  - tests/**
+  - infra/config/node-providers/**
+  - src/tiny_swarm_world/domain/node_provider/**
+contract_locks:
+  - issue_65_backend_resource_mapping
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #65.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - provider resource configuration
+affected_contracts:
+  - issue_65_backend_resource_mapping
+dependencies:
+  - S03
+parallel_group: issue-65-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_65_backend_resource_mapping
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: infra/config/node-providers/**, src/tiny_swarm_world/domain/node_provider/**, src/tiny_swarm_world/infrastructure/adapters/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-65-backend-resource-mapping-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #65 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-66/context-pack.json
+++ b/documentation/workflow/issues/issue-66/context-pack.json
@@ -1,0 +1,59 @@
+{
+  "workflow_id": "issue-66-platform-verify-checks-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/66",
+  "issue_number": 66,
+  "workflow_path": "documentation/workflow/issues/issue-66/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-66-platform-verify-checks-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-74"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/application/services/platform/**",
+    "src/tiny_swarm_world/application/ports/**",
+    "src/tiny_swarm_world/infrastructure/adapters/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-66/context-pack.md
+++ b/documentation/workflow/issues/issue-66/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #66 Strengthen platform verify checks
+
+- Workflow id: `issue-66-platform-verify-checks-20260614`
+- Workflow path: `documentation/workflow/issues/issue-66/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-66-platform-verify-checks-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-74
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-66/workflow.md
+++ b/documentation/workflow/issues/issue-66/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Strengthen platform verify checks
+
+```yaml
+workflow_id: issue-66-platform-verify-checks-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/66
+issue_number: 66
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-66-platform-verify-checks-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 86
+dependencies: ['issue-74']
+```
+
+## Executive Summary
+
+Make platform verify perform read-only checks for managed nodes, Docker Engine, Swarm membership, proxy devices, and Portainer reachability when selected.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #66: Strengthen platform verify checks.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future read-only platform verification work.
+
+Affected process strand:
+
+- read-only platform verification.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/application/services/platform/**`
+- `src/tiny_swarm_world/application/ports/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 86 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #66 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-66/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #66.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #66.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-66/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+affected_modules:
+  - read-only platform verification
+affected_contracts:
+  - issue_66_platform_verify_checks
+dependencies:
+  []
+parallel_group: issue-66-group-1
+file_locks:
+  - documentation/workflow/issues/issue-66/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+contract_locks:
+  - issue_66_platform_verify_checks
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #66.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - read-only platform verification
+affected_contracts:
+  - issue_66_platform_verify_checks
+dependencies:
+  - S01
+parallel_group: issue-66-group-2
+file_locks:
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_66_platform_verify_checks
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #66.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+affected_modules:
+  - read-only platform verification
+affected_contracts:
+  - issue_66_platform_verify_checks
+dependencies:
+  - S02
+parallel_group: issue-66-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/application/ports/**
+contract_locks:
+  - issue_66_platform_verify_checks
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #66.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - read-only platform verification
+affected_contracts:
+  - issue_66_platform_verify_checks
+dependencies:
+  - S03
+parallel_group: issue-66-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_66_platform_verify_checks
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-74.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/application/services/platform/**, src/tiny_swarm_world/application/ports/**, src/tiny_swarm_world/infrastructure/adapters/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-66-platform-verify-checks-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #66 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-67/context-pack.json
+++ b/documentation/workflow/issues/issue-67/context-pack.json
@@ -1,0 +1,61 @@
+{
+  "workflow_id": "issue-67-python-installer-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/67",
+  "issue_number": 67,
+  "workflow_path": "documentation/workflow/issues/issue-67/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-67-python-installer-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-68",
+    "issue-69",
+    "issue-81"
+  ],
+  "affected_areas": [
+    "install.sh",
+    "src/tiny_swarm_world/**",
+    "tests/test_install_script.py",
+    "tests/test_install_debugger.py",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-67/context-pack.md
+++ b/documentation/workflow/issues/issue-67/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #67 Move install logic from shell to Python
+
+- Workflow id: `issue-67-python-installer-20260614`
+- Workflow path: `documentation/workflow/issues/issue-67/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-67-python-installer-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-68, issue-69, issue-81
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-67/workflow.md
+++ b/documentation/workflow/issues/issue-67/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Move install logic from shell to Python
+
+```yaml
+workflow_id: issue-67-python-installer-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/67
+issue_number: 67
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-67-python-installer-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 82
+dependencies: ['issue-68', 'issue-69', 'issue-81']
+```
+
+## Executive Summary
+
+Reduce install.sh to a minimal Linux/WSL bootstrap wrapper and move product decisions into tested Python installer modules.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #67: Move install logic from shell to Python.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future installer architecture work.
+
+Affected process strand:
+
+- installer architecture.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `install.sh`
+- `src/tiny_swarm_world/**`
+- `tests/test_install_script.py`
+- `tests/test_install_debugger.py`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 82 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #67 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-67/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #67.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #67.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-67/**
+  - install.sh
+  - src/tiny_swarm_world/**
+affected_modules:
+  - installer architecture
+affected_contracts:
+  - issue_67_python_installer
+dependencies:
+  []
+parallel_group: issue-67-group-1
+file_locks:
+  - documentation/workflow/issues/issue-67/**
+  - install.sh
+  - src/tiny_swarm_world/**
+contract_locks:
+  - issue_67_python_installer
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #67.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - install.sh
+  - src/tiny_swarm_world/**
+  - tests/test_install_script.py
+  - tests/test_install_debugger.py
+  - documentation/**
+affected_modules:
+  - installer architecture
+affected_contracts:
+  - issue_67_python_installer
+dependencies:
+  - S01
+parallel_group: issue-67-group-2
+file_locks:
+  - install.sh
+  - src/tiny_swarm_world/**
+  - tests/test_install_script.py
+  - tests/test_install_debugger.py
+  - documentation/**
+contract_locks:
+  - issue_67_python_installer
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #67.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - install.sh
+  - src/tiny_swarm_world/**
+affected_modules:
+  - installer architecture
+affected_contracts:
+  - issue_67_python_installer
+dependencies:
+  - S02
+parallel_group: issue-67-group-3
+file_locks:
+  - tests/**
+  - install.sh
+  - src/tiny_swarm_world/**
+contract_locks:
+  - issue_67_python_installer
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #67.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - installer architecture
+affected_contracts:
+  - issue_67_python_installer
+dependencies:
+  - S03
+parallel_group: issue-67-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_67_python_installer
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-68, issue-69, issue-81.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: install.sh, src/tiny_swarm_world/**, tests/test_install_script.py, tests/test_install_debugger.py, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-67-python-installer-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #67 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-68/context-pack.json
+++ b/documentation/workflow/issues/issue-68/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-68-explicit-live-approval-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/68",
+  "issue_number": 68,
+  "workflow_path": "documentation/workflow/issues/issue-68/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-68-explicit-live-approval-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "install.sh",
+    "src/tiny_swarm_world/__main__.py",
+    "src/tiny_swarm_world/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-68/context-pack.md
+++ b/documentation/workflow/issues/issue-68/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #68 Replace piped installer approval with explicit flag
+
+- Workflow id: `issue-68-explicit-live-approval-20260614`
+- Workflow path: `documentation/workflow/issues/issue-68/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-68-explicit-live-approval-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-68/workflow.md
+++ b/documentation/workflow/issues/issue-68/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Replace piped installer approval with explicit flag
+
+```yaml
+workflow_id: issue-68-explicit-live-approval-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/68
+issue_number: 68
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-68-explicit-live-approval-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 92
+dependencies: []
+```
+
+## Executive Summary
+
+Separate interactive live approval from explicit non-interactive automation approval and record the approval source in evidence.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #68: Replace piped installer approval with explicit flag.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future live-operation consent work.
+
+Affected process strand:
+
+- live-operation consent.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `install.sh`
+- `src/tiny_swarm_world/__main__.py`
+- `src/tiny_swarm_world/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 92 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #68 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-68/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #68.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #68.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-68/**
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+affected_modules:
+  - live-operation consent
+affected_contracts:
+  - issue_68_explicit_live_approval
+dependencies:
+  []
+parallel_group: issue-68-group-1
+file_locks:
+  - documentation/workflow/issues/issue-68/**
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+contract_locks:
+  - issue_68_explicit_live_approval
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #68.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - live-operation consent
+affected_contracts:
+  - issue_68_explicit_live_approval
+dependencies:
+  - S01
+parallel_group: issue-68-group-2
+file_locks:
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+  - src/tiny_swarm_world/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_68_explicit_live_approval
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #68.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+affected_modules:
+  - live-operation consent
+affected_contracts:
+  - issue_68_explicit_live_approval
+dependencies:
+  - S02
+parallel_group: issue-68-group-3
+file_locks:
+  - tests/**
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+contract_locks:
+  - issue_68_explicit_live_approval
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #68.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - live-operation consent
+affected_contracts:
+  - issue_68_explicit_live_approval
+dependencies:
+  - S03
+parallel_group: issue-68-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_68_explicit_live_approval
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: install.sh, src/tiny_swarm_world/__main__.py, src/tiny_swarm_world/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-68-explicit-live-approval-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #68 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-69/context-pack.json
+++ b/documentation/workflow/issues/issue-69/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-69-host-evidence-directories-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/69",
+  "issue_number": 69,
+  "workflow_path": "documentation/workflow/issues/issue-69/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-69-host-evidence-directories-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/domain/preflight/**",
+    "src/tiny_swarm_world/application/ports/preflight/**",
+    "src/tiny_swarm_world/infrastructure/adapters/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-69/context-pack.md
+++ b/documentation/workflow/issues/issue-69/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #69 Use host-specific evidence directories
+
+- Workflow id: `issue-69-host-evidence-directories-20260614`
+- Workflow path: `documentation/workflow/issues/issue-69/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-69-host-evidence-directories-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-69/workflow.md
+++ b/documentation/workflow/issues/issue-69/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Use host-specific evidence directories
+
+```yaml
+workflow_id: issue-69-host-evidence-directories-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/69
+issue_number: 69
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-69-host-evidence-directories-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 90
+dependencies: []
+```
+
+## Executive Summary
+
+Resolve evidence directories from host runtime type instead of writing misleading native Linux evidence under a fixed wsl2 path.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #69: Use host-specific evidence directories.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future evidence path governance work.
+
+Affected process strand:
+
+- evidence path governance.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/domain/preflight/**`
+- `src/tiny_swarm_world/application/ports/preflight/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 90 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #69 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-69/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #69.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #69.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-69/**
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+affected_modules:
+  - evidence path governance
+affected_contracts:
+  - issue_69_host_evidence_directories
+dependencies:
+  []
+parallel_group: issue-69-group-1
+file_locks:
+  - documentation/workflow/issues/issue-69/**
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+contract_locks:
+  - issue_69_host_evidence_directories
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #69.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - evidence path governance
+affected_contracts:
+  - issue_69_host_evidence_directories
+dependencies:
+  - S01
+parallel_group: issue-69-group-2
+file_locks:
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_69_host_evidence_directories
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #69.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+affected_modules:
+  - evidence path governance
+affected_contracts:
+  - issue_69_host_evidence_directories
+dependencies:
+  - S02
+parallel_group: issue-69-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/domain/preflight/**
+  - src/tiny_swarm_world/application/ports/preflight/**
+contract_locks:
+  - issue_69_host_evidence_directories
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #69.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - evidence path governance
+affected_contracts:
+  - issue_69_host_evidence_directories
+dependencies:
+  - S03
+parallel_group: issue-69-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_69_host_evidence_directories
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/domain/preflight/**, src/tiny_swarm_world/application/ports/preflight/**, src/tiny_swarm_world/infrastructure/adapters/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-69-host-evidence-directories-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #69 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-70/context-pack.json
+++ b/documentation/workflow/issues/issue-70/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-70-command-runner-responsibility-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/70",
+  "issue_number": 70,
+  "workflow_path": "documentation/workflow/issues/issue-70/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-70-command-runner-responsibility-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/domain/command/**",
+    "src/tiny_swarm_world/application/ports/commands/**",
+    "src/tiny_swarm_world/infrastructure/adapters/command_runner/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-70/context-pack.md
+++ b/documentation/workflow/issues/issue-70/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #70 Clarify command runner responsibility
+
+- Workflow id: `issue-70-command-runner-responsibility-20260614`
+- Workflow path: `documentation/workflow/issues/issue-70/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-70-command-runner-responsibility-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-70/workflow.md
+++ b/documentation/workflow/issues/issue-70/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Clarify command runner responsibility
+
+```yaml
+workflow_id: issue-70-command-runner-responsibility-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/70
+issue_number: 70
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-70-command-runner-responsibility-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 90
+dependencies: []
+```
+
+## Executive Summary
+
+Classify the generic command runner path as supported, legacy compatibility, or removal scope and prevent unsupported runner types from active workflows.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #70: Clarify command runner responsibility.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future command runner governance work.
+
+Affected process strand:
+
+- command runner governance.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/domain/command/**`
+- `src/tiny_swarm_world/application/ports/commands/**`
+- `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 90 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #70 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-70/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #70.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #70.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-70/**
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+affected_modules:
+  - command runner governance
+affected_contracts:
+  - issue_70_command_runner_responsibility
+dependencies:
+  []
+parallel_group: issue-70-group-1
+file_locks:
+  - documentation/workflow/issues/issue-70/**
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+contract_locks:
+  - issue_70_command_runner_responsibility
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #70.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - command runner governance
+affected_contracts:
+  - issue_70_command_runner_responsibility
+dependencies:
+  - S01
+parallel_group: issue-70-group-2
+file_locks:
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_70_command_runner_responsibility
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #70.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+affected_modules:
+  - command runner governance
+affected_contracts:
+  - issue_70_command_runner_responsibility
+dependencies:
+  - S02
+parallel_group: issue-70-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/domain/command/**
+  - src/tiny_swarm_world/application/ports/commands/**
+contract_locks:
+  - issue_70_command_runner_responsibility
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #70.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - command runner governance
+affected_contracts:
+  - issue_70_command_runner_responsibility
+dependencies:
+  - S03
+parallel_group: issue-70-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_70_command_runner_responsibility
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/domain/command/**, src/tiny_swarm_world/application/ports/commands/**, src/tiny_swarm_world/infrastructure/adapters/command_runner/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-70-command-runner-responsibility-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #70 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-71/context-pack.json
+++ b/documentation/workflow/issues/issue-71/context-pack.json
@@ -1,0 +1,58 @@
+{
+  "workflow_id": "issue-71-disable-ansible-runner-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/71",
+  "issue_number": 71,
+  "workflow_path": "documentation/workflow/issues/issue-71/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-71-disable-ansible-runner-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-70"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/adapters/command_runner/**",
+    "src/tiny_swarm_world/domain/command/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-71/context-pack.md
+++ b/documentation/workflow/issues/issue-71/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #71 Remove placeholder automation runner
+
+- Workflow id: `issue-71-disable-ansible-runner-20260614`
+- Workflow path: `documentation/workflow/issues/issue-71/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-71-disable-ansible-runner-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-70
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-71/workflow.md
+++ b/documentation/workflow/issues/issue-71/workflow.md
@@ -1,0 +1,558 @@
+# Workflow: Remove placeholder automation runner
+
+```yaml
+workflow_id: issue-71-disable-ansible-runner-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/71
+issue_number: 71
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-71-disable-ansible-runner-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 92
+dependencies: ['issue-70']
+```
+
+## Executive Summary
+
+Ensure Ansible placeholder execution cannot be selected or report success without doing real work.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #71: Remove placeholder automation runner.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future command runner safety work.
+
+Affected process strand:
+
+- command runner safety.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+- `src/tiny_swarm_world/domain/command/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 92 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #71 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-71/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #71.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #71.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-71/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_71_disable_ansible_runner
+dependencies:
+  []
+parallel_group: issue-71-group-1
+file_locks:
+  - documentation/workflow/issues/issue-71/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+contract_locks:
+  - issue_71_disable_ansible_runner
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #71.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_71_disable_ansible_runner
+dependencies:
+  - S01
+parallel_group: issue-71-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_71_disable_ansible_runner
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #71.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_71_disable_ansible_runner
+dependencies:
+  - S02
+parallel_group: issue-71-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/domain/command/**
+contract_locks:
+  - issue_71_disable_ansible_runner
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #71.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_71_disable_ansible_runner
+dependencies:
+  - S03
+parallel_group: issue-71-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_71_disable_ansible_runner
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-70.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/adapters/command_runner/**, src/tiny_swarm_world/domain/command/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-71-disable-ansible-runner-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #71 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-72/context-pack.json
+++ b/documentation/workflow/issues/issue-72/context-pack.json
@@ -1,0 +1,58 @@
+{
+  "workflow_id": "issue-72-rest-runner-decision-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/72",
+  "issue_number": 72,
+  "workflow_path": "documentation/workflow/issues/issue-72/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-72-rest-runner-decision-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-70"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/adapters/command_runner/**",
+    "src/tiny_swarm_world/application/ports/commands/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-72/context-pack.md
+++ b/documentation/workflow/issues/issue-72/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #72 Implement or disable REST command runner
+
+- Workflow id: `issue-72-rest-runner-decision-20260614`
+- Workflow path: `documentation/workflow/issues/issue-72/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-72-rest-runner-decision-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-70
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-72/workflow.md
+++ b/documentation/workflow/issues/issue-72/workflow.md
@@ -1,0 +1,558 @@
+# Workflow: Implement or disable REST command runner
+
+```yaml
+workflow_id: issue-72-rest-runner-decision-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/72
+issue_number: 72
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-72-rest-runner-decision-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 78
+dependencies: ['issue-70']
+```
+
+## Executive Summary
+
+Make the REST command runner either a real tested REST adapter or an explicit unsupported runner that cannot return empty success.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #72: Implement or disable REST command runner.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future command runner safety work.
+
+Affected process strand:
+
+- command runner safety.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+- `src/tiny_swarm_world/application/ports/commands/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 78 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #72 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-72/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #72.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #72.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-72/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_72_rest_runner_decision
+dependencies:
+  []
+parallel_group: issue-72-group-1
+file_locks:
+  - documentation/workflow/issues/issue-72/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+contract_locks:
+  - issue_72_rest_runner_decision
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #72.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_72_rest_runner_decision
+dependencies:
+  - S01
+parallel_group: issue-72-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_72_rest_runner_decision
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #72.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_72_rest_runner_decision
+dependencies:
+  - S02
+parallel_group: issue-72-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/command_runner/**
+  - src/tiny_swarm_world/application/ports/commands/**
+contract_locks:
+  - issue_72_rest_runner_decision
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #72.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - command runner safety
+affected_contracts:
+  - issue_72_rest_runner_decision
+dependencies:
+  - S03
+parallel_group: issue-72-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_72_rest_runner_decision
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-70.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/adapters/command_runner/**, src/tiny_swarm_world/application/ports/commands/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-72-rest-runner-decision-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #72 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-73/context-pack.json
+++ b/documentation/workflow/issues/issue-73/context-pack.json
@@ -1,0 +1,61 @@
+{
+  "workflow_id": "issue-73-split-composition-root-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/73",
+  "issue_number": 73,
+  "workflow_path": "documentation/workflow/issues/issue-73/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-73-split-composition-root-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-64",
+    "issue-65",
+    "issue-74",
+    "issue-77"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "src/tiny_swarm_world/infrastructure/**",
+    "tests/infrastructure/test_composition.py",
+    "documentation/arc42/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-73/context-pack.md
+++ b/documentation/workflow/issues/issue-73/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #73 Split oversized composition root
+
+- Workflow id: `issue-73-split-composition-root-20260614`
+- Workflow path: `documentation/workflow/issues/issue-73/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-73-split-composition-root-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-64, issue-65, issue-74, issue-77
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-73/workflow.md
+++ b/documentation/workflow/issues/issue-73/workflow.md
@@ -1,0 +1,558 @@
+# Workflow: Split oversized composition root
+
+```yaml
+workflow_id: issue-73-split-composition-root-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/73
+issue_number: 73
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-73-split-composition-root-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 88
+dependencies: ['issue-64', 'issue-65', 'issue-74', 'issue-77']
+```
+
+## Executive Summary
+
+Split the infrastructure composition root into focused internal wiring modules while preserving behavior and keeping composition as the standard runtime boundary.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #73: Split oversized composition root.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future composition wiring refactor work.
+
+Affected process strand:
+
+- composition wiring refactor.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/infrastructure/**`
+- `tests/infrastructure/test_composition.py`
+- `documentation/arc42/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 88 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #73 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-73/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #73.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #73.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-73/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+affected_modules:
+  - composition wiring refactor
+affected_contracts:
+  - issue_73_split_composition_root
+dependencies:
+  []
+parallel_group: issue-73-group-1
+file_locks:
+  - documentation/workflow/issues/issue-73/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+contract_locks:
+  - issue_73_split_composition_root
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #73.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+  - tests/infrastructure/test_composition.py
+  - documentation/arc42/**
+affected_modules:
+  - composition wiring refactor
+affected_contracts:
+  - issue_73_split_composition_root
+dependencies:
+  - S01
+parallel_group: issue-73-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+  - tests/infrastructure/test_composition.py
+  - documentation/arc42/**
+contract_locks:
+  - issue_73_split_composition_root
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #73.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+affected_modules:
+  - composition wiring refactor
+affected_contracts:
+  - issue_73_split_composition_root
+dependencies:
+  - S02
+parallel_group: issue-73-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/**
+contract_locks:
+  - issue_73_split_composition_root
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #73.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - composition wiring refactor
+affected_contracts:
+  - issue_73_split_composition_root
+dependencies:
+  - S03
+parallel_group: issue-73-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_73_split_composition_root
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-64, issue-65, issue-74, issue-77.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/composition.py, src/tiny_swarm_world/infrastructure/**, tests/infrastructure/test_composition.py, documentation/arc42/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-73-split-composition-root-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #73 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-74/context-pack.json
+++ b/documentation/workflow/issues/issue-74/context-pack.json
@@ -1,0 +1,58 @@
+{
+  "workflow_id": "issue-74-provider-aware-preflight-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/74",
+  "issue_number": 74,
+  "workflow_path": "documentation/workflow/issues/issue-74/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-74-provider-aware-preflight-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "src/tiny_swarm_world/infrastructure/adapters/preflight/**",
+    "src/tiny_swarm_world/application/services/platform/**",
+    "infra/config/node-providers/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-74/context-pack.md
+++ b/documentation/workflow/issues/issue-74/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #74 Make preflight provider aware
+
+- Workflow id: `issue-74-provider-aware-preflight-20260614`
+- Workflow path: `documentation/workflow/issues/issue-74/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-74-provider-aware-preflight-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-74/workflow.md
+++ b/documentation/workflow/issues/issue-74/workflow.md
@@ -1,0 +1,564 @@
+# Workflow: Make preflight provider aware
+
+```yaml
+workflow_id: issue-74-provider-aware-preflight-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/74
+issue_number: 74
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-74-provider-aware-preflight-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 86
+dependencies: []
+```
+
+## Executive Summary
+
+Select preflight configuration from the resolved provider/backend request and fail clearly when provider-specific definitions are missing.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #74: Make preflight provider aware.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future provider preflight configuration work.
+
+Affected process strand:
+
+- provider preflight configuration.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/infrastructure/adapters/preflight/**`
+- `src/tiny_swarm_world/application/services/platform/**`
+- `infra/config/node-providers/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 86 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #74 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-74/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #74.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #74.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-74/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+affected_modules:
+  - provider preflight configuration
+affected_contracts:
+  - issue_74_provider_aware_preflight
+dependencies:
+  []
+parallel_group: issue-74-group-1
+file_locks:
+  - documentation/workflow/issues/issue-74/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+contract_locks:
+  - issue_74_provider_aware_preflight
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #74.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - infra/config/node-providers/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - provider preflight configuration
+affected_contracts:
+  - issue_74_provider_aware_preflight
+dependencies:
+  - S01
+parallel_group: issue-74-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+  - src/tiny_swarm_world/application/services/platform/**
+  - infra/config/node-providers/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_74_provider_aware_preflight
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #74.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+affected_modules:
+  - provider preflight configuration
+affected_contracts:
+  - issue_74_provider_aware_preflight
+dependencies:
+  - S02
+parallel_group: issue-74-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/preflight/**
+contract_locks:
+  - issue_74_provider_aware_preflight
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #74.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - provider preflight configuration
+affected_contracts:
+  - issue_74_provider_aware_preflight
+dependencies:
+  - S03
+parallel_group: issue-74-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_74_provider_aware_preflight
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/composition.py, src/tiny_swarm_world/infrastructure/adapters/preflight/**, src/tiny_swarm_world/application/services/platform/**, infra/config/node-providers/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-74-provider-aware-preflight-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #74 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-75/context-pack.json
+++ b/documentation/workflow/issues/issue-75/context-pack.json
@@ -1,0 +1,60 @@
+{
+  "workflow_id": "issue-75-status-display-purpose-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/75",
+  "issue_number": 75,
+  "workflow_path": "documentation/workflow/issues/issue-75/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-75-status-display-purpose-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-83",
+    "issue-82"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "src/tiny_swarm_world/infrastructure/adapters/ui/**",
+    "src/tiny_swarm_world/application/ports/ui/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-75/context-pack.md
+++ b/documentation/workflow/issues/issue-75/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #75 Clarify status display purpose
+
+- Workflow id: `issue-75-status-display-purpose-20260614`
+- Workflow path: `documentation/workflow/issues/issue-75/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-75-status-display-purpose-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-83, issue-82
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-75/workflow.md
+++ b/documentation/workflow/issues/issue-75/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Clarify status display purpose
+
+```yaml
+workflow_id: issue-75-status-display-purpose-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/75
+issue_number: 75
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-75-status-display-purpose-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 84
+dependencies: ['issue-83', 'issue-82']
+```
+
+## Executive Summary
+
+Define whether console UI is authoritative, advisory, or legacy and make empty instance handling deliberate instead of accidentally complete.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #75: Clarify status display purpose.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future console status UI semantics work.
+
+Affected process strand:
+
+- console status UI semantics.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/infrastructure/adapters/ui/**`
+- `src/tiny_swarm_world/application/ports/ui/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 84 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #75 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-75/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #75.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #75.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-75/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+affected_modules:
+  - console status UI semantics
+affected_contracts:
+  - issue_75_status_display_purpose
+dependencies:
+  []
+parallel_group: issue-75-group-1
+file_locks:
+  - documentation/workflow/issues/issue-75/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+contract_locks:
+  - issue_75_status_display_purpose
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #75.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/ports/ui/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - console status UI semantics
+affected_contracts:
+  - issue_75_status_display_purpose
+dependencies:
+  - S01
+parallel_group: issue-75-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/ports/ui/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_75_status_display_purpose
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #75.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+affected_modules:
+  - console status UI semantics
+affected_contracts:
+  - issue_75_status_display_purpose
+dependencies:
+  - S02
+parallel_group: issue-75-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+contract_locks:
+  - issue_75_status_display_purpose
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #75.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - console status UI semantics
+affected_contracts:
+  - issue_75_status_display_purpose
+dependencies:
+  - S03
+parallel_group: issue-75-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_75_status_display_purpose
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-83, issue-82.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/composition.py, src/tiny_swarm_world/infrastructure/adapters/ui/**, src/tiny_swarm_world/application/ports/ui/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-75-status-display-purpose-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #75 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-76/context-pack.json
+++ b/documentation/workflow/issues/issue-76/context-pack.json
@@ -1,0 +1,61 @@
+{
+  "workflow_id": "issue-76-configuration-value-ownership-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/76",
+  "issue_number": 76,
+  "workflow_path": "documentation/workflow/issues/issue-76/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-76-configuration-value-ownership-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-67",
+    "issue-68"
+  ],
+  "affected_areas": [
+    "install.sh",
+    ".env.example",
+    "infra/config/secrets/**",
+    "src/tiny_swarm_world/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-76/context-pack.md
+++ b/documentation/workflow/issues/issue-76/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #76 Define configuration value ownership
+
+- Workflow id: `issue-76-configuration-value-ownership-20260614`
+- Workflow path: `documentation/workflow/issues/issue-76/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-76-configuration-value-ownership-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-67, issue-68
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-76/workflow.md
+++ b/documentation/workflow/issues/issue-76/workflow.md
@@ -1,0 +1,564 @@
+# Workflow: Define configuration value ownership
+
+```yaml
+workflow_id: issue-76-configuration-value-ownership-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/76
+issue_number: 76
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-76-configuration-value-ownership-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 80
+dependencies: ['issue-67', 'issue-68']
+```
+
+## Executive Summary
+
+Separate ownership and lifecycle for bootstrap secrets, runtime secrets, recovery files, local env files, and Infisical-managed values.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #76: Define configuration value ownership.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future secrets and configuration ownership work.
+
+Affected process strand:
+
+- secrets and configuration ownership.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `install.sh`
+- `.env.example`
+- `infra/config/secrets/**`
+- `src/tiny_swarm_world/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 80 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #76 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-76/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #76.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #76.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-76/**
+  - install.sh
+  - .env.example
+affected_modules:
+  - secrets and configuration ownership
+affected_contracts:
+  - issue_76_configuration_value_ownership
+dependencies:
+  []
+parallel_group: issue-76-group-1
+file_locks:
+  - documentation/workflow/issues/issue-76/**
+  - install.sh
+  - .env.example
+contract_locks:
+  - issue_76_configuration_value_ownership
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #76.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - install.sh
+  - .env.example
+  - infra/config/secrets/**
+  - src/tiny_swarm_world/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - secrets and configuration ownership
+affected_contracts:
+  - issue_76_configuration_value_ownership
+dependencies:
+  - S01
+parallel_group: issue-76-group-2
+file_locks:
+  - install.sh
+  - .env.example
+  - infra/config/secrets/**
+  - src/tiny_swarm_world/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_76_configuration_value_ownership
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #76.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - install.sh
+  - .env.example
+affected_modules:
+  - secrets and configuration ownership
+affected_contracts:
+  - issue_76_configuration_value_ownership
+dependencies:
+  - S02
+parallel_group: issue-76-group-3
+file_locks:
+  - tests/**
+  - install.sh
+  - .env.example
+contract_locks:
+  - issue_76_configuration_value_ownership
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #76.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - secrets and configuration ownership
+affected_contracts:
+  - issue_76_configuration_value_ownership
+dependencies:
+  - S03
+parallel_group: issue-76-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_76_configuration_value_ownership
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-67, issue-68.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: install.sh, .env.example, infra/config/secrets/**, src/tiny_swarm_world/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-76-configuration-value-ownership-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #76 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-77/context-pack.json
+++ b/documentation/workflow/issues/issue-77/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-77-deployment-gateway-port-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/77",
+  "issue_number": 77,
+  "workflow_path": "documentation/workflow/issues/issue-77/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-77-deployment-gateway-port-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/application/ports/**",
+    "src/tiny_swarm_world/application/services/deployment/**",
+    "src/tiny_swarm_world/infrastructure/adapters/clients/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-77/context-pack.md
+++ b/documentation/workflow/issues/issue-77/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #77 Decouple deployment gateway adapter
+
+- Workflow id: `issue-77-deployment-gateway-port-20260614`
+- Workflow path: `documentation/workflow/issues/issue-77/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-77-deployment-gateway-port-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-77/workflow.md
+++ b/documentation/workflow/issues/issue-77/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Decouple deployment gateway adapter
+
+```yaml
+workflow_id: issue-77-deployment-gateway-port-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/77
+issue_number: 77
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-77-deployment-gateway-port-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 85
+dependencies: []
+```
+
+## Executive Summary
+
+Move deployment orchestration onto an explicit application port so Portainer endpoint, stack, and Swarm-ID details stay in infrastructure adapters.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #77: Decouple deployment gateway adapter.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future deployment port boundary work.
+
+Affected process strand:
+
+- deployment port boundary.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/application/ports/**`
+- `src/tiny_swarm_world/application/services/deployment/**`
+- `src/tiny_swarm_world/infrastructure/adapters/clients/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 85 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #77 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-77/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #77.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #77.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-77/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+affected_modules:
+  - deployment port boundary
+affected_contracts:
+  - issue_77_deployment_gateway_port
+dependencies:
+  []
+parallel_group: issue-77-group-1
+file_locks:
+  - documentation/workflow/issues/issue-77/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+contract_locks:
+  - issue_77_deployment_gateway_port
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #77.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - src/tiny_swarm_world/infrastructure/adapters/clients/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - deployment port boundary
+affected_contracts:
+  - issue_77_deployment_gateway_port
+dependencies:
+  - S01
+parallel_group: issue-77-group-2
+file_locks:
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - src/tiny_swarm_world/infrastructure/adapters/clients/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_77_deployment_gateway_port
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #77.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+affected_modules:
+  - deployment port boundary
+affected_contracts:
+  - issue_77_deployment_gateway_port
+dependencies:
+  - S02
+parallel_group: issue-77-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/application/services/deployment/**
+contract_locks:
+  - issue_77_deployment_gateway_port
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #77.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - deployment port boundary
+affected_contracts:
+  - issue_77_deployment_gateway_port
+dependencies:
+  - S03
+parallel_group: issue-77-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_77_deployment_gateway_port
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/application/ports/**, src/tiny_swarm_world/application/services/deployment/**, src/tiny_swarm_world/infrastructure/adapters/clients/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-77-deployment-gateway-port-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #77 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-78/context-pack.json
+++ b/documentation/workflow/issues/issue-78/context-pack.json
@@ -1,0 +1,58 @@
+{
+  "workflow_id": "issue-78-python-packaging-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/78",
+  "issue_number": 78,
+  "workflow_path": "documentation/workflow/issues/issue-78/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-78-python-packaging-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "pyproject.toml",
+    "src/tiny_swarm_world/__main__.py",
+    "requirements.txt",
+    "tests/**",
+    "README.md",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-78/context-pack.md
+++ b/documentation/workflow/issues/issue-78/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #78 Add standard Python packaging
+
+- Workflow id: `issue-78-python-packaging-20260614`
+- Workflow path: `documentation/workflow/issues/issue-78/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-78-python-packaging-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-78/workflow.md
+++ b/documentation/workflow/issues/issue-78/workflow.md
@@ -1,0 +1,564 @@
+# Workflow: Add standard Python packaging
+
+```yaml
+workflow_id: issue-78-python-packaging-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/78
+issue_number: 78
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-78-python-packaging-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 89
+dependencies: []
+```
+
+## Executive Summary
+
+Add Python 3.12 packaging metadata and a CLI entry point while preserving the thin module entry path.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #78: Add standard Python packaging.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future Python packaging and CLI entry point work.
+
+Affected process strand:
+
+- Python packaging and CLI entry point.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `pyproject.toml`
+- `src/tiny_swarm_world/__main__.py`
+- `requirements.txt`
+- `tests/**`
+- `README.md`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 89 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #78 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-78/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #78.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #78.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-78/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+affected_modules:
+  - Python packaging and CLI entry point
+affected_contracts:
+  - issue_78_python_packaging
+dependencies:
+  []
+parallel_group: issue-78-group-1
+file_locks:
+  - documentation/workflow/issues/issue-78/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+contract_locks:
+  - issue_78_python_packaging
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #78.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+  - requirements.txt
+  - tests/**
+  - README.md
+  - documentation/**
+affected_modules:
+  - Python packaging and CLI entry point
+affected_contracts:
+  - issue_78_python_packaging
+dependencies:
+  - S01
+parallel_group: issue-78-group-2
+file_locks:
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+  - requirements.txt
+  - tests/**
+  - README.md
+  - documentation/**
+contract_locks:
+  - issue_78_python_packaging
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #78.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+affected_modules:
+  - Python packaging and CLI entry point
+affected_contracts:
+  - issue_78_python_packaging
+dependencies:
+  - S02
+parallel_group: issue-78-group-3
+file_locks:
+  - tests/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+contract_locks:
+  - issue_78_python_packaging
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #78.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - Python packaging and CLI entry point
+affected_contracts:
+  - issue_78_python_packaging
+dependencies:
+  - S03
+parallel_group: issue-78-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_78_python_packaging
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: pyproject.toml, src/tiny_swarm_world/__main__.py, requirements.txt, tests/**, README.md, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-78-python-packaging-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #78 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-80/context-pack.json
+++ b/documentation/workflow/issues/issue-80/context-pack.json
@@ -1,0 +1,60 @@
+{
+  "workflow_id": "issue-80-ui-execution-decoupling-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/80",
+  "issue_number": 80,
+  "workflow_path": "documentation/workflow/issues/issue-80/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-80-ui-execution-decoupling-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-83",
+    "issue-82"
+  ],
+  "affected_areas": [
+    "src/tiny_swarm_world/infrastructure/adapters/ui/**",
+    "src/tiny_swarm_world/application/services/commands/**",
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-80/context-pack.md
+++ b/documentation/workflow/issues/issue-80/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #80 Decouple command execution from the console UI adapter
+
+- Workflow id: `issue-80-ui-execution-decoupling-20260614`
+- Workflow path: `documentation/workflow/issues/issue-80/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-80-ui-execution-decoupling-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-83, issue-82
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-80/workflow.md
+++ b/documentation/workflow/issues/issue-80/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Decouple command execution from the console UI adapter
+
+```yaml
+workflow_id: issue-80-ui-execution-decoupling-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/80
+issue_number: 80
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-80-ui-execution-decoupling-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 90
+dependencies: ['issue-83', 'issue-82']
+```
+
+## Executive Summary
+
+Make console UI adapters presentation-only by moving command execution orchestration into application/workflow services behind ports.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #80: Decouple command execution from the console UI adapter.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future console UI responsibility boundary work.
+
+Affected process strand:
+
+- console UI responsibility boundary.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/infrastructure/adapters/ui/**`
+- `src/tiny_swarm_world/application/services/commands/**`
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 90 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #80 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-80/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #80.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #80.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-80/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+affected_modules:
+  - console UI responsibility boundary
+affected_contracts:
+  - issue_80_ui_execution_decoupling
+dependencies:
+  []
+parallel_group: issue-80-group-1
+file_locks:
+  - documentation/workflow/issues/issue-80/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+contract_locks:
+  - issue_80_ui_execution_decoupling
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #80.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - tests/**
+  - documentation/**
+affected_modules:
+  - console UI responsibility boundary
+affected_contracts:
+  - issue_80_ui_execution_decoupling
+dependencies:
+  - S01
+parallel_group: issue-80-group-2
+file_locks:
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+  - src/tiny_swarm_world/infrastructure/composition.py
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_80_ui_execution_decoupling
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #80.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+affected_modules:
+  - console UI responsibility boundary
+affected_contracts:
+  - issue_80_ui_execution_decoupling
+dependencies:
+  - S02
+parallel_group: issue-80-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - src/tiny_swarm_world/application/services/commands/**
+contract_locks:
+  - issue_80_ui_execution_decoupling
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #80.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - console UI responsibility boundary
+affected_contracts:
+  - issue_80_ui_execution_decoupling
+dependencies:
+  - S03
+parallel_group: issue-80-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_80_ui_execution_decoupling
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-83, issue-82.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/infrastructure/adapters/ui/**, src/tiny_swarm_world/application/services/commands/**, src/tiny_swarm_world/infrastructure/composition.py, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-80-ui-execution-decoupling-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #80 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-81/context-pack.json
+++ b/documentation/workflow/issues/issue-81/context-pack.json
@@ -1,0 +1,56 @@
+{
+  "workflow_id": "issue-81-headless-install-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/81",
+  "issue_number": 81,
+  "workflow_path": "documentation/workflow/issues/issue-81/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-81-headless-install-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "install.sh",
+    "tests/test_install_script.py",
+    "tests/test_install_debugger.py",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-81/context-pack.md
+++ b/documentation/workflow/issues/issue-81/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #81 Make install.sh complete without requiring the console TUI
+
+- Workflow id: `issue-81-headless-install-20260614`
+- Workflow path: `documentation/workflow/issues/issue-81/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-81-headless-install-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-81/workflow.md
+++ b/documentation/workflow/issues/issue-81/workflow.md
@@ -1,0 +1,558 @@
+# Workflow: Make install.sh complete without requiring the console TUI
+
+```yaml
+workflow_id: issue-81-headless-install-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/81
+issue_number: 81
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-81-headless-install-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 90
+dependencies: []
+```
+
+## Executive Summary
+
+Add a non-TUI/headless install path that executes the same governed reset/setup commands, preserves exit codes, and still writes evidence.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #81: Make install.sh complete without requiring the console TUI.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future headless installer execution work.
+
+Affected process strand:
+
+- headless installer execution.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `install.sh`
+- `tests/test_install_script.py`
+- `tests/test_install_debugger.py`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 90 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #81 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-81/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #81.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #81.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-81/**
+  - install.sh
+  - tests/test_install_script.py
+affected_modules:
+  - headless installer execution
+affected_contracts:
+  - issue_81_headless_install
+dependencies:
+  []
+parallel_group: issue-81-group-1
+file_locks:
+  - documentation/workflow/issues/issue-81/**
+  - install.sh
+  - tests/test_install_script.py
+contract_locks:
+  - issue_81_headless_install
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #81.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - install.sh
+  - tests/test_install_script.py
+  - tests/test_install_debugger.py
+  - documentation/**
+affected_modules:
+  - headless installer execution
+affected_contracts:
+  - issue_81_headless_install
+dependencies:
+  - S01
+parallel_group: issue-81-group-2
+file_locks:
+  - install.sh
+  - tests/test_install_script.py
+  - tests/test_install_debugger.py
+  - documentation/**
+contract_locks:
+  - issue_81_headless_install
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #81.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - install.sh
+  - tests/test_install_script.py
+affected_modules:
+  - headless installer execution
+affected_contracts:
+  - issue_81_headless_install
+dependencies:
+  - S02
+parallel_group: issue-81-group-3
+file_locks:
+  - tests/**
+  - install.sh
+  - tests/test_install_script.py
+contract_locks:
+  - issue_81_headless_install
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #81.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - headless installer execution
+affected_contracts:
+  - issue_81_headless_install
+dependencies:
+  - S03
+parallel_group: issue-81-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_81_headless_install
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: install.sh, tests/test_install_script.py, tests/test_install_debugger.py, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-81-headless-install-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #81 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-82/context-pack.json
+++ b/documentation/workflow/issues/issue-82/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-82-ui-presentation-arch-tests-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/82",
+  "issue_number": 82,
+  "workflow_path": "documentation/workflow/issues/issue-82/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-82-ui-presentation-arch-tests-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [
+    "issue-83"
+  ],
+  "affected_areas": [
+    "tests/architecture/test_hexagonal_imports.py",
+    "src/tiny_swarm_world/infrastructure/adapters/ui/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-82/context-pack.md
+++ b/documentation/workflow/issues/issue-82/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #82 Add architecture tests that keep the console UI presentation-only
+
+- Workflow id: `issue-82-ui-presentation-arch-tests-20260614`
+- Workflow path: `documentation/workflow/issues/issue-82/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-82-ui-presentation-arch-tests-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: issue-83
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-82/workflow.md
+++ b/documentation/workflow/issues/issue-82/workflow.md
@@ -1,0 +1,555 @@
+# Workflow: Add architecture tests that keep the console UI presentation-only
+
+```yaml
+workflow_id: issue-82-ui-presentation-arch-tests-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/82
+issue_number: 82
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-82-ui-presentation-arch-tests-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: NORMAL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 95
+dependencies: ['issue-83']
+```
+
+## Executive Summary
+
+Add deterministic architecture tests that prevent UI adapters from importing or instantiating execution and infrastructure orchestration concerns.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #82: Add architecture tests that keep the console UI presentation-only.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future architecture guardrail testing work.
+
+Affected process strand:
+
+- architecture guardrail testing.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `tests/architecture/test_hexagonal_imports.py`
+- `src/tiny_swarm_world/infrastructure/adapters/ui/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 95 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #82 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-82/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #82.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #82.
+
+```yaml
+slice_id: S01
+profile: NORMAL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-82/**
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+affected_modules:
+  - architecture guardrail testing
+affected_contracts:
+  - issue_82_ui_presentation_arch_tests
+dependencies:
+  []
+parallel_group: issue-82-group-1
+file_locks:
+  - documentation/workflow/issues/issue-82/**
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+contract_locks:
+  - issue_82_ui_presentation_arch_tests
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #82.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - documentation/**
+affected_modules:
+  - architecture guardrail testing
+affected_contracts:
+  - issue_82_ui_presentation_arch_tests
+dependencies:
+  - S01
+parallel_group: issue-82-group-2
+file_locks:
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - documentation/**
+contract_locks:
+  - issue_82_ui_presentation_arch_tests
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #82.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+affected_modules:
+  - architecture guardrail testing
+affected_contracts:
+  - issue_82_ui_presentation_arch_tests
+dependencies:
+  - S02
+parallel_group: issue-82-group-3
+file_locks:
+  - tests/**
+  - tests/architecture/test_hexagonal_imports.py
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+contract_locks:
+  - issue_82_ui_presentation_arch_tests
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #82.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - architecture guardrail testing
+affected_contracts:
+  - issue_82_ui_presentation_arch_tests
+dependencies:
+  - S03
+parallel_group: issue-82-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_82_ui_presentation_arch_tests
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: issue-83.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: tests/architecture/test_hexagonal_imports.py, src/tiny_swarm_world/infrastructure/adapters/ui/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-82-ui-presentation-arch-tests-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #82 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/issues/issue-83/context-pack.json
+++ b/documentation/workflow/issues/issue-83/context-pack.json
@@ -1,0 +1,57 @@
+{
+  "workflow_id": "issue-83-ui-status-evidence-contract-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/83",
+  "issue_number": 83,
+  "workflow_path": "documentation/workflow/issues/issue-83/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-83-ui-status-evidence-contract-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
+  "affected_areas": [
+    "src/tiny_swarm_world/application/ports/**",
+    "src/tiny_swarm_world/domain/**",
+    "src/tiny_swarm_world/infrastructure/adapters/ui/**",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot",
+    "React/TypeScript/Vite frontend setup",
+    "Kubernetes-first deployment",
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer",
+    "Senior Tester",
+    "Senior Documentation Engineer"
+  ],
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
+    },
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
+    }
+  ]
+}

--- a/documentation/workflow/issues/issue-83/context-pack.md
+++ b/documentation/workflow/issues/issue-83/context-pack.md
@@ -1,0 +1,13 @@
+# Context Pack: Issue #83 Define the status and evidence contract consumed by the console UI
+
+- Workflow id: `issue-83-ui-status-evidence-contract-20260614`
+- Workflow path: `documentation/workflow/issues/issue-83/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Proposed execution branch: `feature/workflow-issue-83-ui-status-evidence-contract-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
+
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/issues/issue-83/workflow.md
+++ b/documentation/workflow/issues/issue-83/workflow.md
@@ -1,0 +1,561 @@
+# Workflow: Define the status and evidence contract consumed by the console UI
+
+```yaml
+workflow_id: issue-83-ui-status-evidence-contract-20260614
+workflow_version: 1.0.0
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/83
+issue_number: 83
+authoring_branch: feature/workflow-index-open-issues-20260614
+proposed_execution_branch: feature/workflow-issue-83-ui-status-evidence-contract-20260614
+indexed_workflow: true
+active_workflow: false
+execution_profile: FULL_PATH
+released_for_workflow_execute: false
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 88
+dependencies: []
+```
+
+## Executive Summary
+
+Introduce or identify an application-level status/evidence model with command, result status, recovery hint, evidence path, and correlation/trace data for console UI rendering.
+
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
+
+## Requirement Clarification Gate
+
+Original request:
+
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
+
+Interpreted intent:
+
+- Create an executable workflow plan for Issue #83: Define the status and evidence contract consumed by the console UI.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
+
+Change type:
+
+- Workflow creation for future console UI status contract work.
+
+Affected process strand:
+
+- console UI status contract.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
+
+Affected architecture area:
+
+- `src/tiny_swarm_world/application/ports/**`
+- `src/tiny_swarm_world/domain/**`
+- `src/tiny_swarm_world/infrastructure/adapters/ui/**`
+- `tests/**`
+- `documentation/**`
+
+Explicit requirements:
+
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
+
+Implicit requirements:
+
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
+
+Assumptions:
+
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
+
+Non-goals:
+
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
+
+Risks:
+
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
+
+Open questions:
+
+- Resolve slice-local design choices from repository evidence before code
+  changes.
+
+Blocking questions:
+
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
+
+Confidence level: 88 percent.
+
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
+
+## Target Picture
+
+Issue #83 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
+
+## Verified Baseline
+
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-83/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
+
+## Scope
+
+In scope:
+
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #83.
+- Quality gates from `QUALITY.md`.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
+
+## Architecture Constraints
+
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
+
+## Python Automation Assessment
+
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
+
+## Frontend Assessment
+
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
+
+## Test Strategy
+
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
+
+## Resilience Requirements
+
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
+
+## Ordered Slices
+
+### Slice 01: Requirement, repository baseline, and decision gate
+
+Purpose:
+
+- Requirement, repository baseline, and decision gate for Issue #83.
+
+```yaml
+slice_id: S01
+profile: FULL_PATH
+owner: Senior Requirement Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/workflow/issues/issue-83/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+affected_modules:
+  - console UI status contract
+affected_contracts:
+  - issue_83_ui_status_evidence_contract
+dependencies:
+  []
+parallel_group: issue-83-group-1
+file_locks:
+  - documentation/workflow/issues/issue-83/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+contract_locks:
+  - issue_83_ui_status_evidence_contract
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #83.
+
+```yaml
+slice_id: S02
+profile: FULL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - console UI status contract
+affected_contracts:
+  - issue_83_ui_status_evidence_contract
+dependencies:
+  - S01
+parallel_group: issue-83-group-2
+file_locks:
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+  - src/tiny_swarm_world/infrastructure/adapters/ui/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_83_ui_status_evidence_contract
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #83.
+
+```yaml
+slice_id: S03
+profile: FULL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+affected_modules:
+  - console UI status contract
+affected_contracts:
+  - issue_83_ui_status_evidence_contract
+dependencies:
+  - S02
+parallel_group: issue-83-group-3
+file_locks:
+  - tests/**
+  - src/tiny_swarm_world/application/ports/**
+  - src/tiny_swarm_world/domain/**
+contract_locks:
+  - issue_83_ui_status_evidence_contract
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #83.
+
+```yaml
+slice_id: S04
+profile: FULL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - console UI status contract
+affected_contracts:
+  - issue_83_ui_status_evidence_contract
+dependencies:
+  - S03
+parallel_group: issue-83-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_83_ui_status_evidence_contract
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+- git diff --check
+- python3 tools/quality_gate.py test
+  required:
+- python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+## Slice Dependency Graph
+
+```text
+S01 -> S02 -> S03 -> S04
+```
+
+Cross-workflow dependencies: none.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: src/tiny_swarm_world/application/ports/**, src/tiny_swarm_world/domain/**, src/tiny_swarm_world/infrastructure/adapters/ui/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
+For every slice, create `.codex/evidence/slice-<number>-distribution.md`
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
+
+## Git Worktree Execution Rule
+
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
+
+```text
+<workflow-branch>-slice-<number>-<stream>
+```
+
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
+
+## Role And Ownership Map
+
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
+
+## Quality-Gate Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Documentation Synchronization Points
+
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
+
+## Stop Conditions
+
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
+
+## Uncertainty Escalation Rules
+
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
+
+## Commit And Push Plan
+
+Workflow authoring commit:
+
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
+- Run `git diff --check`.
+- Push the authoring branch after all indexed workflows are created.
+
+Future workflow execution:
+
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-83-ui-status-evidence-contract-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
+
+## Definition Of Done
+
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
+
+Issue #83 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
+
+## Handoff To Workflow Execute
+
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
+
+## arc42 Check Status
+
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/documentation/workflow/workflow.index.md
+++ b/documentation/workflow/workflow.index.md
@@ -1,0 +1,93 @@
+# Workflow Index: Open Issue Workflow Batch
+
+```yaml
+workflow_index_id: open-issue-workflow-batch-20260614
+workflow_index_version: 1.0.0
+authoring_branch: feature/workflow-index-open-issues-20260614
+created_utc: "2026-06-14T00:00:00Z"
+active_workflow_preserved: documentation/workflow/workflow.md
+included_issue_count: 21
+excluded_issue_count: 2
+status: AUTHORED_INDEXED_NOT_ACTIVE
+```
+
+## Purpose
+
+This index coordinates multiple issue-local workflows without overwriting the
+single active workflow file at `documentation/workflow/workflow.md`. Each
+included issue has its own `workflow.md` and context pack under
+`documentation/workflow/issues/issue-<number>/`.
+
+Unqualified `workflow execute` must not guess from this index. A workflow must
+first be promoted to the active workflow path or the executor must be extended
+to accept an explicit indexed workflow path.
+
+## Included Workflows
+
+| Order | Issue | Title | Workflow id | Workflow path | Proposed execution branch | Dependencies | Status |
+|---:|---:|---|---|---|---|---|---|
+| 1 | #4 | Validate Docker Swarm stack definitions | `issue-4-swarm-stack-validation-20260614` | `documentation/workflow/issues/issue-4/workflow.md` | `feature/workflow-issue-4-swarm-stack-validation-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 2 | #78 | Add standard Python packaging | `issue-78-python-packaging-20260614` | `documentation/workflow/issues/issue-78/workflow.md` | `feature/workflow-issue-78-python-packaging-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 3 | #64 | Honor backend selection order | `issue-64-backend-selection-order-20260614` | `documentation/workflow/issues/issue-64/workflow.md` | `feature/workflow-issue-64-backend-selection-order-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 4 | #65 | Make resource mapping backend aware | `issue-65-backend-resource-mapping-20260614` | `documentation/workflow/issues/issue-65/workflow.md` | `feature/workflow-issue-65-backend-resource-mapping-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 5 | #69 | Use host-specific evidence directories | `issue-69-host-evidence-directories-20260614` | `documentation/workflow/issues/issue-69/workflow.md` | `feature/workflow-issue-69-host-evidence-directories-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 6 | #68 | Replace piped installer approval with explicit flag | `issue-68-explicit-live-approval-20260614` | `documentation/workflow/issues/issue-68/workflow.md` | `feature/workflow-issue-68-explicit-live-approval-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 7 | #81 | Make install.sh complete without requiring the console TUI | `issue-81-headless-install-20260614` | `documentation/workflow/issues/issue-81/workflow.md` | `feature/workflow-issue-81-headless-install-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 8 | #67 | Move install logic from shell to Python | `issue-67-python-installer-20260614` | `documentation/workflow/issues/issue-67/workflow.md` | `feature/workflow-issue-67-python-installer-20260614` | issue-68, issue-69, issue-81 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 9 | #76 | Define configuration value ownership | `issue-76-configuration-value-ownership-20260614` | `documentation/workflow/issues/issue-76/workflow.md` | `feature/workflow-issue-76-configuration-value-ownership-20260614` | issue-67, issue-68 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 10 | #70 | Clarify command runner responsibility | `issue-70-command-runner-responsibility-20260614` | `documentation/workflow/issues/issue-70/workflow.md` | `feature/workflow-issue-70-command-runner-responsibility-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 11 | #71 | Remove placeholder automation runner | `issue-71-disable-ansible-runner-20260614` | `documentation/workflow/issues/issue-71/workflow.md` | `feature/workflow-issue-71-disable-ansible-runner-20260614` | issue-70 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 12 | #72 | Implement or disable REST command runner | `issue-72-rest-runner-decision-20260614` | `documentation/workflow/issues/issue-72/workflow.md` | `feature/workflow-issue-72-rest-runner-decision-20260614` | issue-70 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 13 | #74 | Make preflight provider aware | `issue-74-provider-aware-preflight-20260614` | `documentation/workflow/issues/issue-74/workflow.md` | `feature/workflow-issue-74-provider-aware-preflight-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 14 | #66 | Strengthen platform verify checks | `issue-66-platform-verify-checks-20260614` | `documentation/workflow/issues/issue-66/workflow.md` | `feature/workflow-issue-66-platform-verify-checks-20260614` | issue-74 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 15 | #77 | Decouple deployment gateway adapter | `issue-77-deployment-gateway-port-20260614` | `documentation/workflow/issues/issue-77/workflow.md` | `feature/workflow-issue-77-deployment-gateway-port-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 16 | #73 | Split oversized composition root | `issue-73-split-composition-root-20260614` | `documentation/workflow/issues/issue-73/workflow.md` | `feature/workflow-issue-73-split-composition-root-20260614` | issue-64, issue-65, issue-74, issue-77 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 17 | #83 | Define the status and evidence contract consumed by the console UI | `issue-83-ui-status-evidence-contract-20260614` | `documentation/workflow/issues/issue-83/workflow.md` | `feature/workflow-issue-83-ui-status-evidence-contract-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+| 18 | #82 | Add architecture tests that keep the console UI presentation-only | `issue-82-ui-presentation-arch-tests-20260614` | `documentation/workflow/issues/issue-82/workflow.md` | `feature/workflow-issue-82-ui-presentation-arch-tests-20260614` | issue-83 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 19 | #80 | Decouple command execution from the console UI adapter | `issue-80-ui-execution-decoupling-20260614` | `documentation/workflow/issues/issue-80/workflow.md` | `feature/workflow-issue-80-ui-execution-decoupling-20260614` | issue-83, issue-82 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 20 | #75 | Clarify status display purpose | `issue-75-status-display-purpose-20260614` | `documentation/workflow/issues/issue-75/workflow.md` | `feature/workflow-issue-75-status-display-purpose-20260614` | issue-83, issue-82 | AUTHORED_INDEXED_NOT_ACTIVE |
+| 21 | #63 | Align reconcile workflow semantics | `issue-63-reconcile-semantics-20260614` | `documentation/workflow/issues/issue-63/workflow.md` | `feature/workflow-issue-63-reconcile-semantics-20260614` | none | AUTHORED_INDEXED_NOT_ACTIVE |
+
+## Excluded Issues
+
+| Issue | Title | Reason |
+|---:|---|---|
+| #5 | Collect information in structured format | Excluded by user decision and blocked by the Requirement Clarification Gate; source, target format, persistence, interface, and acceptance criteria are missing. |
+| #7 | Testen | Excluded by user decision and blocked by the Requirement Clarification Gate; the issue body is the unchanged feature template and contains no actionable requirement. |
+
+## Execution Sequencing Notes
+
+- `#83` should execute before `#82`, `#80`, and `#75` because it defines the
+  status/evidence contract consumed by console UI work.
+- `#70` should execute before `#71` and `#72` because it defines command runner
+  responsibility.
+- `#68`, `#69`, and `#81` should execute before or alongside `#67` because the
+  Python installer migration depends on consent, evidence path, and headless
+  installation semantics.
+- `#64`, `#65`, `#74`, and `#77` should execute before `#73` where practical to
+  reduce composition-root merge conflicts.
+- Live validation remains serialized for all workflows unless isolated live
+  infrastructure is explicitly approved.
+
+## Quality Expectations
+
+Workflow authoring:
+
+```bash
+git diff --check
+```
+
+Workflow execution for promoted workflows:
+
+```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+## Governance Notes
+
+- Root `AGENTS.md` and `QUALITY.md` remain authoritative.
+- The multi-issue layout is governed by `.agents/skills/workflow-authoring/SKILL.md`.
+- `#5` and `#7` are intentionally excluded by user decision and because their
+  requirements are not actionable enough for executable workflow authoring.


### PR DESCRIPTION
## Summary

- Add a multi-issue workflow index so issue-local workflows do not overwrite the active `documentation/workflow/workflow.md`.
- Add indexed workflows and context packs for Issues #4, #63-#78, and #80-#83.
- Exclude Issues #5 and #7 in the index because they are blocked by the requirement clarification gate.
- Extend the workflow-authoring skill with the indexed multi-issue layout rule.

## Validation

- `git diff --check`
- JSON context packs parsed successfully with local Python launcher

## Notes

This PR preserves the existing active workflow file. Unqualified `workflow execute` must not guess from the index; an indexed workflow must be promoted or selected explicitly before execution.