### PR TITLE
[codex] Validate Docker Swarm stack compose files

### DIFF
--- a/.codex/evidence/slice-01-consolidation.md
+++ b/.codex/evidence/slice-01-consolidation.md
@@ -1,0 +1,54 @@
+# Slice 01 Consolidation: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S01`
+
+## Stream Results
+
+- Documentation stream recorded the validation baseline and selected rule.
+- Architecture stream confirmed YAML parsing and stack-file validation belong
+  in the infrastructure repository adapter boundary.
+- Tests stream identified
+  `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
+  as the focused regression target for Slice 02.
+
+## Accepted Findings
+
+- Product compose files are structured configuration and should fail closed
+  before live deployment if they are not valid Swarm stack files.
+- The validation rule should require `deploy` per service rather than one
+  token anywhere in the file.
+- Existing committed stack files appear compatible with the selected rule.
+
+## Rejected Findings
+
+- Running live Docker stack validation was rejected for this slice because the
+  requirement can be proven with structured YAML tests and repository fixtures.
+
+## Files Changed
+
+- `.codex/evidence/slice-01-distribution.md`
+- `.codex/evidence/slice-01-consolidation.md`
+- `documentation/workflow/issues/issue-4/swarm-stack-validation-baseline.md`
+
+## Conflicts
+
+No file conflicts were found in Slice 01.
+
+## Tests Executed
+
+- `git diff --check`
+- Active workflow YAML metadata parse check
+
+## SonarQube
+
+No SonarQube findings were produced locally. Remote checks run during the PR
+publication phase.
+
+## Documentation Updates
+
+Baseline decision recorded under the Issue #4 workflow directory.
+
+## Final Integration Decision
+
+Slice 01 is complete. Continue with Slice 02 after checkpoint commit.

--- a/.codex/evidence/slice-01-distribution.md
+++ b/.codex/evidence/slice-01-distribution.md
@@ -1,0 +1,57 @@
+# Slice 01 Distribution: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S01`
+Slice title: Requirement, repository baseline, and decision gate
+
+## Affected Areas
+
+- `infra/config/compose/**`
+- `src/tiny_swarm_world/domain/deployment/**`
+- `src/tiny_swarm_world/application/services/deployment/**`
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py`
+- `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
+- `documentation/workflow/issues/issue-4/**`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not spawned for this slice because the slice is a small
+baseline and decision-gate step with overlapping documentation and repository
+inspection. Role-based fallback review is used in the main execution thread.
+
+## Selected Streams
+
+- documentation
+- architecture
+- tests
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-4-swarm-stack-validation
+```
+
+No additional stream worktrees are used for Slice 01.
+
+## Conflict Risks
+
+- Later implementation touches compose repository tests and repository adapter
+  behavior.
+- No live infrastructure state is required.
+- All product compose files already contain at least one `deploy:` section.
+
+## Quality Gates
+
+- `git diff --check`
+- YAML metadata parse check for the active workflow.
+
+## Consolidation Plan
+
+Commit the baseline and decision evidence as a Slice 01 checkpoint. Continue
+to Slice 02 only with a clean worktree.

--- a/.codex/evidence/slice-02-consolidation.md
+++ b/.codex/evidence/slice-02-consolidation.md
@@ -1,0 +1,62 @@
+# Slice 02 Consolidation: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S02`
+
+## Stream Results
+
+- Backend stream added structured Swarm stack validation in
+  `ComposeFileRepositoryYaml`.
+- Test stream updated compose fixtures to represent Swarm stack files and added
+  negative tests for invalid stack definitions.
+
+## Accepted Findings
+
+- The validation belongs at the YAML repository boundary because that adapter
+  owns structured YAML parsing.
+- A compose stack file must have a non-empty mapping-valued `services` section.
+- Every service must define a mapping-valued `deploy` section before the stack
+  can be returned to deployment services.
+- Current committed product stack files remain valid under this rule.
+
+## Rejected Findings
+
+- Live Docker or `docker stack config` validation was rejected because default
+  verification must remain non-mutating and deterministic.
+
+## Files Changed
+
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py`
+- `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
+- `.codex/evidence/slice-02-distribution.md`
+- `.codex/evidence/slice-02-consolidation.md`
+
+## Conflicts
+
+No file conflicts were found in Slice 02.
+
+## Tests Executed
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml
+python3 tools/quality_gate.py test
+```
+
+Results:
+
+- Focused compose repository tests: 32 tests passed.
+- Repository test gate: 833 tests passed, 17 skipped.
+
+## SonarQube
+
+No local SonarQube scan was run. Remote PR checks will provide the configured
+repository CI/SonarCloud result.
+
+## Documentation Updates
+
+No operator documentation changed in this slice. The Slice 01 baseline records
+the selected validation boundary.
+
+## Final Integration Decision
+
+Slice 02 is complete. Continue with Slice 03 after checkpoint commit.

--- a/.codex/evidence/slice-02-distribution.md
+++ b/.codex/evidence/slice-02-distribution.md
@@ -1,0 +1,54 @@
+# Slice 02 Distribution: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S02`
+Slice title: Scoped implementation inside the declared architecture boundary
+
+## Affected Areas
+
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py`
+- `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not used. The implementation is tightly scoped to one
+infrastructure adapter and one focused test module, so role-based fallback
+review is recorded in this evidence.
+
+## Selected Streams
+
+- backend
+- tests
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-4-swarm-stack-validation
+```
+
+No additional stream worktrees are used for Slice 02 because implementation and
+tests touch coupled files.
+
+## Conflict Risks
+
+- Existing tests use minimal compose fixtures that are not Swarm stack-valid
+  once per-service `deploy` validation is introduced.
+- Product compose files are expected to stay unchanged.
+
+## Quality Gates
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml`
+- `python3 tools/quality_gate.py test`
+- `git diff --check`
+
+## Consolidation Plan
+
+Add repository-boundary validation, update fixtures to represent Swarm stack
+files, run focused tests, then record Slice 02 consolidation evidence before
+committing.

--- a/.codex/evidence/slice-03-consolidation.md
+++ b/.codex/evidence/slice-03-consolidation.md
@@ -1,0 +1,55 @@
+# Slice 03 Consolidation: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S03`
+
+## Stream Results
+
+- Tests stream confirmed focused regression tests passed in Slice 02.
+- Architecture stream verified hexagonal import guardrails after the
+  infrastructure adapter validation change.
+
+## Accepted Findings
+
+- YAML parsing remains in infrastructure.
+- Domain and application layers did not gain YAML parser or infrastructure
+  dependencies.
+- The selected validation boundary is compatible with existing architecture
+  tests.
+
+## Rejected Findings
+
+- No live validation was run; it is unnecessary for this static repository
+  validation feature.
+
+## Files Changed
+
+- `.codex/evidence/slice-03-distribution.md`
+- `.codex/evidence/slice-03-consolidation.md`
+
+## Conflicts
+
+No conflicts found.
+
+## Tests Executed
+
+```bash
+python3 tools/quality_gate.py arch-tests
+```
+
+Result:
+
+- 16 architecture tests passed.
+
+## SonarQube
+
+No local SonarQube scan was run. Remote PR checks will provide the configured
+repository CI/SonarCloud result.
+
+## Documentation Updates
+
+No product documentation changes were required in this slice.
+
+## Final Integration Decision
+
+Slice 03 is complete. Continue with Slice 04 after checkpoint commit.

--- a/.codex/evidence/slice-03-distribution.md
+++ b/.codex/evidence/slice-03-distribution.md
@@ -1,0 +1,48 @@
+# Slice 03 Distribution: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S03`
+Slice title: Focused regression and architecture tests
+
+## Affected Areas
+
+- `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
+- `tests/architecture/test_hexagonal_imports.py`
+- `.codex/evidence/**`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not used. The slice is a verification slice over the
+already committed implementation and uses role-based fallback review.
+
+## Selected Streams
+
+- tests
+- architecture
+- quality
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-4-swarm-stack-validation
+```
+
+## Conflict Risks
+
+No implementation files are changed in this slice. The main risk is an
+architecture regression introduced by Slice 02.
+
+## Quality Gates
+
+- `python3 tools/quality_gate.py arch-tests`
+- `git diff --check`
+
+## Consolidation Plan
+
+Run architecture tests, record results, and commit evidence only.

--- a/.codex/evidence/slice-04-consolidation.md
+++ b/.codex/evidence/slice-04-consolidation.md
@@ -1,0 +1,60 @@
+# Slice 04 Consolidation: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S04`
+
+## Stream Results
+
+- Quality stream ran the full repository quality gate.
+- Documentation stream updated workflow closeout evidence.
+
+## Accepted Findings
+
+- Full quality gate passed after the Swarm stack compose validation change.
+- Architecture boundaries remain intact.
+- No product compose file needed modification because current committed stack
+  files already satisfy the per-service `deploy` rule.
+
+## Rejected Findings
+
+- No live deployment validation was run. The issue is covered by static
+  structured YAML validation and unit tests.
+
+## Files Changed
+
+- `.codex/evidence/slice-04-distribution.md`
+- `.codex/evidence/slice-04-consolidation.md`
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+
+## Conflicts
+
+No conflicts found.
+
+## Tests Executed
+
+```bash
+python3 tools/quality_gate.py quality
+```
+
+Result:
+
+- `lint`: passed.
+- `arch-lint`: passed, 3 contracts kept.
+- `arch-tests`: passed, 16 tests.
+- `typecheck`: passed, 390 source files.
+- `test`: passed, 833 tests, 17 skipped.
+
+## SonarQube
+
+No local SonarQube scan was run. Remote PR checks will provide the configured
+repository CI/SonarCloud result.
+
+## Documentation Updates
+
+Workflow closeout evidence was added to the active workflow and context pack.
+
+## Final Integration Decision
+
+Issue #4 workflow execution is complete and ready for push/PR lifecycle.

--- a/.codex/evidence/slice-04-distribution.md
+++ b/.codex/evidence/slice-04-distribution.md
@@ -1,0 +1,49 @@
+# Slice 04 Distribution: Issue 4 Swarm Stack Validation
+
+Workflow id: `issue-4-swarm-stack-validation-20260614`
+Slice id: `S04`
+Slice title: Documentation synchronization and final quality evidence
+
+## Affected Areas
+
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `.codex/evidence/**`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not used. This closeout slice consolidates verification
+evidence in the main execution thread.
+
+## Selected Streams
+
+- documentation
+- quality
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-4-swarm-stack-validation
+```
+
+## Conflict Risks
+
+No product code changes are expected in this slice. The full quality gate may
+surface repository-wide issues that must be classified before push.
+
+## Quality Gates
+
+- `python3 tools/quality_gate.py quality`
+- `git diff --check`
+
+## Consolidation Plan
+
+Run full quality, update active workflow closeout evidence, record
+consolidation, and commit the final workflow closeout slice.

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,170 +1,58 @@
 {
+  "workflow_id": "issue-4-swarm-stack-validation-20260614",
+  "workflow_version": "1.0.0",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4",
+  "issue_number": 4,
+  "workflow_path": "documentation/workflow/issues/issue-4/workflow.md",
+  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
+  "execution_profile": "NORMAL_PATH",
+  "status": "ACTIVE_READY_FOR_WORKFLOW_EXECUTE",
+  "created_utc": "2026-06-14T00:00:00Z",
+  "dependencies": [],
   "affected_areas": [
-    "documentation/workflow/**",
-    "documentation/configuration/**",
-    "src/tiny_swarm_world/domain/configuration/**",
-    "src/tiny_swarm_world/application/services/configuration/**",
-    "src/tiny_swarm_world/application/ports/configuration/**",
-    "src/tiny_swarm_world/infrastructure/adapters/configuration/**",
-    "src/tiny_swarm_world/infrastructure/composition.py",
-    "infra/config/**",
+    "infra/config/compose/**",
+    "src/tiny_swarm_world/domain/deployment/**",
+    "src/tiny_swarm_world/application/services/deployment/**",
     "tests/**",
-    "README.md",
-    "documentation/deployment/**",
-    "documentation/user_guide/**",
-    "documentation/arc42/**",
-    ".codex/evidence/slice-*-distribution.md",
-    ".codex/evidence/slice-*-consolidation.md"
+    "documentation/**"
   ],
-  "branch": "feature/workflow-config-contracts-20260613",
-  "conditional_roles": [
-    "ADR Steward",
-    "Quality Gate Orchestrator",
-    "Documentation Sync",
-    "Platform Quality Gates"
-  ],
-  "created_utc": "2026-06-13T00:00:00Z",
-  "execution_profile": "FULL_PATH",
   "forbidden_areas": [
     "Java/Maven/Spring Boot",
-    "React/TypeScript/Vite frontend project setup",
+    "React/TypeScript/Vite frontend setup",
     "Kubernetes-first deployment",
-    "Windows-native setup examples",
-    "committed secrets or local runtime env files",
-    "generated live evidence or logs",
-    "live infrastructure commands without explicit consent"
+    "Multipass provider reintroduction",
+    "Windows-native behavior",
+    "committed secrets",
+    "live infrastructure without explicit approval"
   ],
-  "governing_files": [
-    {
-      "path": "AGENTS.md",
-      "sha256": "e95f7cb81cbc70823de6ea09c620a4bb2d1e91a72f17ac990f1b9830c7ade603"
-    },
-    {
-      "path": "QUALITY.md",
-      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
-    },
-    {
-      "path": "documentation/epics/autonomous-runnable-setup.md",
-      "sha256": "026a1c3349d19601b8b0d3733649206b9b53a0c5a0536b086dbe62feffbc6307"
-    },
-    {
-      "path": "documentation/epics/system-unification.md",
-      "sha256": "7ccaf0165a53fa3393a8bfbf8d0973e67d542cf4b24d661a234f72dec9e9f152"
-    },
-    {
-      "path": "documentation/architecture/adr-autonomous-setup-safety.adoc",
-      "sha256": "0e6c48917d1550330b15a9a70c44eb7db5c937f96c29b6a7abafb3c7214c2d3d"
-    },
-    {
-      "path": "documentation/architecture/adr-service-access-dashboard-vaultwarden.adoc",
-      "sha256": "aa54aba46e870c27fe6c8cc80f64cf50100d7c8726f28de0b89beabbc86913c9"
-    },
-    {
-      "path": "documentation/arc42/05_building_blocks.adoc",
-      "sha256": "fc41d9cdf52080355de9467799e123ac9121577ac90ec97f973c9347a4414e61"
-    },
-    {
-      "path": "documentation/arc42/06_runtime_view.adoc",
-      "sha256": "df8d4e3d1f9ecae07f614f4ab3b270b9ab4cf87294ac64f53fe04faedcca166f"
-    },
-    {
-      "path": "documentation/arc42/10_quality_requirements.adoc",
-      "sha256": "0856922c1ab9967003993020f9ed932d1d119119055b09a8c047fdc6818d5fd4"
-    },
-    {
-      "path": ".agents/skills/workflow-authoring/SKILL.md",
-      "sha256": "4711371208cabc8102c3a308ceab8349af90baef908b23eb633c7f3a14ba8b5a"
-    },
-    {
-      "path": "documentation/workflow/workflow.md",
-      "sha256": "8bcd911d0089c66cee62baa5845ee4c092c12c72a2460e57ffac64d0956636a0"
-    }
-  ],
-  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/24",
-  "process_strand": [
-    "workflow-authoring",
-    "configuration-governance",
-    "python-automation",
-    "platform-preflight",
-    "deployment-setup-safety",
-    "documentation-sync",
-    "automatic-work-distribution",
-    "git-worktree-stream-isolation",
-    "commit-and-push"
-  ],
-  "quality_commands": [
-    "git diff --check",
-    "PYTHONPATH=src python3 -m unittest tests.domain.configuration",
-    "PYTHONPATH=src python3 -m unittest tests.application.services.configuration",
-    "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration",
-    "PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service",
-    "PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition",
-    "PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene",
-    "python3 tools/quality_gate.py quality"
-  ],
-  "released_for_workflow_execute": true,
   "required_roles": [
     "Senior Requirement Engineer",
     "Senior System Architect",
     "Senior Python Automation Developer",
     "Senior React Frontend Developer",
     "Senior Tester",
-    "Senior Documentation Engineer",
-    "Senior Security Sandbox Engineer"
+    "Senior Documentation Engineer"
   ],
-  "workflow_id": "config-contract-validation-issue-24-20260613",
-  "workflow_version": "1.0.0",
-  "execution_closeout": {
-    "status": "COMPLETED_WITH_EVIDENCE",
-    "slice_commits": [
-      {
-        "slice_id": "S01",
-        "commit": "c819847",
-        "evidence": "configuration surface inventory"
-      },
-      {
-        "slice_id": "S02",
-        "commit": "9bb2f75",
-        "evidence": "typed configuration contract"
-      },
-      {
-        "slice_id": "S03",
-        "commit": "7ca805d",
-        "evidence": "operator configuration sources"
-      },
-      {
-        "slice_id": "S04",
-        "commit": "57f36dd",
-        "evidence": "preflight contract validation"
-      },
-      {
-        "slice_id": "S05",
-        "commit": "a0f8741",
-        "evidence": "template and operator documentation"
-      }
-    ],
-    "acceptance_mapping": {
-      "config_schema_validates_before_execution": [
-        "src/tiny_swarm_world/domain/configuration/configuration_contract.py",
-        "src/tiny_swarm_world/application/services/configuration/configuration_validation_service.py",
-        "src/tiny_swarm_world/application/services/platform/preflight_service.py",
-        "src/tiny_swarm_world/infrastructure/composition.py"
-      ],
-      "example_template_provided": [
-        ".env.example"
-      ],
-      "overrides_documented": [
-        "documentation/configuration/operator-configuration-contract.md",
-        "README.md",
-        "documentation/user_guide/installation.adoc",
-        "documentation/deployment/system.adoc",
-        "documentation/user_guide/usage.adoc"
-      ]
+  "quality_commands": [
+    "git diff --check",
+    "python3 tools/quality_gate.py test",
+    "python3 tools/quality_gate.py arch-tests",
+    "python3 tools/quality_gate.py quality"
+  ],
+  "governing_files": [
+    {
+      "path": "AGENTS.md",
+      "sha256": "e2a689e25890138e7a383e2b50efe5094f8ae6a878ce0d84682e32e74fdade71"
     },
-    "final_quality_gate": {
-      "command": ".venv/bin/python tools/quality_gate.py quality",
-      "status": "passed",
-      "note": "System python3 quality attempt stopped because Ruff was not installed for system Python."
+    {
+      "path": "QUALITY.md",
+      "sha256": "458e5f4d8fbdedea1c413e1ff135ec91392a4bb5a5aea20300dcac8e209414b6"
+    },
+    {
+      "path": ".agents/skills/workflow-authoring/SKILL.md",
+      "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
     }
-  }
+  ]
 }

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -8,7 +8,7 @@
   "branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
   "proposed_execution_branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
   "execution_profile": "NORMAL_PATH",
-  "status": "ACTIVE_READY_FOR_WORKFLOW_EXECUTE",
+  "status": "COMPLETED_WITH_EVIDENCE",
   "created_utc": "2026-06-14T00:00:00Z",
   "dependencies": [],
   "affected_areas": [
@@ -54,5 +54,35 @@
       "path": ".agents/skills/workflow-authoring/SKILL.md",
       "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
     }
-  ]
+  ],
+  "execution_closeout": {
+    "status": "COMPLETED_WITH_EVIDENCE",
+    "slice_commits": [
+      {
+        "slice_id": "S01",
+        "commit": "ec24db3",
+        "evidence": "baseline and decision gate"
+      },
+      {
+        "slice_id": "S02",
+        "commit": "fa0744d",
+        "evidence": "compose repository validation and tests"
+      },
+      {
+        "slice_id": "S03",
+        "commit": "920dc94",
+        "evidence": "architecture validation"
+      },
+      {
+        "slice_id": "S04",
+        "commit": "pending",
+        "evidence": "final quality closeout"
+      }
+    ],
+    "final_quality_gate": {
+      "command": "python3 tools/quality_gate.py quality",
+      "status": "passed",
+      "tests": "833 passed, 17 skipped"
+    }
+  }
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,122 +1,15 @@
-# Workflow Context Pack
+# Context Pack: Issue #4 Validate Docker Swarm stack definitions
 
-Workflow: `config-contract-validation-issue-24-20260613`
-Version: `1.0.0`
-Branch: `feature/workflow-config-contracts-20260613`
-Profile: `FULL_PATH`
-Issue: `https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/24`
+- Workflow id: `issue-4-swarm-stack-validation-20260614`
+- Workflow path: `documentation/workflow/issues/issue-4/workflow.md`
+- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Active execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
+- Proposed execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
+- Execution profile:
+ORMAL_PATH`
+- Status: `ACTIVE_READY_FOR_WORKFLOW_EXECUTE`
+- Dependencies: none
+- Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
+  `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
 
-## Purpose
-
-Navigation aid for the active Issue #24 configuration contract workflow. This
-file does not replace `AGENTS.md`, `QUALITY.md`, ADRs, arc42, routing rules,
-role files, skill files, or `documentation/workflow/workflow.md`.
-
-## Process Strand
-
-- Workflow authoring
-- Configuration governance
-- Python automation
-- Platform preflight
-- Deployment setup safety
-- Documentation synchronization
-- Automatic workflow execute work distribution
-- Git worktree stream isolation
-- Commit and push publication
-
-## Affected Areas
-
-- `documentation/workflow/**`
-- Future `documentation/configuration/**`
-- Future `src/tiny_swarm_world/domain/configuration/**`
-- Future `src/tiny_swarm_world/application/services/configuration/**`
-- Future `src/tiny_swarm_world/application/ports/configuration/**`
-- Future `src/tiny_swarm_world/infrastructure/adapters/configuration/**`
-- Future `src/tiny_swarm_world/infrastructure/composition.py`
-- Future `infra/config/**`
-- Future `tests/**`
-- Future README, deployment, user guide, and arc42 documentation
-- Future `.codex/evidence/slice-*-distribution.md`
-- Future `.codex/evidence/slice-*-consolidation.md`
-
-## Forbidden Areas
-
-- Java, Maven, Spring Boot project structure
-- React, TypeScript, Vite, TSX/JSX frontend project setup
-- Kubernetes-first deployment model
-- Windows-native setup examples for normal operation
-- Committed secrets, passwords, tokens, local env files, generated evidence,
-  logs, local IP addresses, user names, host-specific paths, or raw environment
-  payloads
-- Live LXD, Incus, LXC, Docker Swarm, compose deployment, or service bootstrap
-  commands without explicit live consent
-
-## Required Roles
-
-- Senior Requirement Engineer
-- Senior System Architect
-- Senior Python Automation Developer
-- Senior React Frontend Developer
-- Senior Tester
-- Senior Documentation Engineer
-- Senior Security Sandbox Engineer
-
-## Conditional Roles
-
-- ADR Steward
-- Quality Gate Orchestrator
-- Documentation Sync
-- Platform Quality Gates
-
-## Quality Commands
-
-Workflow creation:
-
-```bash
-git diff --check
-```
-
-Workflow execution targeted checks:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.domain.configuration
-PYTHONPATH=src python3 -m unittest tests.application.services.configuration
-PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration
-PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service
-PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition
-PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene
-```
-
-Required before merge when practical:
-
-```bash
-python3 tools/quality_gate.py quality
-```
-
-Execution closeout used the repository-local development environment because
-system `python3` did not have Ruff installed:
-
-```bash
-.venv/bin/python tools/quality_gate.py quality
-```
-
-No live infrastructure command is part of this workflow by default.
-
-## Execution Evidence
-
-Status: `COMPLETED_WITH_EVIDENCE`
-
-Pushed slice commits:
-
-- `c819847` - S01 configuration surface inventory.
-- `9bb2f75` - S02 typed configuration contract.
-- `7ca805d` - S03 operator configuration sources.
-- `57f36dd` - S04 preflight contract validation.
-- `a0f8741` - S05 template and operator documentation.
-
-Issue #24 acceptance criteria are mapped in
-`documentation/workflow/workflow.md`.
-
-## Hash Provenance
-
-See `context-pack.json` for recorded file hashes.
+Governing hashes are recorded in `context-pack.json`.

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -7,9 +7,17 @@
 - Proposed execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
 - Execution profile:
 ORMAL_PATH`
-- Status: `ACTIVE_READY_FOR_WORKFLOW_EXECUTE`
+- Status: `COMPLETED_WITH_EVIDENCE`
 - Dependencies: none
 - Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
   `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
 
 Governing hashes are recorded in `context-pack.json`.
+
+Execution closeout:
+
+- S01: `ec24db3`
+- S02: `fa0744d`
+- S03: `920dc94`
+- S04: pending final checkpoint commit
+- Final quality gate: `python3 tools/quality_gate.py quality` passed.

--- a/documentation/workflow/issues/issue-4/swarm-stack-validation-baseline.md
+++ b/documentation/workflow/issues/issue-4/swarm-stack-validation-baseline.md
@@ -1,0 +1,61 @@
+# Issue 4 Swarm Stack Validation Baseline
+
+## Decision
+
+Issue #4 is implemented as repository-level validation of product compose stack
+files loaded through `ComposeFileRepositoryYaml`.
+
+The selected rule is:
+
+- a stack compose file must define a mapping-valued top-level `services`
+  section;
+- each service in that mapping must define a mapping-valued `deploy` section;
+- invalid stack compose files fail before deployment clients or live Docker
+  commands are reached.
+
+This is stricter than checking that a file contains one `deploy:` token. It
+matches Docker Swarm stack intent better because each deployable service should
+carry stack deployment metadata.
+
+## Repository Evidence
+
+Current product compose files:
+
+- `infra/config/compose/infisical/docker-compose.yml`
+- `infra/config/compose/jenkins/docker-compose.yml`
+- `infra/config/compose/nexus/docker-compose.yml`
+- `infra/config/compose/portainer/docker-compose.yml`
+- `infra/config/compose/rabbitmq/docker-compose.yml`
+- `infra/config/compose/service-access/docker-compose.yml`
+- `infra/config/compose/sonarqube/docker-compose.yml`
+- `infra/config/compose/swagger/docker-compose.yml`
+- `infra/config/compose/traefik/docker-compose.yml`
+
+All current product stack files already include `deploy:` sections. Existing
+tests for `ComposeFileRepositoryYaml` already parse these files and assert
+service names, published ports, stack contracts, Traefik labels, and packaged
+service-access assets.
+
+## Implementation Target
+
+Add validation at the infrastructure repository boundary that reads structured
+YAML and returns `StackDefinition`. This keeps YAML parsing in infrastructure,
+keeps deployment application services dependent on ports, and fails before
+Portainer or Swarm runtime adapters can apply an invalid stack file.
+
+## Non-Goals
+
+- No live Docker, Docker Swarm, Portainer, Nexus, or LXC operation.
+- No compose file rewrite unless a fixture or product file is proven invalid.
+- No Java, Maven, Spring Boot, React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+
+## Next Slice
+
+Slice 02 should add the validation behavior and focused tests for:
+
+- missing top-level `services`;
+- non-mapping `services`;
+- a service missing `deploy`;
+- a service with non-mapping `deploy`;
+- current committed stack files remaining valid.

--- a/documentation/workflow/issues/issue-4/workflow.md
+++ b/documentation/workflow/issues/issue-4/workflow.md
@@ -200,8 +200,7 @@ affected_modules:
   - deployment configuration validation
 affected_contracts:
   - issue_4_swarm_stack_validation
-dependencies:
-  []
+dependencies: []
 parallel_group: issue-4-group-1
 file_locks:
   - documentation/workflow/issues/issue-4/**
@@ -214,10 +213,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -279,10 +278,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -340,10 +339,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -399,10 +398,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -546,6 +546,41 @@ Issue #4 implementation is done when acceptance criteria are satisfied
 by scoped code, tests, documentation, quality evidence, and merge-ready
 review.
 
+## Workflow Execution Evidence
+
+Execution status: `COMPLETED_WITH_EVIDENCE`.
+
+Slice checkpoint commits:
+
+| Slice | Commit | Evidence |
+|---|---|---|
+| S01 | `ec24db3` | Baseline and decision gate for per-service `deploy` validation. |
+| S02 | `fa0744d` | `ComposeFileRepositoryYaml` validates Swarm stack compose files and focused tests cover invalid definitions. |
+| S03 | `920dc94` | Architecture validation evidence confirms hexagonal boundaries remain intact. |
+
+Issue #4 acceptance mapping:
+
+- Valid Docker Swarm stack detection: product compose files are loaded through
+  structured YAML and must define a non-empty `services` mapping.
+- `deploy:` section present: each service returned by the compose repository
+  must define a mapping-valued `deploy` section.
+- Failure before live mutation: invalid compose files raise `ValueError` at the
+  repository boundary before Portainer or Swarm runtime adapters are called.
+
+Verification evidence:
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
+python3 tools/quality_gate.py quality
+```
+
+Final quality result:
+
+- `python3 tools/quality_gate.py quality` passed.
+- 833 repository tests passed, 17 skipped.
+
 ## Handoff To Workflow Execute
 
 Run `workflow execute` from this branch and this worktree. The executor must verify S3/S3D metadata, locks, evidence, targeted checks, and quality gates before implementation.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,974 +1,558 @@
-# Workflow: Configuration Contract Validation For Issue 24
+# Workflow: Validate Docker Swarm stack definitions
 
 ```yaml
-workflow_id: config-contract-validation-issue-24-20260613
+workflow_id: issue-4-swarm-stack-validation-20260614
 workflow_version: 1.0.0
-branch: feature/workflow-config-contracts-20260613
-execution_profile: FULL_PATH
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4
+issue_number: 4
+authoring_branch: feature/workflow-index-open-issues-20260614
+branch: feature/workflow-issue-4-swarm-stack-validation-20260614
+proposed_execution_branch: feature/workflow-issue-4-swarm-stack-validation-20260614
+indexed_workflow: true
+active_workflow: true
+execution_profile: NORMAL_PATH
 released_for_workflow_execute: true
-created_utc: "2026-06-13T00:00:00Z"
-issue: "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/24"
-request: "Create a workflow for Issue #24, Configuration contracts are implicit and unvalidated, and push it."
-decision: READY_FOR_WORKFLOW
-confidence: 92
+created_utc: "2026-06-14T00:00:00Z"
+decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
+confidence: 75
+dependencies: []
 ```
 
 ## Executive Summary
 
-Issue #24 reports that required configuration parameters are implicit,
-partially hardcoded, and not validated through a single documented contract.
-The repository already has important pieces: node-provider YAML validation,
-command catalog validation, setup-manifest secret requirements, and guarded
-preflight checks. The gap is that the full operator-facing configuration
-surface is not inventoried, not exposed through a versioned template, and not
-validated consistently before live setup or deployment paths consume it.
+Validate compose files as Docker Swarm stack definitions and fail when stack-only requirements such as deploy sections are missing.
 
-This workflow creates an executable implementation plan for a typed
-configuration contract. The target is deliberately small and fail-closed:
-inventory the current config surface, add a typed contract for supported
-`TSW_*` settings and product YAML files, provide a tracked example template,
-wire validation into static and live preflight before mutation, update
-operator documentation, and prove behavior with focused unit tests plus the
-repository quality gate.
-
-No live LXD, Incus, LXC, Docker Swarm, compose deployment, Portainer, Nexus,
-Jenkins, RabbitMQ, SonarQube, Infisical, Traefik, or browser smoke run is part
-of workflow creation. Future workflow execution must keep those operations
-mocked unless the user explicitly grants live infrastructure consent.
+This workflow has been promoted from the indexed workflow set and is active for `workflow execute` on branch `feature/workflow-issue-4-swarm-stack-validation-20260614`.
 
 ## Requirement Clarification Gate
 
 Original request:
 
-- Create and push a workflow for GitHub Issue #24.
-- The referenced local `.tiny-swarm-world/local/live-installation.env` is a
-  local runtime secret file and must not be committed.
+- Create workflows for all open GitHub issues except Issue #5 and Issue #7.
+- Use `workflow.index.md` so multiple `workflow.md` files do not overwrite
+  each other.
+- Use subagents for workflow creation analysis.
 
 Interpreted intent:
 
-- Replace the active workflow under `documentation/workflow` with a
-  repository-compliant workflow for Issue #24.
-- Make the workflow ready for `workflow execute`.
-- Keep changes limited to workflow documentation in this commit.
-- Push the workflow branch after commit.
+- Create an executable workflow plan for Issue #4: Validate Docker Swarm stack definitions.
+- Defer implementation until all indexed workflows are authored and the
+  execution order is selected from `workflow.index.md`.
 
 Change type:
 
-- Workflow creation.
-- Future Python automation changes.
-- Future configuration contract and preflight behavior changes.
-- Future documentation and example-template changes.
+- Workflow creation for future deployment configuration validation work.
 
 Affected process strand:
 
-- Workflow authoring.
-- Future workflow execution.
-- Configuration governance.
-- Platform preflight.
-- Deployment and setup safety.
-- Documentation synchronization.
+- deployment configuration validation.
+- Workflow execution with S3/S3D validation.
+- Documentation and quality-gate synchronization.
 
 Affected architecture area:
 
-- `documentation/workflow/**`
-- Future `src/tiny_swarm_world/domain/configuration/**`
-- Future `src/tiny_swarm_world/application/services/configuration/**`
-- Future `src/tiny_swarm_world/application/ports/**`
-- Future `src/tiny_swarm_world/infrastructure/adapters/**`
-- Future `src/tiny_swarm_world/infrastructure/composition.py`
-- Future `infra/config/**`
-- Future example template and documentation files
-- Future `tests/**`
+- `infra/config/compose/**`
+- `src/tiny_swarm_world/domain/deployment/**`
+- `src/tiny_swarm_world/application/services/deployment/**`
+- `tests/**`
+- `documentation/**`
 
 Explicit requirements:
 
-- Address Issue #24 acceptance criteria:
-  - config schema validates before execution;
-  - example env or config template is provided;
-  - overrides are documented.
-- Preserve Linux/WSL-only operating assumptions.
-- Preserve Python 3.12 compatibility.
-- Preserve hexagonal architecture.
-- Do not commit local secrets, generated runtime env files, evidence, logs, or
-  host-specific values.
-- Keep live infrastructure commands out of default verification.
-- Push the workflow branch.
+- Address the linked GitHub issue acceptance criteria.
+- Preserve hexagonal architecture and Linux/WSL-only assumptions.
+- Keep live infrastructure commands mocked or static unless explicitly
+  approved.
+- Add or update tests for changed product behavior.
+- Update relevant documentation when behavior or operator workflow changes.
 
 Implicit requirements:
 
-- Existing validated repositories must be reused or extended instead of
-  bypassed.
-- `infra/config` remains product behavior, not throwaway examples.
-- Environment overrides must be allowlisted and typed.
-- Secret values must be checked for presence and policy without logging raw
-  values.
-- Defaults must be explicit and documented.
-- Local runtime files such as `.tiny-swarm-world/local/live-installation.env`
-  remain ignored.
+- Keep domain independent from infrastructure adapters and side effects.
+- Keep application services dependent on ports rather than concrete adapters.
+- Keep concrete adapter construction in infrastructure composition.
+- Preserve deterministic, redacted, host-neutral evidence.
 
 Assumptions:
 
-- A tracked shell-style example file is acceptable for the installer-facing
-  local env contract.
-- The existing setup manifest remains the source of required secret names
-  unless a slice explicitly changes that contract.
-- The first implementation should cover currently consumed `TSW_*` settings
-  and product YAML files before adding new configuration surfaces.
-- The local duplicate `TSW_SONARQUBE_ADMIN_PASSWORD` entry is operator-local
-  cleanup and is not part of this commit.
+- Subagent analysis classified this issue as workflow-authoring-ready.
+- Slice-local product decisions must be resolved from repository evidence
+  before implementation.
 
 Non-goals:
 
-- No live infrastructure mutation.
-- No secret value migration from the user's local env file.
-- No Kubernetes-first configuration model.
-- No Java, Maven, Spring Boot, React, TypeScript, Vite, or browser frontend
-  project.
-- No broad rewrite of existing deployment, artifact, or platform workflows.
-- No committed raw environment payloads.
+- No live LXD, Incus, LXC, Docker, Swarm, Portainer, Nexus, Jenkins,
+  RabbitMQ, SonarQube, networking, or socat mutation during normal
+  verification.
+- No Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass,
+  or Windows-native behavior.
+- No committed secrets, host-specific absolute paths, local runtime env
+  files, generated evidence, logs, caches, or IDE state.
 
 Risks:
 
-- Centralizing config validation can accidentally change runtime defaults if
-  not introduced with compatibility tests.
-- Compose variable parsing can become brittle if implemented with ad hoc string
-  handling.
-- Treating secret values as normal config can leak credentials through logs or
-  evidence.
-- Preflight integration can block existing greenpath runs if required values
-  are over-scoped.
-- Documentation can drift if the template and runtime allowlist are not tested
-  against each other.
+- Shared files may overlap with other indexed workflows; execution must use
+  the dependency order and S3D lock checks from the index.
+- Quality-gate failures block commit and push until classified and fixed
+  inside the active workflow scope.
 
 Open questions:
 
-- Whether the final tracked template should live at the repository root as
-  `.env.example` or under `documentation/configuration/` as a shell-sourceable
-  `live-installation.env.example`.
-- Whether non-secret local values currently generated by `install.sh` should be
-  represented as optional config or installer-owned derived values.
+- Resolve slice-local design choices from repository evidence before code
+  changes.
 
 Blocking questions:
 
-- None for workflow authoring. Open questions are slice decisions with explicit
-  stop conditions.
+- None for workflow authoring. Any issue-specific decision is represented
+  as an early executable decision slice when required.
 
-Confidence level: 92 percent.
+Confidence level: 75 percent.
 
-Decision: `READY_FOR_WORKFLOW`.
-
-## Execution Profile
-
-```text
-executionProfile=FULL_PATH
-reason=The workflow creates future product configuration, preflight, documentation, branch, commit, and push work that can affect runtime setup safety.
-requiredFullReviews=Senior Requirement Engineer, Senior System Architect, Senior Python Automation Developer, Senior React Frontend Developer, Senior Tester, Senior Documentation Engineer, Security review for secret-handling behavior.
-allowedImpactChecks=Senior React Frontend Developer may return no browser/React impact after verifying no frontend module is introduced.
-requiredQualityChecks=git diff --check; targeted unittest files for changed config/preflight behavior; python3 tools/quality_gate.py quality before merge when practical.
-stopConditions=Unclear config ownership, secret leakage risk, architecture boundary violation, live infrastructure requirement without consent, or missing template-to-contract verification.
-```
-
-## Three Amigos Review
-
-Senior Requirement Engineer:
-
-- The issue goal is clear and testable: validation before execution, a tracked
-  example template, and documented overrides.
-- Does the implementation still match the EPIC? Yes, it supports the
-  autonomous runnable setup EPIC by failing closed on configuration blockers
-  before mutation.
-
-Senior System Architect:
-
-- The contract must preserve hexagonal boundaries. Domain models define typed
-  values and policy, application services orchestrate validation, and
-  infrastructure adapters read environment and YAML sources.
-- Concrete env access must not spread further through application services.
-  Standard wiring remains in `infrastructure/composition.py`.
-
-Senior Python Automation Developer:
-
-- Use small typed value objects and deterministic parsers.
-- Reuse `ruamel.yaml` or existing YAML helpers for product YAML files.
-- Keep command, Docker, LXC, HTTP, and filesystem side effects mocked in tests.
-
-Senior React Frontend Developer:
-
-- No React or browser frontend work is authorized. Any UI impact is limited to
-  CLI/preflight output text and must remain terminal-oriented.
-
-Senior Tester:
-
-- Acceptance is provable with unit tests for valid, missing, invalid, duplicate,
-  undocumented, and secret-redacted configuration cases.
-- Default verification must remain non-mutating.
-
-Dependency / Deadlock Validator:
-
-- Slice dependencies are linear where shared contracts are introduced, then
-  partially parallel for documentation once the config key inventory stabilizes.
-- No slice may write implementation files outside its declared file locks.
+Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
 
 ## Target Picture
 
-Tiny Swarm World has a documented, typed configuration contract for the
-operator-facing setup and deployment configuration surface. Static and live
-preflight validate required configuration before any mutation. The tracked
-example template lists supported overrides without secrets. Documentation
-explains defaults, required values, source precedence, and secret handling. The
-contract is test-backed and aligned with current compose, setup, and
-composition behavior.
+Issue #4 has an executable, test-backed implementation path that
+preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
+boundaries, and guarded live-infrastructure safety.
 
 ## Verified Baseline
 
-- GitHub Issue #24 is open and has no comments at workflow creation time.
-- The repository already validates node-provider config through
-  `NodeProviderConfigYamlRepository`.
-- The command catalog repository has typed contract validation, although
-  product command YAML files are currently retired.
-- Setup preflight checks required secret presence from `SetupManifest`.
-- Many operator values are still read directly from environment helper
-  functions in `infrastructure/composition.py`.
-- No tracked `.env.example`, `live-installation.env.example`, or equivalent
-  complete config template exists.
-- The local `.tiny-swarm-world/local/live-installation.env` file is ignored and
-  must not be committed.
+- Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
+  were checked during indexed workflow authoring.
+- The workflow is stored under `documentation/workflow/issues/issue-4/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
 
 ## Scope
 
-In scope for workflow execution:
+In scope:
 
-- Inventory all currently consumed `TSW_*` environment variables from source,
-  compose files, installer script, tests, and documentation.
-- Define typed config contract models with source precedence, requiredness,
-  defaults, secret classification, validation rules, and redaction policy.
-- Add infrastructure loading for environment and optional local env files
-  without committing secret values.
-- Add static preflight checks that validate config contracts before live setup
-  or deployment mutation.
-- Add a tracked example template with placeholder values only.
-- Update README, deployment docs, user guide, and arc42 where behavior changes.
-- Add focused tests and run repository quality gates.
+- Files and modules listed in the affected architecture area.
+- Tests and documentation needed to satisfy Issue #4.
+- Quality gates from `QUALITY.md`.
 
 Out of scope:
 
-- Executing live setup, reset, or deployment.
-- Modifying the user's local env file.
-- Rotating or generating real credentials in committed files.
-- Introducing external static-analysis CI.
-- Replacing existing node-provider config validation.
-- Reintroducing Multipass as a supported provider.
+- Live infrastructure execution.
+- Java, Maven, Spring Boot, browser React, Kubernetes-first, Multipass, or
+  Windows-native behavior.
+- Secret, local evidence, cache, or IDE-state commits.
 
 ## Architecture Constraints
 
-- Domain configuration types must not import infrastructure, OS env access,
-  YAML libraries, logging, Docker, HTTP, command runners, or composition code.
-- Application services may depend on ports and domain types only.
-- Infrastructure adapters own environment reads, shell env parsing, YAML
-  loading, and file path handling.
-- `infrastructure/composition.py` remains the standard construction point for
-  concrete adapters.
-- Secrets must never appear in verification evidence, logs, exceptions,
-  templates with real values, or committed test fixtures.
-- Product YAML under `infra/config` must be parsed through structured APIs.
+- Domain code must not import infrastructure, YAML parsers, command runners,
+  Docker/LXC clients, logging setup, file managers, or composition.
+- Application services orchestrate ports and domain types only.
+- Infrastructure adapters own filesystem, YAML, HTTP, shell, Docker, LXC,
+  and composition details.
+- `src/tiny_swarm_world/infrastructure/composition.py` remains the standard
+  wiring boundary unless this issue explicitly and safely refactors its
+  internal modules.
 
 ## Python Automation Assessment
 
-The future implementation is Python automation work. It should add focused
-domain/application contracts and infrastructure adapters rather than extending
-ad hoc environment lookups. Use `unittest`, mocks, and deterministic fixtures.
-Keep compatibility with Python 3.12.
+This is Python automation work. Keep Python 3.12 compatibility, typed value
+objects where useful, deterministic unit tests, and mocked external command
+or network behavior.
 
 ## Frontend Assessment
 
-No browser or React frontend work is authorized. If preflight output changes,
-keep it concise, terminal-safe, and secret-redacted.
+No browser or React frontend work is authorized. Console/status UI work, if
+any, remains terminal-oriented and routes through console/status UI skills.
 
 ## Test Strategy
 
-- Unit-test contract parsing and validation in domain/application layers.
-- Unit-test environment adapter source precedence without reading real local
-  secret files.
-- Unit-test template coverage against the allowlisted config contract.
-- Unit-test preflight behavior for valid config, missing required secrets,
-  invalid integers, invalid URLs, invalid secret-name values, and redaction.
-- Keep Docker, LXC, Portainer, Nexus, Jenkins, RabbitMQ, SonarQube, Infisical,
-  Traefik, and browser checks mocked unless explicitly approved as live tests.
+- Run focused unit or architecture tests for changed files first.
+- Run `python3 tools/quality_gate.py quality` before merge when practical.
+- Do not execute live infrastructure commands in tests.
+- Mock command execution, LXC/Incus/LXD, Docker, Swarm, Portainer, and
+  network calls unless a later explicit live-validation approval exists.
 
 ## Resilience Requirements
 
-- Validation must fail closed before mutation.
-- Error messages must name the config key and remediation without disclosing
-  raw secret values.
-- Unknown env keys may be ignored globally, but keys documented as supported
-  must be contract-tested.
-- Duplicate keys in shell env files should produce a clear warning or failure
-  policy before the local file is trusted by automation.
-- Optional defaults must be explicit, typed, and documented.
+- Fail closed before mutation when configuration, consent, runtime state, or
+  ownership is ambiguous.
+- Report blockers with target, expected state, observed state, and next
+  action when applicable.
+- Preserve deterministic, redacted evidence and diagnostics.
 
 ## Ordered Slices
 
-### Slice 01: Config Surface Inventory
+### Slice 01: Requirement, repository baseline, and decision gate
 
 Purpose:
 
-- Produce a repository-evidence inventory of current `TSW_*` env variables,
-  product YAML files, compose placeholders, installer-generated values, and
-  direct env lookups.
-- Decide the template path and contract ownership before implementation.
+- Requirement, repository baseline, and decision gate for Issue #4.
 
 ```yaml
 slice_id: S01
-profile: FULL_PATH
+profile: NORMAL_PATH
 owner: Senior Requirement Engineer
 secondary_reviewers:
   - Senior System Architect
   - Senior Tester
 affected_files:
-  - documentation/configuration/config-contract-inventory.md
-  - documentation/workflow/workflow.md
+  - documentation/workflow/issues/issue-4/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
 affected_modules:
-  - documentation
+  - deployment configuration validation
 affected_contracts:
-  - configuration_contract_inventory
+  - issue_4_swarm_stack_validation
 dependencies: []
-parallel_group: inventory
+parallel_group: issue-4-group-1
 file_locks:
-  - documentation/configuration/
-  - documentation/workflow/workflow.md
+  - documentation/workflow/issues/issue-4/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
 contract_locks:
-  - configuration_contract_inventory
+  - issue_4_swarm_stack_validation
 architecture_locks:
-  - hexagonal_configuration_boundary
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
 quality_gates:
   targeted:
     - git diff --check
-  required:
-    - git diff --check
-documentation:
-  arc42: checked-no-change-unless-new-contract-decision-is-needed
-  adr: checked-no-change-unless-config-source-precedence-decision-is-needed
-stop_conditions:
-  - Current configuration surface cannot be verified from repository evidence.
-  - Template path or source precedence requires an ADR before implementation.
-```
-
-Done criteria:
-
-- Inventory lists each supported key, source file, default, requiredness,
-  secret classification, and consumer.
-- The workflow records whether root `.env.example` or
-  `documentation/configuration/live-installation.env.example` is the chosen
-  tracked template.
-- No secret values or host-specific values are copied into documentation.
-
-Verification commands:
-
-```bash
-git diff --check
-```
-
-### Slice 02: Typed Configuration Contract Model
-
-Purpose:
-
-- Add domain/application configuration contract types and validation result
-  models for supported operator config values.
-
-```yaml
-slice_id: S02
-profile: FULL_PATH
-owner: Senior Python Automation Developer
-secondary_reviewers:
-  - Senior System Architect
-  - Senior Tester
-affected_files:
-  - src/tiny_swarm_world/domain/configuration/**
-  - src/tiny_swarm_world/application/services/configuration/**
-  - src/tiny_swarm_world/application/ports/configuration/**
-  - tests/domain/configuration/**
-  - tests/application/services/configuration/**
-affected_modules:
-  - domain.configuration
-  - application.services.configuration
-  - application.ports.configuration
-affected_contracts:
-  - typed_configuration_contract
-dependencies:
-  - S01
-parallel_group: contract
-file_locks:
-  - src/tiny_swarm_world/domain/configuration/
-  - src/tiny_swarm_world/application/services/configuration/
-  - src/tiny_swarm_world/application/ports/configuration/
-  - tests/domain/configuration/
-  - tests/application/services/configuration/
-contract_locks:
-  - typed_configuration_contract
-  - secret_redaction_contract
-architecture_locks:
-  - domain_independence
-  - application_depends_on_ports
-quality_gates:
-  targeted:
-    - PYTHONPATH=src python3 -m unittest tests.domain.configuration
-    - PYTHONPATH=src python3 -m unittest tests.application.services.configuration
-  required:
     - python3 tools/quality_gate.py test
-documentation:
-  arc42: checked-for-building-block-update
-  adr: checked-no-change-unless-source-precedence-policy-changes
-stop_conditions:
-  - Domain code needs infrastructure imports.
-  - Secret values would be represented in persisted validation evidence.
-  - Validation cannot distinguish secret value, secret name, URL, integer, boolean, and image reference kinds.
-```
-
-Done criteria:
-
-- Contract definitions cover required and optional values from S01.
-- Validation results are structured and redacted.
-- Tests prove missing, invalid, defaulted, and secret-classified values.
-
-Verification commands:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.domain.configuration
-PYTHONPATH=src python3 -m unittest tests.application.services.configuration
-python3 tools/quality_gate.py test
-```
-
-### Slice 03: Infrastructure Loader And Source Precedence
-
-Purpose:
-
-- Implement infrastructure adapters that read environment and optional local
-  shell env files through the typed contract without leaking secret values.
-
-```yaml
-slice_id: S03
-profile: FULL_PATH
-owner: Senior Python Automation Developer
-secondary_reviewers:
-  - Senior Security Sandbox Engineer
-  - Senior Tester
-affected_files:
-  - src/tiny_swarm_world/infrastructure/adapters/configuration/**
-  - src/tiny_swarm_world/infrastructure/composition.py
-  - tests/infrastructure/adapters/configuration/**
-  - tests/infrastructure/test_composition.py
-affected_modules:
-  - infrastructure.adapters.configuration
-  - infrastructure.composition
-affected_contracts:
-  - configuration_source_precedence
-  - secret_redaction_contract
-dependencies:
-  - S02
-parallel_group: loader
-file_locks:
-  - src/tiny_swarm_world/infrastructure/adapters/configuration/
-  - src/tiny_swarm_world/infrastructure/composition.py
-  - tests/infrastructure/adapters/configuration/
-  - tests/infrastructure/test_composition.py
-contract_locks:
-  - configuration_source_precedence
-  - composition_wiring
-architecture_locks:
-  - composition_root_only
-  - infrastructure_owns_env_and_file_io
-quality_gates:
-  targeted:
-    - PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration
-    - PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition
-  required:
-    - python3 tools/quality_gate.py test
-documentation:
-  arc42: checked-for-runtime-view-update
-  adr: checked-no-change-unless-source-precedence-policy-changes
-stop_conditions:
-  - Loader reads live infrastructure state.
-  - Loader logs or persists raw secrets.
-  - Composition starts constructing adapters inside application services.
-```
-
-Done criteria:
-
-- Source precedence is deterministic and tested.
-- Duplicate local env key policy is explicit and tested.
-- Existing composition consumers get values from the contract loader or a
-  compatibility wrapper with tests.
-
-Verification commands:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration
-PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition
-python3 tools/quality_gate.py test
-```
-
-### Slice 04: Preflight Integration
-
-Purpose:
-
-- Add a preflight configuration-contract check that runs before live mutation
-  and reports redacted blockers.
-
-```yaml
-slice_id: S04
-profile: FULL_PATH
-owner: Senior Python Automation Developer
-secondary_reviewers:
-  - Senior Tester
-  - Senior System Architect
-affected_files:
-  - src/tiny_swarm_world/application/services/platform/preflight_service.py
-  - src/tiny_swarm_world/domain/preflight/**
-  - src/tiny_swarm_world/infrastructure/composition.py
-  - tests/application/services/platform/test_preflight_service.py
-  - tests/domain/preflight/test_preflight_result.py
-affected_modules:
-  - application.services.platform
-  - domain.preflight
-  - infrastructure.composition
-affected_contracts:
-  - preflight_configuration_validation
-  - setup_manifest_secret_requirements
-dependencies:
-  - S03
-parallel_group: preflight
-file_locks:
-  - src/tiny_swarm_world/application/services/platform/preflight_service.py
-  - src/tiny_swarm_world/domain/preflight/
-  - src/tiny_swarm_world/infrastructure/composition.py
-  - tests/application/services/platform/test_preflight_service.py
-  - tests/domain/preflight/test_preflight_result.py
-contract_locks:
-  - preflight_configuration_validation
-  - setup_manifest_secret_requirements
-architecture_locks:
-  - application_orchestrates_ports
-  - fail_closed_before_mutation
-quality_gates:
-  targeted:
-    - PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service
-    - PYTHONPATH=src python3 -m unittest tests.domain.preflight.test_preflight_result
-  required:
-    - python3 tools/quality_gate.py test
-documentation:
-  arc42: documentation/arc42/10_quality_requirements.adoc
-  adr: checked-no-change-unless-preflight-safety-policy-changes
-stop_conditions:
-  - Static preflight requires live Docker, LXC, HTTP, or browser access.
-  - Preflight output includes raw env values or secret values.
-  - Existing setup manifest secret checks are weakened.
-```
-
-Done criteria:
-
-- Preflight includes a configuration contract category or equivalent structured
-  checks.
-- Missing or invalid config fails before live mutation.
-- Preflight evidence remains summary-only and secret-redacted.
-
-Verification commands:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service
-PYTHONPATH=src python3 -m unittest tests.domain.preflight.test_preflight_result
-python3 tools/quality_gate.py test
-```
-
-### Slice 05: Template And Documentation Synchronization
-
-Purpose:
-
-- Add the tracked example template and synchronize operator documentation with
-  the validated override contract.
-
-```yaml
-slice_id: S05
-profile: NORMAL_PATH
-owner: Senior Documentation Engineer
-secondary_reviewers:
-  - Senior Requirement Engineer
-  - Senior Tester
-affected_files:
-  - .env.example
-  - documentation/configuration/**
-  - documentation/deployment/system.adoc
-  - documentation/user_guide/installation.adoc
-  - documentation/user_guide/usage.adoc
-  - README.md
-  - tests/architecture/test_repository_hygiene.py
-affected_modules:
-  - documentation
-  - repository_hygiene_tests
-affected_contracts:
-  - operator_override_documentation
-  - example_env_template
-dependencies:
-  - S01
-  - S02
-parallel_group: docs
-file_locks:
-  - .env.example
-  - documentation/configuration/
-  - documentation/deployment/system.adoc
-  - documentation/user_guide/installation.adoc
-  - documentation/user_guide/usage.adoc
-  - README.md
-  - tests/architecture/test_repository_hygiene.py
-contract_locks:
-  - operator_override_documentation
-  - example_env_template
-architecture_locks:
-  - linux_wsl_only_documentation
-  - no_committed_secret_values
-quality_gates:
-  targeted:
-    - git diff --check
-    - PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene
-  required:
-    - python3 tools/quality_gate.py test
-documentation:
-  arc42: checked-for-quality-requirements-update
-  adr: checked-no-change-unless-template-location-policy-changes
-stop_conditions:
-  - Template includes real secrets, local IPs, host paths, user names, or credentials.
-  - Documentation expands Windows-native setup behavior.
-  - Template and typed contract disagree.
-```
-
-Done criteria:
-
-- A tracked example template exists and contains placeholders only.
-- Documentation describes required values, optional overrides, defaults,
-  source precedence, local env file handling, and redaction behavior.
-- Tests or static checks prove template coverage against the contract.
-
-Verification commands:
-
-```bash
-git diff --check
-PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene
-python3 tools/quality_gate.py test
-```
-
-### Slice 06: Final Quality Gate And Issue Closure Evidence
-
-Purpose:
-
-- Run final verification, update workflow status if needed, and prepare
-  evidence for Issue #24 closure.
-
-```yaml
-slice_id: S06
-profile: FULL_PATH
-owner: Senior Tester
-secondary_reviewers:
-  - Senior Documentation Engineer
-  - Senior System Architect
-affected_files:
-  - documentation/workflow/workflow.md
-  - documentation/workflow/context-pack.md
-  - documentation/workflow/context-pack.json
-affected_modules:
-  - workflow_documentation
-affected_contracts:
-  - issue_24_acceptance_evidence
-dependencies:
-  - S03
-  - S04
-  - S05
-parallel_group: closeout
-file_locks:
-  - documentation/workflow/
-contract_locks:
-  - issue_24_acceptance_evidence
-architecture_locks:
-  - quality_gate_integrity
-quality_gates:
-  targeted:
-    - git diff --check
   required:
     - python3 tools/quality_gate.py quality
 documentation:
-  arc42: checked-updated-if-behavior-changed
-  adr: checked-updated-if-config-policy-changed
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
 stop_conditions:
-  - Full quality gate fails without documented and accepted blocker.
-  - Acceptance evidence cannot map to Issue #24 criteria.
-  - Workflow changes include unclassified implementation drift.
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
 ```
 
 Done criteria:
 
-- Issue #24 acceptance criteria map to committed files and verification
-  evidence.
-- `python3 tools/quality_gate.py quality` passes or any blocker is documented
-  and routed before merge.
-- No local env file, secret value, generated evidence, cache, or IDE state is
-  staged.
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
 
 Verification commands:
 
 ```bash
 git diff --check
-python3 tools/quality_gate.py quality
+python3 tools/quality_gate.py test
+```
+
+### Slice 02: Scoped implementation inside the declared architecture boundary
+
+Purpose:
+
+- Scoped implementation inside the declared architecture boundary for Issue #4.
+
+```yaml
+slice_id: S02
+profile: NORMAL_PATH
+owner: Senior Python Automation Developer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - tests/**
+  - documentation/**
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S01
+parallel_group: issue-4-group-2
+file_locks:
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+  - src/tiny_swarm_world/application/services/deployment/**
+  - tests/**
+  - documentation/**
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+    - git diff --check
+    - python3 tools/quality_gate.py test
+  required:
+    - python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 03: Focused regression and architecture tests
+
+Purpose:
+
+- Focused regression and architecture tests for Issue #4.
+
+```yaml
+slice_id: S03
+profile: NORMAL_PATH
+owner: Senior Tester
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - tests/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S02
+parallel_group: issue-4-group-3
+file_locks:
+  - tests/**
+  - infra/config/compose/**
+  - src/tiny_swarm_world/domain/deployment/**
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+    - git diff --check
+    - python3 tools/quality_gate.py test
+  required:
+    - python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
+```
+
+### Slice 04: Documentation synchronization and final quality evidence
+
+Purpose:
+
+- Documentation synchronization and final quality evidence for Issue #4.
+
+```yaml
+slice_id: S04
+profile: NORMAL_PATH
+owner: Senior Documentation Engineer
+secondary_reviewers:
+  - Senior System Architect
+  - Senior Tester
+affected_files:
+  - documentation/**
+  - README.md
+affected_modules:
+  - deployment configuration validation
+affected_contracts:
+  - issue_4_swarm_stack_validation
+dependencies:
+  - S03
+parallel_group: issue-4-group-4
+file_locks:
+  - documentation/**
+  - README.md
+contract_locks:
+  - issue_4_swarm_stack_validation
+architecture_locks:
+  - hexagonal_architecture
+  - linux_wsl_only_runtime
+quality_gates:
+  targeted:
+    - git diff --check
+    - python3 tools/quality_gate.py test
+  required:
+    - python3 tools/quality_gate.py quality
+documentation:
+  arc42: checked-update-if-behavior-or-boundary-changes
+  adr: checked-update-if-policy-or-architecture-decision-changes
+stop_conditions:
+  - Repository evidence contradicts the selected implementation direction.
+  - A slice requires live infrastructure mutation without explicit approval.
+  - The change would violate hexagonal architecture or Linux/WSL-only scope.
+```
+
+Done criteria:
+
+- The slice is complete inside the declared file locks.
+- Targeted checks cover the accepted behavior.
+- No live infrastructure command is executed by default verification.
+
+Verification commands:
+
+```bash
+git diff --check
+python3 tools/quality_gate.py test
 ```
 
 ## Slice Dependency Graph
 
 ```text
-S01
- |
- +--> S02
-       |
-       +--> S03 --> S04 --+
-       |                  |
-       +--> S05 ----------+--> S06
+S01 -> S02 -> S03 -> S04
 ```
 
-## Parallelization Opportunities
+Cross-workflow dependencies: none.
 
-- S05 documentation can start after S01 and S02 once the key inventory and
-  typed contract names stabilize.
-- S03 and S05 may proceed in parallel only if the template coverage contract is
-  locked and both slices avoid editing the same files.
-- S04 waits for S03 because preflight wiring must consume the loader contract.
+## Parallel Execution
+
+- Can this workflow run in parallel? Only after S3D confirms disjoint file,
+  contract, module, and architecture locks.
+- Conflicting workflows: see `documentation/workflow/workflow.index.md`.
+- Shared files: infra/config/compose/**, src/tiny_swarm_world/domain/deployment/**, src/tiny_swarm_world/application/services/deployment/**, tests/**, documentation/**.
+- Shared infrastructure: none for default verification; live validation is
+  serialized unless isolated infrastructure is explicitly provided.
+- Requires isolated worktree: yes for workflow execution streams.
+- Requires serialized live validation: yes.
+- Merge-order constraints: honor cross-workflow dependencies and slice order.
 
 ## Automatic Work Distribution Policy
 
-During `workflow execute`, Codex must automatically inspect every slice and
-determine whether it can be split into specialist execution streams. Codex
-must prefer automatic work distribution when the slice contains clearly
-separable concerns, without replacing Three Amigos, S3/S3D, evidence,
-quality-gate, SonarQube, branch, PR, or merge protections.
-
-Codex must use real Codex subagents where supported. If real subagents are
-unavailable or not visible, Codex must perform explicit role-based fallback
-review in the main execution thread and record the fallback in evidence.
-
-| Stream | Scope |
-|---|---|
-| backend | Java/Python backend, domain logic, ports, adapters, service code |
-| frontend | UI, UX, frontend components, frontend tests |
-| tests | unit, component, integration, acceptance tests, fixtures |
-| runtime | Docker, LXD/LXC, install.sh, deployment, CI/CD, platform scripts |
-| documentation | arc42, README, workflow.md, ADR, evidence, process documentation |
-| quality | SonarQube, linting, coverage, static analysis, quality gate repair |
-| architecture | boundaries, module structure, hexagonal architecture, SCA/SCAP constraints |
-| security | secrets, permissions, credentials, network exposure, risky automation |
-
-Do not split work if the slice modifies the same files across multiple
-streams, the architectural boundary is unclear, the workflow contains
-contradictory requirements, implementation order is mandatory, a shared
-migration step must happen first, database/schema changes require strict
-sequencing, generated files would create merge conflicts, the Three Amigos
-gate marks the slice as not safely parallelizable, secrets or credentials
-handling is unclear, or safety guards would be weakened.
-
+During `workflow execute`, Codex must inspect each slice for safe specialist
+stream decomposition. Real Codex subagents should be used where supported;
+otherwise explicit role-based fallback review must be recorded in evidence.
 For every slice, create `.codex/evidence/slice-<number>-distribution.md`
-before implementation. For every implemented slice, create or update
-`.codex/evidence/slice-<number>-consolidation.md`. Codex remains the final
-integration owner for consolidation, tests, evidence, PR, and merge readiness.
+before implementation and `.codex/evidence/slice-<number>-consolidation.md`
+after implementation. Codex remains final integration owner.
+
+Stream map: backend, frontend, tests, runtime, documentation, quality,
+architecture, security. Do not split work when files overlap, architecture
+is unclear, requirements contradict, ordering is mandatory, generated files
+may conflict, secrets handling is unclear, or safety guards would be
+weakened.
 
 ## Git Worktree Execution Rule
 
-Parallel execution must use isolated Git worktrees. Each stream must use its
-own branch and worktree.
-
-Branch names must follow this pattern:
+Parallel execution must use isolated Git worktrees. Stream branch names must
+follow:
 
 ```text
 <workflow-branch>-slice-<number>-<stream>
 ```
 
-Examples:
-
-```text
-feature/workflow-refactor-config-20260613-slice-01-backend
-feature/workflow-refactor-config-20260613-slice-01-tests
-feature/workflow-refactor-config-20260613-slice-01-docs
-```
-
-Stream branches may only be merged back after stream-specific tests pass, file
-ownership conflicts are resolved, evidence is written, and consolidation
-review accepts the changes. Subagents and stream workers must not merge
-directly to the main workflow branch.
+Subagents or stream workers must not merge directly to the integration
+branch. Codex consolidates accepted changes after tests and evidence pass.
 
 ## Role And Ownership Map
 
-- Senior Workflow Architect: workflow dependency ordering and handoff.
-- Senior Requirement Engineer: Issue #24 acceptance traceability.
-- Senior System Architect: hexagonal boundary and arc42 impact.
-- Senior Python Automation Developer: typed contract, loader, and preflight
-  implementation.
-- Senior React Frontend Developer: no-impact verification for browser/React
-  scope.
-- Senior Documentation Engineer: template and operator documentation.
-- Senior Security Sandbox Engineer: secret classification, redaction, and local-file safety review.
-- Senior Tester: regression design and final quality evidence.
+- Senior Workflow Architect: dependency order and workflow handoff.
+- Senior Requirement Engineer: issue acceptance traceability.
+- Senior System Architect: hexagonal boundaries and architecture decisions.
+- Senior Python Automation Developer: Python implementation slices.
+- Senior React Frontend Developer: no-impact check for browser/React scope.
+- Senior Tester: regression and quality evidence.
+- Senior Documentation Engineer: documentation synchronization.
 
 ## Quality-Gate Expectations
 
-Workflow creation commit:
+Workflow authoring:
 
 ```bash
 git diff --check
 ```
 
-Workflow execution targeted gates:
+Workflow execution:
 
 ```bash
-PYTHONPATH=src python3 -m unittest tests.domain.configuration
-PYTHONPATH=src python3 -m unittest tests.application.services.configuration
-PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration
-PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service
-PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition
-PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene
-```
-
-Required before merge when practical:
-
-```bash
+python3 tools/quality_gate.py test
+python3 tools/quality_gate.py arch-tests
 python3 tools/quality_gate.py quality
 ```
 
-Live tests are not required for Issue #24 unless a future slice explicitly
-changes live deployment behavior and the user grants live infrastructure
-consent.
-
 ## Documentation Synchronization Points
 
-- Update README when the operator setup path or template location changes.
-- Update `documentation/deployment/system.adoc` and user guide pages when
-  override defaults or source precedence change.
-- Update arc42 quality/runtime/building-block sections if preflight or config
-  ownership changes.
-- Add or update ADR only if source precedence, template location, or config
-  ownership becomes an architectural decision rather than implementation detail.
+- Update README or user guide when operator behavior changes.
+- Update `documentation/arc42/**` when boundaries, runtime view, quality
+  attributes, or building blocks change.
+- Add or update ADRs only when a slice creates architecture-significant
+  policy or ownership decisions.
 
 ## Stop Conditions
 
-Stop workflow execution and report when:
-
-- repository evidence cannot prove a config key is supported;
-- a planned check requires live infrastructure without explicit consent;
-- a secret value would be committed, logged, persisted, or echoed;
-- domain code needs infrastructure imports;
-- application services need direct `os.environ`, file IO, YAML parser, HTTP,
-  Docker, LXC, or command-runner access;
-- template and contract definitions drift;
-- quality gates fail and the failure is not understood;
-- Issue #24 acceptance criteria cannot be mapped to tests and documentation.
+Stop and report when repository evidence contradicts this workflow, when
+live infrastructure would be required without approval, when architecture
+boundaries are unclear, when quality gates fail without a safe scoped fix,
+or when acceptance criteria cannot be mapped to tests and documentation.
 
 ## Uncertainty Escalation Rules
 
-- Escalate source-precedence policy changes to Senior System Architect and ADR
-  Steward.
-- Escalate new secret handling semantics to Security Engineer and Senior
-  Tester.
-- Escalate broad composition rewiring to Senior System Architect.
-- Escalate quality-gate uncertainty to Quality Gate Orchestrator.
-- Escalate documentation mismatch to Documentation Sync.
+- Architecture ambiguity: Root Architect and Senior System Architect.
+- Requirement ambiguity: Senior Requirement Engineer.
+- Quality failure: Senior Tester and Quality Gate Orchestrator.
+- Security or secret handling: security and configuration owners.
+- Documentation mismatch: Senior Documentation Engineer.
 
 ## Commit And Push Plan
 
-Workflow creation:
+Workflow authoring commit:
 
-- Branch: `feature/workflow-config-contracts-20260613`.
-- Commit type: `docs(workflow)`.
-- Stage only `documentation/workflow/**`.
+- Branch: `feature/workflow-index-open-issues-20260614`.
+- Stage this issue workflow, its context pack, `workflow.index.md`, and the
+  workflow-authoring skill update.
 - Run `git diff --check`.
-- Push branch to `origin`.
+- Push the authoring branch after all indexed workflows are created.
 
 Future workflow execution:
 
-- Use this branch unless a later workflow-execute preflight requires a
-  successor branch.
-- Commit each completed slice or logical set only after scoped diff review and
-  required verification.
-- Never push directly to `main`.
+- Promote or explicitly select this indexed workflow.
+- Use proposed execution branch `feature/workflow-issue-4-swarm-stack-validation-20260614` unless a later
+  governance decision selects another branch.
+- Commit each executable slice separately.
 
 ## Definition Of Done
 
-Workflow creation is done when:
+Workflow authoring is done when this file, its context pack, and the index
+entry exist and pass documentation checks.
 
-- `documentation/workflow/workflow.md` describes Issue #24 with executable
-  slice metadata.
-- `documentation/workflow/context-pack.md` and
-  `documentation/workflow/context-pack.json` are updated.
-- The workflow records arc42 and ADR check status.
-- `git diff --check` passes.
-- The branch is committed and pushed.
-
-Issue #24 implementation is done when:
-
-- config schema validates before execution;
-- an example env/config template is tracked;
-- overrides are documented;
-- focused tests prove the config contract and preflight integration;
-- full quality gate passes or an accepted blocker is documented before merge.
-
-## Workflow Execution Evidence
-
-Execution status: `COMPLETED_WITH_EVIDENCE`.
-
-Slice checkpoints pushed to `origin/feature/workflow-config-contracts-20260613`:
-
-| Slice | Commit | Evidence |
-|---|---|---|
-| S01 | `c819847` | `documentation/configuration/config-contract-inventory.md` inventories required keys, optional overrides, validation gaps, and local-file policy without secret values. |
-| S02 | `9bb2f75` | `src/tiny_swarm_world/domain/configuration/**` and application ports/services define the typed configuration contract and redacted validation result. |
-| S03 | `7ca805d` | `src/tiny_swarm_world/infrastructure/adapters/configuration/**` loads process and local env sources with duplicate-key and shell-syntax fail-closed behavior. |
-| S04 | `57f36dd` | `PreflightService` maps configuration findings to `CONFIGURATION` checks before setup phases and keeps evidence summary-only. |
-| S05 | `a0f8741` | `.env.example` and operator documentation describe required values, optional overrides, defaults, source precedence, local env file handling, and redaction. |
-
-Issue #24 acceptance mapping:
-
-- Config schema validates before execution: `ConfigurationValidationService`
-  validates `default_configuration_contract()` and `setup run` injects it into
-  preflight before mutating setup phases.
-- Example env/config template: `.env.example` is tracked and covered by
-  `tests.architecture.test_repository_hygiene`.
-- Overrides documented: `documentation/configuration/operator-configuration-contract.md`
-  is linked from README, installation, deployment, and usage docs.
-
-Verification evidence:
-
-```bash
-git diff --check
-PYTHONPATH=src python3 -m unittest tests.domain.configuration tests.application.services.configuration
-PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.configuration tests.infrastructure.test_composition
-PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_preflight_service tests.domain.preflight.test_preflight_result
-PYTHONPATH=src python3 -m unittest tests.architecture.test_repository_hygiene
-python3 tools/quality_gate.py test
-.venv/bin/python tools/quality_gate.py quality
-```
-
-The system `python3 tools/quality_gate.py quality` attempt stopped at missing
-tooling (`ruff` was not installed for system Python). The repository-local
-`.venv` contains Ruff and mypy, and `.venv/bin/python tools/quality_gate.py
-quality` completed successfully.
+Issue #4 implementation is done when acceptance criteria are satisfied
+by scoped code, tests, documentation, quality evidence, and merge-ready
+review.
 
 ## Handoff To Workflow Execute
 
-To execute this workflow, run the repository's `workflow execute` procedure
-against `documentation/workflow/workflow.md`. The executor must verify the
-active branch, context-pack hashes, slice metadata, locks, and quality gates
-before any write-capable implementation work.
+Run `workflow execute` from this branch and this worktree. The executor must verify S3/S3D metadata, locks, evidence, targeted checks, and quality gates before implementation.
 
 ## arc42 Check Status
 
-- `documentation/arc42/05_building_blocks.adoc`: checked. Future update likely
-  needed when the configuration contract module is implemented.
-- `documentation/arc42/06_runtime_view.adoc`: checked. Future update likely
-  needed when preflight consumes the config contract.
-- `documentation/arc42/10_quality_requirements.adoc`: checked. Future update
-  likely needed when config blockers become an explicit preflight quality
-  behavior.
-- ADR status: checked. No ADR is required for workflow creation. Future ADR
-  may be required if template location or source precedence becomes
-  architecture-significant.
+- arc42 impact: checked during workflow authoring; update during execution
+  if behavior, boundaries, runtime view, or quality requirements change.
+- ADR impact: checked during workflow authoring; add or update ADR only for
+  architecture-significant decisions.

--- a/src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py
@@ -31,10 +31,12 @@ class ComposeFileRepositoryYaml(PortComposeFileRepository):
 
         for base_directory in self.base_directories:
             for compose_path in self._compose_paths_for(base_directory, stack_name):
+                compose_content = compose_path.read_text(encoding="utf-8")
+                _validate_swarm_stack_compose(stack_name, compose_content)
                 self.logger.info("Loaded compose file for stack '%s'.", stack_name)
                 return StackDefinition(
                     name=stack_name,
-                    compose_content=compose_path.read_text(encoding="utf-8"),
+                    compose_content=compose_content,
                 )
 
         raise FileNotFoundError(f"No docker-compose.yml found for stack '{stack_name}' in {self.base_directories}.")
@@ -83,6 +85,32 @@ def _published_ports_from_service(service_payload: Mapping[object, object]) -> t
         if published is not None:
             published_ports.append(published)
     return tuple(dict.fromkeys(published_ports))
+
+
+def _validate_swarm_stack_compose(stack_name: str, compose_content: str) -> None:
+    payload = _YAML.load(compose_content) or {}
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"compose stack '{stack_name}' must be a YAML mapping")
+
+    services = payload.get("services")
+    if not isinstance(services, Mapping) or not services:
+        raise ValueError(f"compose stack '{stack_name}' must define a non-empty services mapping")
+
+    invalid_services: list[str] = []
+    for service_name, service_payload in services.items():
+        if not isinstance(service_name, str):
+            invalid_services.append(str(service_name))
+            continue
+        if not isinstance(service_payload, Mapping):
+            invalid_services.append(service_name)
+            continue
+        deploy = service_payload.get("deploy")
+        if not isinstance(deploy, Mapping):
+            invalid_services.append(service_name)
+
+    if invalid_services:
+        invalid = ", ".join(sorted(invalid_services))
+        raise ValueError(f"compose stack '{stack_name}' has services without a deploy mapping: {invalid}")
 
 
 def _published_port_from_entry(port_entry: object) -> int | None:

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -27,7 +27,7 @@ class TestComposeFileRepositoryYaml(unittest.TestCase):
             config_root = Path(temp_dir) / "config" / "compose"
             config_root.joinpath("nexus").mkdir(parents=True)
             compose_file = config_root / "nexus" / "docker-compose.yml"
-            compose_file.write_text("services:\n  nexus:\n    image: nexus:latest\n", encoding="utf-8")
+            compose_file.write_text("services:\n  nexus:\n    image: nexus:latest\n    deploy: {}\n", encoding="utf-8")
 
             repository = ComposeFileRepositoryYaml(base_directories=[compose_root, config_root])
             stack_definition = repository.get_compose_of("nexus")
@@ -44,6 +44,7 @@ class TestComposeFileRepositoryYaml(unittest.TestCase):
 services:
   web:
     image: nginx
+    deploy: {}
     ports:
       - target: 80
         published: 8080
@@ -53,8 +54,10 @@ services:
       - "9000"
   worker:
     image: busybox
+    deploy: {}
   admin:
     image: nginx
+    deploy: {}
     ports:
       - published: "9090"
         target: 90
@@ -81,7 +84,7 @@ services:
             config_root = Path(temp_dir) / "config" / "compose"
             config_root.joinpath("platform", "services", "nexus").mkdir(parents=True)
             compose_file = config_root / "platform" / "services" / "nexus" / "docker-compose.yml"
-            compose_file.write_text("services:\n  nexus:\n    image: nested\n", encoding="utf-8")
+            compose_file.write_text("services:\n  nexus:\n    image: nested\n    deploy: {}\n", encoding="utf-8")
 
             repository = ComposeFileRepositoryYaml(base_directories=[compose_root, config_root])
             stack_definition = repository.get_compose_of("nexus")
@@ -96,11 +99,11 @@ services:
             compose_root.joinpath("portainer").mkdir(parents=True)
             config_root.joinpath("portainer").mkdir(parents=True)
             compose_root.joinpath("portainer", "docker-compose.yml").write_text(
-                "services:\n  portainer:\n    image: preferred\n",
+                "services:\n  portainer:\n    image: preferred\n    deploy: {}\n",
                 encoding="utf-8",
             )
             config_root.joinpath("portainer", "docker-compose.yml").write_text(
-                "services:\n  portainer:\n    image: fallback\n",
+                "services:\n  portainer:\n    image: fallback\n    deploy: {}\n",
                 encoding="utf-8",
             )
 
@@ -115,7 +118,7 @@ services:
             root = Path(temp_dir)
             root.joinpath("config", "compose", "jenkins").mkdir(parents=True)
             root.joinpath("config", "compose", "jenkins", "docker-compose.yml").write_text(
-                "services:\n  jenkins:\n    image: config-side\n",
+                "services:\n  jenkins:\n    image: config-side\n    deploy: {}\n",
                 encoding="utf-8",
             )
 
@@ -149,6 +152,48 @@ services:
             with self.subTest(stack_name=stack_name):
                 with self.assertRaises(ValueError):
                     repository.get_compose_of(stack_name)
+
+    def test_rejects_compose_file_without_services_mapping(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            compose_root = Path(temp_dir) / "compose"
+            compose_root.joinpath("broken").mkdir(parents=True)
+            compose_root.joinpath("broken", "docker-compose.yml").write_text(
+                "name: broken\n",
+                encoding="utf-8",
+            )
+
+            repository = ComposeFileRepositoryYaml(base_directories=[compose_root])
+
+            with self.assertRaisesRegex(ValueError, "non-empty services mapping"):
+                repository.get_compose_of("broken")
+
+    def test_rejects_compose_service_without_deploy_mapping(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            compose_root = Path(temp_dir) / "compose"
+            compose_root.joinpath("broken").mkdir(parents=True)
+            compose_root.joinpath("broken", "docker-compose.yml").write_text(
+                "services:\n  web:\n    image: nginx\n",
+                encoding="utf-8",
+            )
+
+            repository = ComposeFileRepositoryYaml(base_directories=[compose_root])
+
+            with self.assertRaisesRegex(ValueError, "web"):
+                repository.get_compose_of("broken")
+
+    def test_rejects_compose_service_with_non_mapping_deploy_section(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            compose_root = Path(temp_dir) / "compose"
+            compose_root.joinpath("broken").mkdir(parents=True)
+            compose_root.joinpath("broken", "docker-compose.yml").write_text(
+                "services:\n  web:\n    image: nginx\n    deploy: invalid\n",
+                encoding="utf-8",
+            )
+
+            repository = ComposeFileRepositoryYaml(base_directories=[compose_root])
+
+            with self.assertRaisesRegex(ValueError, "deploy mapping"):
+                repository.get_compose_of("broken")
 
     def test_committed_portainer_compose_uses_docker_socket_mount(self):
         repository_root = Path(__file__).resolve().parents[4]


### PR DESCRIPTION
## Summary

- Promote and execute the Issue #4 workflow for Docker Swarm stack validation.
- Validate compose stack files in `ComposeFileRepositoryYaml` before returning a stack definition.
- Require a non-empty `services` mapping and a per-service mapping-valued `deploy` section.
- Add focused regression tests for invalid compose files and keep committed stack files valid.
- Record slice distribution/consolidation evidence.

## Validation

- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml` - 32 tests passed
- `python3 tools/quality_gate.py test` - 833 tests passed, 17 skipped
- `python3 tools/quality_gate.py arch-tests` - 16 tests passed
- `python3 tools/quality_gate.py quality` - passed

## Live operations

No live Docker, Swarm, Portainer, LXC, or Nexus operation is part of this PR.