### PR TITLE
Add Python packaging metadata and installed CLI

### DIFF
--- a/.codex/evidence/issue-78/slice-01-consolidation.md
+++ b/.codex/evidence/issue-78/slice-01-consolidation.md
@@ -1,0 +1,44 @@
+# Slice 01 Consolidation: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S01`
+
+## Stream Results
+
+- Backend stream confirmed the existing entrypoint is async and needs a sync
+  wrapper for console-script use.
+- Packaging stream confirmed `setup.py` exists but `pyproject.toml` does not.
+- Documentation stream identified README and user-guide command examples that
+  should prefer the installed CLI after editable install.
+
+## Accepted Findings
+
+- Use setuptools through `pyproject.toml`.
+- Preserve `setup.py` as compatibility surface.
+- Preserve `python -m tiny_swarm_world`.
+
+## Rejected Findings
+
+- Removing `setup.py` was rejected as unnecessary churn.
+- Changing quality-gate commands away from repository-root `python3` was
+  rejected because `QUALITY.md` remains authoritative.
+
+## Files Changed
+
+- `.codex/evidence/slice-01-distribution.md`
+- `.codex/evidence/slice-01-consolidation.md`
+- `documentation/workflow/issues/issue-78/python-packaging-baseline.md`
+
+## Conflicts
+
+No conflicts found.
+
+## Tests Executed
+
+```bash
+git diff --check
+```
+
+## Final Integration Decision
+
+Slice 01 is complete. Continue with Slice 02 after checkpoint commit.

--- a/.codex/evidence/issue-78/slice-01-distribution.md
+++ b/.codex/evidence/issue-78/slice-01-distribution.md
@@ -1,0 +1,56 @@
+# Slice 01 Distribution: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S01`
+Slice title: Packaging metadata and CLI entry point baseline
+
+## Affected Areas
+
+- `setup.py`
+- `requirements.txt`
+- `src/tiny_swarm_world/__main__.py`
+- `README.md`
+- `documentation/user_guide/**`
+- `tests/**`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not used. This baseline slice is a small repository
+inspection and decision gate, so role-based fallback review is recorded in the
+main execution thread.
+
+## Selected Streams
+
+- backend
+- tests
+- documentation
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-78-python-packaging
+```
+
+## Conflict Risks
+
+- Documentation contains many `PYTHONPATH=src python3 -m tiny_swarm_world`
+  examples. Slice 03 should update operator-facing install/usage examples
+  without changing quality-gate instructions that still intentionally use
+  `PYTHONPATH=src`.
+- Existing `setup.py` should remain compatible while `pyproject.toml` becomes
+  the standard metadata entry point.
+
+## Quality Gates
+
+- `git diff --check`
+
+## Consolidation Plan
+
+Record the packaging baseline and selected implementation direction, then
+continue with package metadata and CLI entry point changes.

--- a/.codex/evidence/issue-78/slice-02-consolidation.md
+++ b/.codex/evidence/issue-78/slice-02-consolidation.md
@@ -1,0 +1,86 @@
+# Slice 02 Consolidation: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S02`
+Slice title: Package metadata and CLI entry point
+
+## Stream Results
+
+- backend: accepted. Added a synchronous console-script wrapper around the
+  existing async CLI entry point.
+- tests: accepted. Added package metadata regression tests for `pyproject.toml`
+  and legacy `setup.py` compatibility.
+
+## Subagent Review
+
+Real subagent review completed for packaging and test adequacy.
+
+Result: no blocking findings.
+
+Residual risks accepted or mitigated:
+
+- `cli()` direct unit coverage: accepted. The editable-install gate invokes the
+  installed `tiny-swarm-world` script and covers the console-script integration
+  path.
+- package version parity: mitigated by adding a regression test that compares
+  `pyproject.toml` and `setup.py`.
+- `requests==2.32.0` yanked warning: accepted as inherited dependency risk
+  from the existing `requirements.txt` pin.
+
+## Accepted Findings
+
+- `tiny-swarm-world` must resolve to a synchronous callable because setuptools
+  console scripts cannot await an async coroutine directly.
+- `pyproject.toml` dependencies must match `requirements.txt` so package
+  installs and source-checkout execution remain aligned.
+- `pyproject.toml` and `setup.py` package versions must remain aligned while
+  both metadata surfaces exist.
+
+## Rejected Findings
+
+None.
+
+## Files Changed Per Stream
+
+- backend: `src/tiny_swarm_world/__main__.py`
+- packaging: `pyproject.toml`, `setup.py`
+- tests: `tests/test_package_metadata.py`
+- evidence: `.codex/evidence/issue-78/slice-02-distribution.md`,
+  `.codex/evidence/issue-78/slice-02-consolidation.md`
+
+## Conflicts
+
+No file conflicts detected. Issue-specific evidence path is used so Issue #4
+root-level slice evidence remains intact.
+
+## Tests Executed
+
+```text
+PYTHONPATH=src python3 -m unittest tests.test_package_metadata tests.test_package_entrypoint
+```
+
+Result: passed, 33 tests.
+
+```text
+python3 -m pip install -e . && tiny-swarm-world --list-workflows
+```
+
+Result: passed in a temporary WSL virtual environment.
+
+Note: pip reported that the existing `requests==2.32.0` pin is yanked. The
+slice mirrors the existing repository requirement and does not change the
+dependency version.
+
+## SonarQube Findings
+
+Not run locally for this slice. Remote PR checks remain the SonarQube decision
+point during `push auto`.
+
+## Documentation Updates
+
+Documentation changes are intentionally deferred to Slice 03.
+
+## Final Integration Decision
+
+Accepted for Slice 02 checkpoint commit after subagent review, focused tests,
+editable-install verification, and diff checks.

--- a/.codex/evidence/issue-78/slice-02-distribution.md
+++ b/.codex/evidence/issue-78/slice-02-distribution.md
@@ -1,0 +1,51 @@
+# Slice 02 Distribution: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S02`
+Slice title: Package metadata and CLI entry point
+
+## Affected Areas
+
+- `pyproject.toml`
+- `setup.py`
+- `src/tiny_swarm_world/__main__.py`
+- `tests/test_package_metadata.py`
+
+## Execution Mode
+
+Sequential.
+
+## Subagents
+
+Real subagents were not used. Packaging metadata, entry point wrapper, and
+tests are tightly coupled in this slice.
+
+## Selected Streams
+
+- backend
+- tests
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-78-python-packaging
+```
+
+## Conflict Risks
+
+- `setup.py` and `pyproject.toml` metadata must stay aligned.
+- Console script must call a synchronous wrapper, not the async `main`
+  coroutine directly.
+
+## Quality Gates
+
+- `PYTHONPATH=src python3 -m unittest tests.test_package_metadata tests.test_package_entrypoint`
+- `python3 -m pip install -e .` in a temporary virtual environment
+- `git diff --check`
+
+## Consolidation Plan
+
+Add packaging metadata, run focused tests, verify editable install in an
+isolated virtual environment, then record consolidation evidence.

--- a/.codex/evidence/issue-78/slice-03-consolidation.md
+++ b/.codex/evidence/issue-78/slice-03-consolidation.md
@@ -1,0 +1,80 @@
+# Slice 03 Consolidation: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S03`
+Slice title: Focused regression and architecture tests
+
+## Stream Results
+
+- tests: accepted. Focused package metadata and CLI entrypoint regression tests
+  passed.
+- architecture: accepted. Hexagonal architecture import tests passed.
+- quality: accepted. Repository test gate passed.
+
+## Subagent Review
+
+Senior Tester subagent review completed.
+
+Result: no blockers.
+
+Accepted findings:
+
+- `tests/test_package_metadata.py` covers `pyproject.toml` metadata,
+  dependency alignment, package version parity, and script entry point.
+- `tests/test_package_metadata.py` covers legacy `setup.py` console-script
+  compatibility.
+- Editable-install evidence from Slice 02 covers the installed
+  `tiny-swarm-world` integration path.
+- Existing `tests/test_package_entrypoint.py` covers entrypoint import and
+  architecture boundary expectations.
+
+Residual risks accepted:
+
+- `cli()` is not directly unit-tested. The installed console-script gate covers
+  it as an integration check.
+- `requests==2.32.0` remains an inherited yanked dependency pin mirrored from
+  `requirements.txt`.
+
+## Files Changed Per Stream
+
+- evidence: `.codex/evidence/issue-78/slice-03-distribution.md`,
+  `.codex/evidence/issue-78/slice-03-consolidation.md`
+
+No product code, packaging metadata, or tests were changed in Slice 03.
+
+## Conflicts
+
+No conflicts detected.
+
+## Tests Executed
+
+```text
+PYTHONPATH=src python3 -m unittest tests.test_package_metadata tests.test_package_entrypoint
+```
+
+Result: passed, 33 tests.
+
+```text
+python3 tools/quality_gate.py arch-tests
+```
+
+Result: passed, 16 tests.
+
+```text
+python3 tools/quality_gate.py test
+```
+
+Result: passed, 837 tests, 17 skipped.
+
+## SonarQube Findings
+
+Not run locally for this slice. Remote PR checks remain the SonarQube decision
+point during `push auto`.
+
+## Documentation Updates
+
+Documentation synchronization is deferred to Slice 04.
+
+## Final Integration Decision
+
+Accepted for Slice 03 checkpoint commit.

--- a/.codex/evidence/issue-78/slice-03-distribution.md
+++ b/.codex/evidence/issue-78/slice-03-distribution.md
@@ -1,0 +1,53 @@
+# Slice 03 Distribution: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S03`
+Slice title: Focused regression and architecture tests
+
+## Affected Areas
+
+- `tests/**`
+- `pyproject.toml`
+- `src/tiny_swarm_world/__main__.py`
+
+## Execution Mode
+
+Sequential verification.
+
+## Subagents
+
+Real subagent review requested from the Senior Tester stream. No write-capable
+subagent was spawned because Slice 03 is a verification slice and the working
+tree must remain stable for quality-gate attribution.
+
+## Selected Streams
+
+- tests
+- architecture
+- quality
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-78-python-packaging
+```
+
+## Conflict Risks
+
+- Test failures may point back to Slice 02 packaging metadata or CLI entry
+  point behavior.
+- Architecture failures must not be fixed by weakening import boundaries.
+
+## Quality Gates
+
+- `PYTHONPATH=src python3 -m unittest tests.test_package_metadata tests.test_package_entrypoint`
+- `python3 tools/quality_gate.py arch-tests`
+- `python3 tools/quality_gate.py test`
+- `git diff --check`
+
+## Consolidation Plan
+
+Run focused regression and architecture gates, collect tester subagent findings,
+then commit only Slice 03 evidence unless the checks expose an in-scope defect.

--- a/.codex/evidence/issue-78/slice-04-consolidation.md
+++ b/.codex/evidence/issue-78/slice-04-consolidation.md
@@ -1,0 +1,109 @@
+# Slice 04 Consolidation: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S04`
+Slice title: Documentation synchronization and final quality evidence
+
+## Stream Results
+
+- documentation: accepted. README, user guide, and arc42 context now document
+  the installed `tiny-swarm-world` CLI as the preferred operator entry point
+  after editable install.
+- quality: accepted. Full repository quality gate passed after resolving a
+  Slice 02 metadata-test typecheck issue.
+
+## Subagent Review
+
+Senior Documentation Engineer subagent review completed.
+
+Result: no blockers.
+
+Accepted recommendations:
+
+- Keep `python3 -m pip install -e .` in both README setup paths.
+- Document installed CLI usage while retaining
+  `PYTHONPATH=src python3 -m tiny_swarm_world` as the direct source-checkout
+  fallback.
+- Keep live-infrastructure consent language unchanged and avoid rewriting
+  unrelated live setup sections.
+
+## Accepted Findings
+
+- The supported operator entry point after editable install is
+  `tiny-swarm-world`.
+- Direct source-checkout execution remains useful for diagnostics before
+  installation.
+- The full quality gate initially failed in `tests/test_package_metadata.py`
+  because `ast.keyword.arg` is typed as optional. The failure was classified as
+  `BUILD_FAILURE`, fixed inside the Slice 02 commit by narrowing `keyword.arg`
+  before dictionary insertion, and verified before continuing.
+
+## Rejected Findings
+
+None.
+
+## Files Changed Per Stream
+
+- documentation: `README.md`,
+  `documentation/user_guide/installation.adoc`,
+  `documentation/user_guide/usage.adoc`,
+  `documentation/arc42/04_context_and_scope.adoc`
+- evidence: `.codex/evidence/issue-78/slice-04-distribution.md`,
+  `.codex/evidence/issue-78/slice-04-consolidation.md`
+
+## Conflicts
+
+No merge conflicts or file ownership conflicts detected.
+
+## Tests Executed
+
+```text
+git diff --check
+```
+
+Result: passed.
+
+```text
+PYTHONPATH=src python3 -m unittest tests.test_package_metadata
+```
+
+Result: passed, 4 tests.
+
+```text
+python3 tools/quality_gate.py typecheck
+```
+
+Result: passed, no issues in 391 source files.
+
+```text
+python3 tools/quality_gate.py quality
+```
+
+Result: passed.
+
+Quality gate details:
+
+- lint: passed.
+- arch-lint: passed, 3 contracts kept.
+- arch-tests: passed, 16 tests.
+- typecheck: passed, no issues in 391 source files.
+- test: passed, 837 tests, 17 skipped.
+
+## SonarQube Findings
+
+Not run locally. Remote PR checks remain the SonarQube decision point during
+`push auto`.
+
+## Documentation Updates
+
+- README quick start and quality setup now install the package in editable
+  mode and use `tiny-swarm-world` for primary CLI examples.
+- Installation guide documents editable install and keeps direct module
+  execution as a source-checkout fallback.
+- Usage guide uses `tiny-swarm-world` for core operator commands while
+  preserving live-consent warnings.
+- arc42 context names the installed CLI as the supported operator boundary.
+
+## Final Integration Decision
+
+Accepted for Slice 04 checkpoint commit and `push auto` readiness.

--- a/.codex/evidence/issue-78/slice-04-distribution.md
+++ b/.codex/evidence/issue-78/slice-04-distribution.md
@@ -1,0 +1,52 @@
+# Slice 04 Distribution: Issue 78 Python Packaging
+
+Workflow id: `issue-78-python-packaging-20260614`
+Slice id: `S04`
+Slice title: Documentation synchronization and final quality evidence
+
+## Affected Areas
+
+- `README.md`
+- `documentation/**`
+
+## Execution Mode
+
+Sequential documentation synchronization.
+
+## Subagents
+
+Real subagent review requested from the Senior Documentation Engineer stream.
+No write-capable documentation subagent was spawned because the primary docs
+share operator command examples and require one final integration pass.
+
+## Selected Streams
+
+- documentation
+- quality
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-78-python-packaging
+```
+
+## Conflict Risks
+
+- Rewriting all historical `PYTHONPATH=src python3 -m tiny_swarm_world`
+  examples would create broad documentation churn.
+- Live-infrastructure examples must remain Linux/WSL-only and must not imply
+  that setup commands are safe without explicit operator consent.
+
+## Quality Gates
+
+- `git diff --check`
+- `python3 tools/quality_gate.py quality`
+
+## Consolidation Plan
+
+Document the installed `tiny-swarm-world` CLI as the preferred command after
+editable install, keep `python3 -m tiny_swarm_world` as source-checkout
+fallback, run the full repository quality gate, then commit final evidence and
+documentation updates.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ source .venv/bin/activate
 ```bash
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 python3 -m pip install pytest ruff mypy import-linter types-PyYAML types-requests
 ```
 
@@ -92,20 +93,20 @@ python3 tools/quality_gate.py quality
 5. Inspect the current workflow entry point
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world --list-workflows
+tiny-swarm-world --list-workflows
 ```
 
 6. Run the static preflight check for the default node provider
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world --preflight
+tiny-swarm-world --preflight
 ```
 
 Running the module without arguments does not execute infrastructure commands.
 Use an explicit workflow selection before running automation:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world platform verify
+tiny-swarm-world platform verify
 ```
 
 Mutating workflows can call LXD/Incus/LXC, Docker, networking, or other local
@@ -116,7 +117,7 @@ exact `--confirm` phrase shown by the workflow contract.
 The safe setup probe is `setup run` without `--live`:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world setup run
+tiny-swarm-world setup run
 ```
 
 Without the full live-consent contract this command refuses before setup
@@ -124,14 +125,14 @@ services are constructed and prints `REFUSED_LIVE_CONSENT_MISSING`. The
 canonical live operator command uses the default `lxc_native` provider:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ```
 
 Operators may select a managed LXC backend explicitly:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend lxd setup run --live
-PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend incus setup run --live
+tiny-swarm-world --lxc-backend lxd setup run --live
+tiny-swarm-world --lxc-backend incus setup run --live
 ```
 
 For repeatable WSL/Linux operator runs with evidence capture, use the repository
@@ -242,26 +243,26 @@ Where to find the scripts/services:
 List the supported workflow-level commands first:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world --list-workflows
+tiny-swarm-world --list-workflows
 ```
 
 Run only the workflow you explicitly intend to execute, for example:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world platform verify
+tiny-swarm-world platform verify
 ```
 
 For the autonomous setup flow, `setup run` without `--live` is the safe refusal
 probe:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world setup run
+tiny-swarm-world setup run
 ```
 
 The canonical live operator command is:
 
 ```bash
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ```
 
 Platform workflows are constructed through the infrastructure composition root
@@ -394,6 +395,7 @@ Prepare a local environment:
 - `source .venv/bin/activate`
 - `python3 -m pip install --upgrade pip`
 - `python3 -m pip install -r requirements.txt`
+- `python3 -m pip install -e .`
 - `python3 -m pip install ruff mypy import-linter types-requests`
 
 Run the full gate before handing off a change:
@@ -428,7 +430,9 @@ Notes:
   installed.
 - Docker connection issues: Verify Docker Engine or the Docker CLI target is available and your user has permission to access the Docker socket.
 - WSL2 networking/ports: Install `socat` and review `infra/config/network` for port-forwarding helpers.
-- Python import errors: Run commands from the repository root and set `PYTHONPATH=src` for direct script execution.
+- Python import errors: Use the installed `tiny-swarm-world` CLI after
+  `python3 -m pip install -e .`; set `PYTHONPATH=src` only for direct
+  source-checkout module execution.
 
 ---
 

--- a/documentation/arc42/04_context_and_scope.adoc
+++ b/documentation/arc42/04_context_and_scope.adoc
@@ -28,8 +28,12 @@ The supported operator entry point is:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world
+tiny-swarm-world
 ----
+
+This command is provided by the editable or packaged Python installation.
+`PYTHONPATH=src python3 -m tiny_swarm_world` remains the source-checkout
+fallback for diagnostics before installation.
 
 Removed direct setup helpers and host-side orchestration scripts are classified
 in `documentation/system/live-operation-surfaces.adoc`. They are not default

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -73,6 +73,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 python3 -m pip install ruff mypy import-linter types-requests
 ----
 
@@ -140,21 +141,26 @@ LXD/Incus setup notes and official references.
 Python source code lives under `src/tiny_swarm_world` and uses package imports
 such as `tiny_swarm_world.application...`,
 `tiny_swarm_world.domain...`, and `tiny_swarm_world.infrastructure...`.
-Manual Python commands therefore need `PYTHONPATH=src` unless they are run
-through `tools/quality_gate.py`.
+Install the repository in editable mode from a Linux or WSL shell before
+operator runs:
 
 Example:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world
+python3 -m pip install -e .
+tiny-swarm-world
 ----
+
+Manual source-checkout commands can still use
+`PYTHONPATH=src python3 -m tiny_swarm_world`. `tools/quality_gate.py` sets the
+needed source path for repository checks.
 
 List supported workflow-level commands without building application services:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world --list-workflows
+tiny-swarm-world --list-workflows
 ----
 
 == IntelliJ Execution Context
@@ -166,7 +172,7 @@ preflight checks. The command remains:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ----
 
 The live confirmation prompt requires stdin. Run the command from an IntelliJ
@@ -177,7 +183,7 @@ The safe setup probe is:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run
+tiny-swarm-world setup run
 ----
 
 Without the complete live-consent contract, `setup run` refuses before setup
@@ -188,7 +194,7 @@ The canonical live operator command uses `lxc_native` by default:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ----
 
 For repeatable Linux or WSL operator runs with local evidence capture, use:

--- a/documentation/user_guide/usage.adoc
+++ b/documentation/user_guide/usage.adoc
@@ -35,33 +35,37 @@ directory.
 
 == Main Python Entrypoint
 
-The main workflow entry point is:
+After installing the repository in editable mode, the main workflow entry point
+is:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world
+tiny-swarm-world
 ----
+
+For source-checkout diagnostics before installation, the equivalent module
+fallback remains `PYTHONPATH=src python3 -m tiny_swarm_world`.
 
 Running without arguments does not execute infrastructure commands. List the
 workflow-level commands first:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world --list-workflows
+tiny-swarm-world --list-workflows
 ----
 
 Static preflight remains available without live-infrastructure consent:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world --preflight
+tiny-swarm-world --preflight
 ----
 
 Non-mutating workflow checks can be selected explicitly:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world platform verify
+tiny-swarm-world platform verify
 ----
 
 The safe setup probe is `setup run` without `--live`. It refuses before setup
@@ -69,7 +73,7 @@ services are constructed:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run
+tiny-swarm-world setup run
 ----
 
 The canonical live operator command requires live-infrastructure consent before
@@ -77,7 +81,7 @@ services are constructed and uses `lxc_native` by default:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ----
 
 The setup sequence includes `platform expose`, which configures the
@@ -88,8 +92,8 @@ Select a managed LXC backend explicitly when both LXD and Incus are available:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend lxd setup run --live
-PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend incus setup run --live
+tiny-swarm-world --lxc-backend lxd setup run --live
+tiny-swarm-world --lxc-backend incus setup run --live
 ----
 
 The command prompts for a short confirmation:
@@ -107,8 +111,8 @@ Destructive platform workflows also require the exact confirmation phrase:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world platform reset --confirm RESET_TINY_SWARM_PLATFORM --live
-PYTHONPATH=src python3 -m tiny_swarm_world platform destroy --confirm DESTROY_TINY_SWARM_PLATFORM --live
+tiny-swarm-world platform reset --confirm RESET_TINY_SWARM_PLATFORM --live
+tiny-swarm-world platform destroy --confirm DESTROY_TINY_SWARM_PLATFORM --live
 ----
 
 Reset and destroy are explicit confirmation contracts. Their destructive
@@ -148,7 +152,7 @@ blocked or failed phase evidence when live prerequisites are unavailable:
 
 [source,bash]
 ----
-PYTHONPATH=src python3 -m tiny_swarm_world setup run --live
+tiny-swarm-world setup run --live
 ----
 
 Former direct service preparation helpers have been

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,21 +1,21 @@
 {
-  "workflow_id": "issue-4-swarm-stack-validation-20260614",
+  "workflow_id": "issue-78-python-packaging-20260614",
   "workflow_version": "1.0.0",
-  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4",
-  "issue_number": 4,
-  "workflow_path": "documentation/workflow/issues/issue-4/workflow.md",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/78",
+  "issue_number": 78,
+  "workflow_path": "documentation/workflow/issues/issue-78/workflow.md",
   "authoring_branch": "feature/workflow-index-open-issues-20260614",
-  "branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
-  "proposed_execution_branch": "feature/workflow-issue-4-swarm-stack-validation-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-78-python-packaging-20260614",
   "execution_profile": "NORMAL_PATH",
-  "status": "COMPLETED_WITH_EVIDENCE",
+  "status": "ACTIVE_READY_FOR_WORKFLOW_EXECUTE",
   "created_utc": "2026-06-14T00:00:00Z",
   "dependencies": [],
   "affected_areas": [
-    "infra/config/compose/**",
-    "src/tiny_swarm_world/domain/deployment/**",
-    "src/tiny_swarm_world/application/services/deployment/**",
+    "pyproject.toml",
+    "src/tiny_swarm_world/__main__.py",
+    "requirements.txt",
     "tests/**",
+    "README.md",
     "documentation/**"
   ],
   "forbidden_areas": [
@@ -55,34 +55,5 @@
       "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
     }
   ],
-  "execution_closeout": {
-    "status": "COMPLETED_WITH_EVIDENCE",
-    "slice_commits": [
-      {
-        "slice_id": "S01",
-        "commit": "ec24db3",
-        "evidence": "baseline and decision gate"
-      },
-      {
-        "slice_id": "S02",
-        "commit": "fa0744d",
-        "evidence": "compose repository validation and tests"
-      },
-      {
-        "slice_id": "S03",
-        "commit": "920dc94",
-        "evidence": "architecture validation"
-      },
-      {
-        "slice_id": "S04",
-        "commit": "pending",
-        "evidence": "final quality closeout"
-      }
-    ],
-    "final_quality_gate": {
-      "command": "python3 tools/quality_gate.py quality",
-      "status": "passed",
-      "tests": "833 passed, 17 skipped"
-    }
-  }
+  "branch": "feature/workflow-issue-78-python-packaging-20260614"
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,23 +1,14 @@
-# Context Pack: Issue #4 Validate Docker Swarm stack definitions
+# Context Pack: Issue #78 Add standard Python packaging
 
-- Workflow id: `issue-4-swarm-stack-validation-20260614`
-- Workflow path: `documentation/workflow/issues/issue-4/workflow.md`
+- Workflow id: `issue-78-python-packaging-20260614`
+- Workflow path: `documentation/workflow/issues/issue-78/workflow.md`
 - Authoring branch: `feature/workflow-index-open-issues-20260614`
-- Active execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
-- Proposed execution branch: `feature/workflow-issue-4-swarm-stack-validation-20260614`
-- Execution profile:
-ORMAL_PATH`
-- Status: `COMPLETED_WITH_EVIDENCE`
+- Active execution branch: `feature/workflow-issue-78-python-packaging-20260614`
+- Proposed execution branch: `feature/workflow-issue-78-python-packaging-20260614`
+- Execution profile: `NORMAL_PATH`
+- Status: `ACTIVE_READY_FOR_WORKFLOW_EXECUTE`
 - Dependencies: none
 - Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
   `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.
 
 Governing hashes are recorded in `context-pack.json`.
-
-Execution closeout:
-
-- S01: `ec24db3`
-- S02: `fa0744d`
-- S03: `920dc94`
-- S04: pending final checkpoint commit
-- Final quality gate: `python3 tools/quality_gate.py quality` passed.

--- a/documentation/workflow/issues/issue-78/python-packaging-baseline.md
+++ b/documentation/workflow/issues/issue-78/python-packaging-baseline.md
@@ -1,0 +1,40 @@
+# Issue 78 Python Packaging Baseline
+
+## Decision
+
+Issue #78 should add standard `pyproject.toml` metadata while preserving the
+existing `setup.py` compatibility surface.
+
+The selected implementation path is:
+
+- add `pyproject.toml` with setuptools build metadata, Python 3.12 support,
+  runtime dependencies, package discovery under `src`, and a console script;
+- add a synchronous CLI wrapper in `tiny_swarm_world.__main__` for console
+  script execution while preserving `python -m tiny_swarm_world`;
+- keep `setup.py` compatible with the same console script for legacy editable
+  installs;
+- add package metadata tests that do not require live infrastructure;
+- update README and user guide command examples to prefer the installed CLI
+  while keeping direct module execution documented for source checkout work.
+
+## Repository Evidence
+
+- `setup.py` already exists and reads runtime dependencies from
+  `requirements.txt`.
+- No `pyproject.toml` exists at workflow start.
+- `src/tiny_swarm_world/__main__.py` exposes async `main(...)` and currently
+  calls `asyncio.run(main())` only under the module guard.
+- README and user-guide command examples mostly use
+  `PYTHONPATH=src python3 -m tiny_swarm_world`.
+
+## Non-Goals
+
+- No live infrastructure execution.
+- No packaging backend switch away from setuptools.
+- No removal of `python -m tiny_swarm_world`.
+- No change to repository quality gate behavior.
+
+## Next Slice
+
+Slice 02 should add `pyproject.toml`, add the console script wrapper, keep
+`setup.py` compatible, and add package metadata tests.

--- a/documentation/workflow/issues/issue-78/workflow.md
+++ b/documentation/workflow/issues/issue-78/workflow.md
@@ -6,11 +6,12 @@ workflow_version: 1.0.0
 issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/78
 issue_number: 78
 authoring_branch: feature/workflow-index-open-issues-20260614
+branch: feature/workflow-issue-78-python-packaging-20260614
 proposed_execution_branch: feature/workflow-issue-78-python-packaging-20260614
 indexed_workflow: true
-active_workflow: false
+active_workflow: true
 execution_profile: NORMAL_PATH
-released_for_workflow_execute: false
+released_for_workflow_execute: true
 created_utc: "2026-06-14T00:00:00Z"
 decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
 confidence: 89
@@ -21,8 +22,7 @@ dependencies: []
 
 Add Python 3.12 packaging metadata and a CLI entry point while preserving the thin module entry path.
 
-This indexed workflow is authored for later promotion or explicit indexed
-execution. It does not replace `documentation/workflow/workflow.md`.
+This workflow has been promoted from the indexed workflow set and is active for `workflow execute` on branch `feature/workflow-issue-78-python-packaging-20260614`.
 
 ## Requirement Clarification Gate
 
@@ -201,8 +201,7 @@ affected_modules:
   - Python packaging and CLI entry point
 affected_contracts:
   - issue_78_python_packaging
-dependencies:
-  []
+dependencies: []
 parallel_group: issue-78-group-1
 file_locks:
   - documentation/workflow/issues/issue-78/**
@@ -215,10 +214,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -282,10 +281,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -343,10 +342,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -402,10 +401,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -552,9 +551,7 @@ review.
 
 ## Handoff To Workflow Execute
 
-Do not run unqualified `workflow execute` for this indexed workflow. First
-promote it to `documentation/workflow/workflow.md` or extend the executor to
-accept an explicit indexed workflow path.
+Run `workflow execute` from this branch and this worktree. The executor must verify S3/S3D metadata, locks, evidence, targeted checks, and quality gates before implementation.
 
 ## arc42 Check Status
 

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,28 +1,28 @@
-# Workflow: Validate Docker Swarm stack definitions
+# Workflow: Add standard Python packaging
 
 ```yaml
-workflow_id: issue-4-swarm-stack-validation-20260614
+workflow_id: issue-78-python-packaging-20260614
 workflow_version: 1.0.0
-issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/4
-issue_number: 4
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/78
+issue_number: 78
 authoring_branch: feature/workflow-index-open-issues-20260614
-branch: feature/workflow-issue-4-swarm-stack-validation-20260614
-proposed_execution_branch: feature/workflow-issue-4-swarm-stack-validation-20260614
+branch: feature/workflow-issue-78-python-packaging-20260614
+proposed_execution_branch: feature/workflow-issue-78-python-packaging-20260614
 indexed_workflow: true
 active_workflow: true
 execution_profile: NORMAL_PATH
 released_for_workflow_execute: true
 created_utc: "2026-06-14T00:00:00Z"
 decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
-confidence: 75
+confidence: 89
 dependencies: []
 ```
 
 ## Executive Summary
 
-Validate compose files as Docker Swarm stack definitions and fail when stack-only requirements such as deploy sections are missing.
+Add Python 3.12 packaging metadata and a CLI entry point while preserving the thin module entry path.
 
-This workflow has been promoted from the indexed workflow set and is active for `workflow execute` on branch `feature/workflow-issue-4-swarm-stack-validation-20260614`.
+This workflow has been promoted from the indexed workflow set and is active for `workflow execute` on branch `feature/workflow-issue-78-python-packaging-20260614`.
 
 ## Requirement Clarification Gate
 
@@ -35,26 +35,27 @@ Original request:
 
 Interpreted intent:
 
-- Create an executable workflow plan for Issue #4: Validate Docker Swarm stack definitions.
+- Create an executable workflow plan for Issue #78: Add standard Python packaging.
 - Defer implementation until all indexed workflows are authored and the
   execution order is selected from `workflow.index.md`.
 
 Change type:
 
-- Workflow creation for future deployment configuration validation work.
+- Workflow creation for future Python packaging and CLI entry point work.
 
 Affected process strand:
 
-- deployment configuration validation.
+- Python packaging and CLI entry point.
 - Workflow execution with S3/S3D validation.
 - Documentation and quality-gate synchronization.
 
 Affected architecture area:
 
-- `infra/config/compose/**`
-- `src/tiny_swarm_world/domain/deployment/**`
-- `src/tiny_swarm_world/application/services/deployment/**`
+- `pyproject.toml`
+- `src/tiny_swarm_world/__main__.py`
+- `requirements.txt`
 - `tests/**`
+- `README.md`
 - `documentation/**`
 
 Explicit requirements:
@@ -106,13 +107,13 @@ Blocking questions:
 - None for workflow authoring. Any issue-specific decision is represented
   as an early executable decision slice when required.
 
-Confidence level: 75 percent.
+Confidence level: 89 percent.
 
 Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
 
 ## Target Picture
 
-Issue #4 has an executable, test-backed implementation path that
+Issue #78 has an executable, test-backed implementation path that
 preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
 boundaries, and guarded live-infrastructure safety.
 
@@ -120,7 +121,7 @@ boundaries, and guarded live-infrastructure safety.
 
 - Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
   were checked during indexed workflow authoring.
-- The workflow is stored under `documentation/workflow/issues/issue-4/`.
+- The workflow is stored under `documentation/workflow/issues/issue-78/`.
 - This workflow is not the active workflow until explicitly promoted or
   selected by an indexed executor.
 
@@ -129,7 +130,7 @@ boundaries, and guarded live-infrastructure safety.
 In scope:
 
 - Files and modules listed in the affected architecture area.
-- Tests and documentation needed to satisfy Issue #4.
+- Tests and documentation needed to satisfy Issue #78.
 - Quality gates from `QUALITY.md`.
 
 Out of scope:
@@ -183,7 +184,7 @@ any, remains terminal-oriented and routes through console/status UI skills.
 
 Purpose:
 
-- Requirement, repository baseline, and decision gate for Issue #4.
+- Requirement, repository baseline, and decision gate for Issue #78.
 
 ```yaml
 slice_id: S01
@@ -193,21 +194,21 @@ secondary_reviewers:
   - Senior System Architect
   - Senior Tester
 affected_files:
-  - documentation/workflow/issues/issue-4/**
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
+  - documentation/workflow/issues/issue-78/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
 affected_modules:
-  - deployment configuration validation
+  - Python packaging and CLI entry point
 affected_contracts:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 dependencies: []
-parallel_group: issue-4-group-1
+parallel_group: issue-78-group-1
 file_locks:
-  - documentation/workflow/issues/issue-4/**
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
+  - documentation/workflow/issues/issue-78/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
 contract_locks:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -243,7 +244,7 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Scoped implementation inside the declared architecture boundary for Issue #4.
+- Scoped implementation inside the declared architecture boundary for Issue #78.
 
 ```yaml
 slice_id: S02
@@ -253,26 +254,28 @@ secondary_reviewers:
   - Senior System Architect
   - Senior Tester
 affected_files:
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
-  - src/tiny_swarm_world/application/services/deployment/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+  - requirements.txt
   - tests/**
+  - README.md
   - documentation/**
 affected_modules:
-  - deployment configuration validation
+  - Python packaging and CLI entry point
 affected_contracts:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 dependencies:
   - S01
-parallel_group: issue-4-group-2
+parallel_group: issue-78-group-2
 file_locks:
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
-  - src/tiny_swarm_world/application/services/deployment/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
+  - requirements.txt
   - tests/**
+  - README.md
   - documentation/**
 contract_locks:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -308,7 +311,7 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Focused regression and architecture tests for Issue #4.
+- Focused regression and architecture tests for Issue #78.
 
 ```yaml
 slice_id: S03
@@ -319,21 +322,21 @@ secondary_reviewers:
   - Senior Tester
 affected_files:
   - tests/**
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
 affected_modules:
-  - deployment configuration validation
+  - Python packaging and CLI entry point
 affected_contracts:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 dependencies:
   - S02
-parallel_group: issue-4-group-3
+parallel_group: issue-78-group-3
 file_locks:
   - tests/**
-  - infra/config/compose/**
-  - src/tiny_swarm_world/domain/deployment/**
+  - pyproject.toml
+  - src/tiny_swarm_world/__main__.py
 contract_locks:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -369,7 +372,7 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Documentation synchronization and final quality evidence for Issue #4.
+- Documentation synchronization and final quality evidence for Issue #78.
 
 ```yaml
 slice_id: S04
@@ -382,17 +385,17 @@ affected_files:
   - documentation/**
   - README.md
 affected_modules:
-  - deployment configuration validation
+  - Python packaging and CLI entry point
 affected_contracts:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 dependencies:
   - S03
-parallel_group: issue-4-group-4
+parallel_group: issue-78-group-4
 file_locks:
   - documentation/**
   - README.md
 contract_locks:
-  - issue_4_swarm_stack_validation
+  - issue_78_python_packaging
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -437,7 +440,7 @@ Cross-workflow dependencies: none.
 - Can this workflow run in parallel? Only after S3D confirms disjoint file,
   contract, module, and architecture locks.
 - Conflicting workflows: see `documentation/workflow/workflow.index.md`.
-- Shared files: infra/config/compose/**, src/tiny_swarm_world/domain/deployment/**, src/tiny_swarm_world/application/services/deployment/**, tests/**, documentation/**.
+- Shared files: pyproject.toml, src/tiny_swarm_world/__main__.py, requirements.txt, tests/**, README.md, documentation/**.
 - Shared infrastructure: none for default verification; live validation is
   serialized unless isolated infrastructure is explicitly provided.
 - Requires isolated worktree: yes for workflow execution streams.
@@ -533,7 +536,7 @@ Workflow authoring commit:
 Future workflow execution:
 
 - Promote or explicitly select this indexed workflow.
-- Use proposed execution branch `feature/workflow-issue-4-swarm-stack-validation-20260614` unless a later
+- Use proposed execution branch `feature/workflow-issue-78-python-packaging-20260614` unless a later
   governance decision selects another branch.
 - Commit each executable slice separately.
 
@@ -542,44 +545,9 @@ Future workflow execution:
 Workflow authoring is done when this file, its context pack, and the index
 entry exist and pass documentation checks.
 
-Issue #4 implementation is done when acceptance criteria are satisfied
+Issue #78 implementation is done when acceptance criteria are satisfied
 by scoped code, tests, documentation, quality evidence, and merge-ready
 review.
-
-## Workflow Execution Evidence
-
-Execution status: `COMPLETED_WITH_EVIDENCE`.
-
-Slice checkpoint commits:
-
-| Slice | Commit | Evidence |
-|---|---|---|
-| S01 | `ec24db3` | Baseline and decision gate for per-service `deploy` validation. |
-| S02 | `fa0744d` | `ComposeFileRepositoryYaml` validates Swarm stack compose files and focused tests cover invalid definitions. |
-| S03 | `920dc94` | Architecture validation evidence confirms hexagonal boundaries remain intact. |
-
-Issue #4 acceptance mapping:
-
-- Valid Docker Swarm stack detection: product compose files are loaded through
-  structured YAML and must define a non-empty `services` mapping.
-- `deploy:` section present: each service returned by the compose repository
-  must define a mapping-valued `deploy` section.
-- Failure before live mutation: invalid compose files raise `ValueError` at the
-  repository boundary before Portainer or Swarm runtime adapters are called.
-
-Verification evidence:
-
-```bash
-PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml
-python3 tools/quality_gate.py test
-python3 tools/quality_gate.py arch-tests
-python3 tools/quality_gate.py quality
-```
-
-Final quality result:
-
-- `python3 tools/quality_gate.py quality` passed.
-- 833 repository tests passed, 17 skipped.
 
 ## Handoff To Workflow Execute
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tiny-swarm-world"
+version = "0.1.0"
+description = "Linux/WSL local infrastructure automation for Tiny Swarm World"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+  "pydantic==2.10.6",
+  "PyYAML==6.0.1",
+  "requests==2.32.0",
+  "ruamel.yaml==0.17.21",
+]
+
+[project.scripts]
+tiny-swarm-world = "tiny_swarm_world.__main__:cli"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,15 @@ def _runtime_requirements() -> list[str]:
 
 setup(
     name="tiny-swarm-world",
-    version="0.1",
+    version="0.1.0",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=_runtime_requirements(),
     python_requires=">=3.12",
+    entry_points={
+        "console_scripts": [
+            "tiny-swarm-world=tiny_swarm_world.__main__:cli",
+        ],
+    },
 )

--- a/src/tiny_swarm_world/__main__.py
+++ b/src/tiny_swarm_world/__main__.py
@@ -208,6 +208,10 @@ async def main(argv: Sequence[str] | None = None) -> None:
     logger.info("Done")
 
 
+def cli(argv: Sequence[str] | None = None) -> None:
+    asyncio.run(main(argv))
+
+
 def _print_workflow_list() -> None:
     for workflow in CLI_WORKFLOWS:
         print(f"{workflow.name}\tmutating={workflow.mutating}\tdestructive={workflow.destructive}")
@@ -544,4 +548,4 @@ def _print_setup_installation_summary(result: SetupWorkflowResult) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    cli()

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,63 @@
+import ast
+import tomllib
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestPackageMetadata(unittest.TestCase):
+    def _setup_keyword_values(self) -> dict[str, ast.expr]:
+        setup_tree = ast.parse((REPOSITORY_ROOT / "setup.py").read_text(encoding="utf-8"))
+        setup_call = next(
+            node
+            for node in ast.walk(setup_tree)
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "setup"
+        )
+        keyword_values: dict[str, ast.expr] = {}
+        for keyword in setup_call.keywords:
+            assert keyword.arg is not None
+            keyword_values[keyword.arg] = keyword.value
+        return keyword_values
+
+    def test_pyproject_declares_package_metadata_and_cli_entrypoint(self):
+        pyproject = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+        self.assertEqual("tiny-swarm-world", pyproject["project"]["name"])
+        self.assertEqual(">=3.12", pyproject["project"]["requires-python"])
+        self.assertEqual(
+            "tiny_swarm_world.__main__:cli",
+            pyproject["project"]["scripts"]["tiny-swarm-world"],
+        )
+        self.assertEqual(["src"], pyproject["tool"]["setuptools"]["packages"]["find"]["where"])
+
+    def test_pyproject_dependencies_match_runtime_requirements(self):
+        requirements = [
+            line.strip()
+            for line in (REPOSITORY_ROOT / "requirements.txt").read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        pyproject = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+        self.assertEqual(requirements, pyproject["project"]["dependencies"])
+
+    def test_package_versions_are_aligned(self):
+        pyproject = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        setup_version = ast.literal_eval(self._setup_keyword_values()["version"])
+
+        self.assertEqual(pyproject["project"]["version"], setup_version)
+
+    def test_setup_py_keeps_legacy_console_script_compatible(self):
+        keyword_values = self._setup_keyword_values()
+
+        self.assertIn("entry_points", keyword_values)
+        entry_points = ast.literal_eval(keyword_values["entry_points"])
+        self.assertEqual(
+            ["tiny-swarm-world=tiny_swarm_world.__main__:cli"],
+            entry_points["console_scripts"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add standard Python package metadata in `pyproject.toml` and keep legacy `setup.py` aligned.
- Add the installed `tiny-swarm-world` console script entry point via a synchronous CLI wrapper.
- Add packaging metadata regression tests and document installed CLI usage in README, user guide, and arc42 context.

## Workflow Evidence

- Issue: #78
- Workflow branch: `feature/workflow-issue-78-python-packaging-20260614`
- Slice evidence: `.codex/evidence/issue-78/`

## Validation

- `PYTHONPATH=src python3 -m unittest tests.test_package_metadata tests.test_package_entrypoint` passed, 33 tests.
- Editable install smoke check passed: `python3 -m pip install -e . && tiny-swarm-world --list-workflows`.
- `python3 tools/quality_gate.py arch-tests` passed, 16 tests.
- `python3 tools/quality_gate.py test` passed, 837 tests, 17 skipped.
- `python3 tools/quality_gate.py quality` passed: lint, arch-lint, arch-tests, typecheck, and tests.

Note: pip reports the existing `requests==2.32.0` pin is yanked. This PR mirrors the existing `requirements.txt` pin and does not change that dependency version.