### PR TITLE
Make provider resource mapping backend aware

### DIFF
--- a/.codex/evidence/issue-65/slice-01-consolidation.md
+++ b/.codex/evidence/issue-65/slice-01-consolidation.md
@@ -1,0 +1,59 @@
+# Slice 01 Consolidation: Issue 65 Baseline
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S01`
+Slice title: Requirement, repository baseline, and decision gate
+
+## Requirement Classification
+
+- Functional: resolve network and storage resources per selected managed LXC
+  backend.
+- Architecture: keep backend-specific mapping in configuration and
+  infrastructure adapters, not domain logic or application services.
+- Resilience: missing selected-backend mappings must block before mutation.
+- Documentation: operator override examples must describe backend-specific
+  resource mappings.
+- Quality: tests must cover Incus, LXD, and missing mapping failure.
+
+## Repository Baseline
+
+- `infra/config/node-providers/provider_config.yaml` currently supports Incus
+  and LXD backend candidates but has a single global
+  `provider_resource_resolution` mapping: `control: lxdbr0`, storage pool
+  `default`.
+- `NodeProviderConfigYamlRepository` currently accepts only
+  `network_mappings` and `storage_pool` directly under
+  `provider_resource_resolution`.
+- `ProviderResourceResolution` is currently a single global value object.
+- `LxcNodeProvider.ensure_node()` already verifies provider resources before
+  profile reconciliation, node lookup, launch, or mutation.
+- Resource verification and launch commands use the selected backend CLI, but
+  read network and storage names from the global mapping.
+- Existing tests include resource-resolution coverage, but some assertions use
+  LXD-specific `lxdbr0` expectations for Incus selections.
+
+## Subagent Findings
+
+- Real subagent review completed read-only.
+- Accepted finding: proceed to S02 with backend-specific resource-resolution
+  configuration.
+- Accepted finding: do not put CLI names, bridge names, YAML structure, or
+  adapter details into domain logic.
+- Accepted finding: selected backend without mapping must block before live
+  mutation.
+
+## Rejected Findings
+
+- None.
+
+## Tests Executed
+
+- `git diff --check`
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_node_provider_config_yaml_repository tests.infrastructure.adapters.clients.test_lxc_node_provider tests.infrastructure.test_composition`
+  - Result: passed, 122 tests.
+
+## Decision
+
+Proceed to S02. Requirements are clear enough and repository evidence supports
+a scoped implementation in configuration parsing plus the LXC node provider
+adapter, with focused tests and documentation updates.

--- a/.codex/evidence/issue-65/slice-01-distribution.md
+++ b/.codex/evidence/issue-65/slice-01-distribution.md
@@ -1,0 +1,54 @@
+# Slice 01 Distribution: Issue 65 Backend Resource Mapping
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S01`
+Slice title: Requirement, repository baseline, and decision gate
+
+## Affected Areas
+
+- `documentation/workflow/issues/issue-65/**`
+- `infra/config/node-providers/**`
+- `src/tiny_swarm_world/domain/node_provider/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
+- `tests/**`
+
+## Execution Mode
+
+Sequential.
+
+## Selected Streams
+
+- requirements
+- architecture
+- tests
+
+## Subagents
+
+Real read-only subagent review used for repository baseline and implementation
+risk assessment.
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-65-backend-resource-mapping
+```
+
+## Conflict Risks
+
+- Backend-specific resource mapping must stay in configuration and
+  infrastructure boundaries.
+- Missing selected-backend mappings must fail before live mutation.
+- Existing tests currently encode LXD-specific expectations for Incus paths.
+
+## Quality Gates
+
+- `git diff --check`
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_node_provider_config_yaml_repository tests.infrastructure.adapters.clients.test_lxc_node_provider tests.infrastructure.test_composition`
+
+## Consolidation Plan
+
+Record repository baseline, classify requirements, and proceed to S02 only if
+repository evidence shows a clear backend-aware configuration path without
+architecture or live-infrastructure conflicts.

--- a/.codex/evidence/issue-65/slice-02-consolidation.md
+++ b/.codex/evidence/issue-65/slice-02-consolidation.md
@@ -1,0 +1,92 @@
+# Slice 02 Consolidation: Issue 65 Implementation
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S02`
+Slice title: Scoped implementation inside the declared architecture boundary
+
+## Stream Results
+
+- Backend stream completed.
+- Test stream completed.
+- Architecture review stream completed read-only.
+
+## Accepted Findings
+
+- `provider_resource_resolution` is now backend-specific through
+  `provider_resource_resolution.backends.incus` and
+  `provider_resource_resolution.backends.lxd`.
+- `LxcNodeProvider` resolves network and storage resources through the selected
+  backend before profile checks, node lookup, launch, or mutation.
+- Missing selected-backend mapping blocks with `inventory_mapping_missing`
+  before runner commands are executed.
+- Evidence includes the selected backend separately and keeps remediation hints
+  backend-neutral to preserve summary-only evidence safety.
+- Repository validation requires Incus and LXD resource mappings because both
+  backends are supported candidates.
+
+## Rejected Findings
+
+- None.
+
+## Files Changed Per Stream
+
+Backend:
+
+- `infra/config/node-providers/provider_config.yaml`
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py`
+- `src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py`
+
+Tests:
+
+- `tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py`
+- `tests/infrastructure/adapters/clients/test_lxc_node_provider.py`
+
+Evidence:
+
+- `.codex/evidence/issue-65/slice-02-distribution.md`
+- `.codex/evidence/issue-65/slice-02-consolidation.md`
+
+## Conflicts Found
+
+- Existing LXC node provider tests encoded LXD-specific resource names for
+  Incus selections.
+- Initial backend-specific remediation text contained provider command-like
+  words in `remediation_hint`, which violated evidence safety.
+
+## Conflicts Resolved
+
+- Tests now assert Incus uses `incusbr0`, LXD uses `lxdbr0`, and selected
+  backend mappings are isolated.
+- Remediation hints are backend-neutral while the `backend` evidence key
+  records the selected backend.
+
+## Tests Executed
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_node_provider_config_yaml_repository tests.infrastructure.adapters.clients.test_lxc_node_provider`
+  - First run failed on evidence-safety validation for backend-specific
+    remediation text.
+  - Final run passed, 61 tests.
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.infrastructure.adapters.preflight.test_lxc_provider_preflight tests.application.services.platform.test_node_provider_selection`
+  - Passed, 95 tests.
+- `python3 tools/quality_gate.py lint`
+  - Passed.
+- `python3 tools/quality_gate.py typecheck`
+  - Passed, no issues in 391 source files.
+- `git diff --check`
+  - Passed.
+
+## SonarQube Findings
+
+- No local SonarQube findings were available during this slice.
+
+## Documentation Updates
+
+- S04 must document the hard schema migration from global
+  `provider_resource_resolution.network_mappings/storage_pool` to
+  backend-specific `provider_resource_resolution.backends.<backend>`.
+
+## Final Integration Decision
+
+Accept S02. The implementation satisfies Issue #65 behavior inside
+configuration and infrastructure boundaries without live infrastructure
+execution.

--- a/.codex/evidence/issue-65/slice-02-distribution.md
+++ b/.codex/evidence/issue-65/slice-02-distribution.md
@@ -1,0 +1,54 @@
+# Slice 02 Distribution: Issue 65 Implementation
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S02`
+Slice title: Scoped implementation inside the declared architecture boundary
+
+## Affected Areas
+
+- `infra/config/node-providers/provider_config.yaml`
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py`
+- `src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py`
+- `tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py`
+- `tests/infrastructure/adapters/clients/test_lxc_node_provider.py`
+
+## Execution Mode
+
+Sequential implementation.
+
+## Selected Streams
+
+- backend
+- tests
+- architecture
+
+## Subagents
+
+Real read-only subagent review used after implementation.
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-65-backend-resource-mapping
+```
+
+## Conflict Risks
+
+- Schema migration must fail closed and be documented in S04.
+- Resource mapping must remain in infrastructure/configuration boundaries.
+- Evidence must remain summary-only and avoid raw command-like remediation text.
+
+## Quality Gates
+
+- `git diff --check`
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_node_provider_config_yaml_repository tests.infrastructure.adapters.clients.test_lxc_node_provider`
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.infrastructure.adapters.preflight.test_lxc_provider_preflight tests.application.services.platform.test_node_provider_selection`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py typecheck`
+
+## Consolidation Plan
+
+Accept the backend-aware resource mapping implementation only if focused tests,
+typecheck, lint, evidence safety, and subagent review pass.

--- a/.codex/evidence/issue-65/slice-03-consolidation.md
+++ b/.codex/evidence/issue-65/slice-03-consolidation.md
@@ -1,0 +1,50 @@
+# Slice 03 Consolidation: Issue 65 Regression
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S03`
+Slice title: Focused regression and architecture tests
+
+## Stream Results
+
+- Architecture regression stream completed.
+- Full unit-test stream completed.
+- Documentation drift scan completed.
+
+## Accepted Findings
+
+- Backend-specific resource mapping did not break composition, preflight,
+  provider selection, architecture tests, or the full unittest suite.
+- Documentation still contains LXD-only bridge examples in the installation
+  guide and must be updated in S04.
+- `_lxc_reachable_host_ip()` still probes `lxdbr0` and `incusbr0`; this is an
+  auto-detection helper, not the provider resource mapping used for LXC node
+  launch.
+
+## Rejected Findings
+
+- No S03 blocker found.
+
+## Files Changed Per Stream
+
+Evidence:
+
+- `.codex/evidence/issue-65/slice-03-distribution.md`
+- `.codex/evidence/issue-65/slice-03-consolidation.md`
+
+## Tests Executed
+
+- `python3 tools/quality_gate.py arch-tests`
+  - Passed, 16 tests.
+- `python3 tools/quality_gate.py test`
+  - Passed, 845 tests, 17 skipped.
+
+## Documentation Drift
+
+Detected S04 documentation candidates:
+
+- `documentation/user_guide/installation.adoc` still uses LXD-only `lxdbr0`
+  bridge wording and commands.
+
+## Final Integration Decision
+
+Accept S03. Route documentation drift and full quality evidence to S04.

--- a/.codex/evidence/issue-65/slice-03-distribution.md
+++ b/.codex/evidence/issue-65/slice-03-distribution.md
@@ -1,0 +1,51 @@
+# Slice 03 Distribution: Issue 65 Regression
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S03`
+Slice title: Focused regression and architecture tests
+
+## Affected Areas
+
+- `tests/**`
+- `infra/config/node-providers/**`
+- `src/tiny_swarm_world/domain/node_provider/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
+
+## Execution Mode
+
+Sequential verification.
+
+## Selected Streams
+
+- tests
+- architecture
+- documentation drift scan
+
+## Subagents
+
+No additional subagent was required for S03 because S02 already received a
+read-only implementation review and S03 is verification-only.
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-65-backend-resource-mapping
+```
+
+## Conflict Risks
+
+- Full test suite may reveal hidden assumptions about the global resource
+  mapping schema.
+- Documentation drift may remain after code and tests pass.
+
+## Quality Gates
+
+- `python3 tools/quality_gate.py arch-tests`
+- `python3 tools/quality_gate.py test`
+- static search for stale resource-mapping wording
+
+## Consolidation Plan
+
+Record full regression results and route documentation-only drift to S04.

--- a/.codex/evidence/issue-65/slice-04-consolidation.md
+++ b/.codex/evidence/issue-65/slice-04-consolidation.md
@@ -1,0 +1,66 @@
+# Slice 04 Consolidation: Issue 65 Documentation And Quality
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S04`
+Slice title: Documentation synchronization and final quality evidence
+
+## Stream Results
+
+- Documentation stream completed.
+- Quality stream completed.
+
+## Accepted Findings
+
+- Documented `provider_resource_resolution.backends.<backend>` as the
+  operator override surface for backend-specific network and storage names.
+- Documented the hard migration away from global
+  `provider_resource_resolution.network_mappings/storage_pool`.
+- Replaced LXD-only bridge firewall examples with selected-backend bridge
+  placeholders.
+- Preserved Linux/WSL-only and live-consent safety wording.
+
+## Rejected Findings
+
+- No findings rejected.
+
+## Files Changed Per Stream
+
+Documentation:
+
+- `documentation/system/lxc-native-setup.adoc`
+- `documentation/user_guide/installation.adoc`
+
+Evidence:
+
+- `.codex/evidence/issue-65/slice-04-distribution.md`
+- `.codex/evidence/issue-65/slice-04-consolidation.md`
+
+## Conflicts Found
+
+- The installation guide still described native Linux forwarding as LXD-only.
+
+## Conflicts Resolved
+
+- Installation guidance now references the bridge resolved from
+  `provider_resource_resolution.backends.<backend>.network_mappings.control`.
+
+## Tests Executed
+
+- `git diff --check`
+- `python3 tools/quality_gate.py quality`
+  - `ruff check`: passed.
+  - `lint-imports`: 3 contracts kept, 0 broken.
+  - `python3 -m unittest tests.architecture.test_hexagonal_imports`: passed,
+    16 tests.
+  - `mypy --explicit-package-bases`: passed, no issues in 391 source files.
+  - `python3 -m unittest discover`: passed, 845 tests, 17 skipped.
+
+## SonarQube Findings
+
+- No local SonarQube findings were available during this slice.
+- Remote PR checks must verify SonarCloud status or a configured green skip
+  result before merge.
+
+## Final Integration Decision
+
+Accept S04. Issue #65 is ready for push auto.

--- a/.codex/evidence/issue-65/slice-04-distribution.md
+++ b/.codex/evidence/issue-65/slice-04-distribution.md
@@ -1,0 +1,48 @@
+# Slice 04 Distribution: Issue 65 Documentation
+
+Workflow id: `issue-65-backend-resource-mapping-20260614`
+Slice id: `S04`
+Slice title: Documentation synchronization and final quality evidence
+
+## Affected Areas
+
+- `documentation/**`
+- README review
+
+## Execution Mode
+
+Sequential documentation synchronization.
+
+## Selected Streams
+
+- documentation
+- quality
+
+## Subagents
+
+No extra S04 subagent was required. S01 and S02 had real read-only subagent
+reviews; S04 scope is the documented drift found by S03 plus final quality.
+
+## Worktrees
+
+Main issue worktree:
+
+```text
+../Tiny-Swarm-World-worktrees/issue-65-backend-resource-mapping
+```
+
+## Conflict Risks
+
+- Documentation must not imply a live infrastructure run was performed.
+- Bridge firewall examples must not remain LXD-only after backend-aware
+  mappings are introduced.
+
+## Quality Gates
+
+- `git diff --check`
+- `python3 tools/quality_gate.py quality`
+
+## Consolidation Plan
+
+Document backend-specific resource mappings and run the full quality gate
+before committing final documentation evidence.

--- a/documentation/system/lxc-native-setup.adoc
+++ b/documentation/system/lxc-native-setup.adoc
@@ -100,8 +100,17 @@ It declares:
 
 * `default_provider: lxc_native`;
 * ordered candidate backends `incus` and `lxd`;
+* backend-specific `provider_resource_resolution.backends.<backend>` network
+  and storage mappings, for example `incus` resolving `control` to `incusbr0`
+  and `lxd` resolving `control` to `lxdbr0`;
 * node names `swarm-manager`, `swarm-worker-1`, and `swarm-worker-2`;
 * the `docker-swarm` profile requirements.
+
+Operators can override local network or storage names by editing the matching
+backend section in `infra/config/node-providers/provider_config.yaml` before a
+live run. The old global
+`provider_resource_resolution.network_mappings/storage_pool` shape is no
+longer accepted; missing selected-backend mappings block before mutation.
 
 Run the non-mutating project preflight before a live run:
 

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -108,6 +108,13 @@ Backend selection first honors an explicit `--lxc-backend` override, then
 `backend_selection.candidates` list in
 `infra/config/node-providers/provider_config.yaml`.
 
+Backend resource names are configured under
+`provider_resource_resolution.backends.<backend>`. The committed defaults map
+Incus `control` traffic to `incusbr0` and LXD `control` traffic to `lxdbr0`,
+with `default` as the storage pool for both backends. Override the selected
+backend section before live setup when the local network bridge or storage
+pool uses a different name.
+
 For LXD on Ubuntu where Snap is available:
 
 [source,bash]
@@ -238,14 +245,16 @@ current shell session has not activated that group yet, `install.sh` runs the
 live reset and setup commands through `sg lxd` so LXD socket access works
 without changing the WSL path.
 
-On native Linux, Docker Swarm also requires that the managed LXD containers can
-reach each other on the LXD bridge. If workers can reach the `lxdbr0` gateway
-but cannot ping the manager container or connect to Swarm port `2377`, allow
-bridge-internal forwarding on the host:
+On native Linux, Docker Swarm also requires that the managed LXC containers can
+reach each other on the selected backend bridge. Use the bridge name resolved
+from `provider_resource_resolution.backends.<backend>.network_mappings.control`
+when applying host firewall rules. If workers can reach the configured bridge
+gateway but cannot ping the manager container or connect to Swarm port `2377`,
+allow bridge-internal forwarding on the host:
 
 [source,bash]
 ----
-sudo iptables -I FORWARD 1 -i lxdbr0 -o lxdbr0 -j ACCEPT
+sudo iptables -I FORWARD 1 -i <backend-bridge> -o <backend-bridge> -j ACCEPT
 ----
 
 Verify the host firewall path before rerunning installation. Replace the
@@ -262,7 +271,7 @@ If `ufw` manages the host firewall, persist the bridge route rule with:
 
 [source,bash]
 ----
-sudo ufw route allow in on lxdbr0 out on lxdbr0
+sudo ufw route allow in on <backend-bridge> out on <backend-bridge>
 sudo ufw reload
 ----
 
@@ -277,7 +286,8 @@ sudo netfilter-persistent save
 
 Swarm bootstrap needs container-to-container access for `2377/tcp`, and later
 Swarm traffic uses `7946/tcp`, `7946/udp`, and `4789/udp`. The bridge-internal
-FORWARD rule above allows that managed LXD-node traffic on `lxdbr0`.
+FORWARD rule above allows that managed backend-node traffic on the configured
+bridge.
 
 Portainer stack create and update calls can take longer than ordinary API
 lookups while Docker Swarm pulls images or reconciles services. The installer

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,19 +1,20 @@
 {
-  "workflow_id": "issue-64-backend-selection-order-20260614",
+  "workflow_id": "issue-65-backend-resource-mapping-20260614",
   "workflow_version": "1.0.0",
-  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/64",
-  "issue_number": 64,
-  "workflow_path": "documentation/workflow/issues/issue-64/workflow.md",
-  "authoring_branch": "feature/workflow-index-open-issues-20260614",
-  "proposed_execution_branch": "feature/workflow-issue-64-backend-selection-order-20260614",
-  "execution_profile": "NORMAL_PATH",
-  "status": "ACTIVE_READY_FOR_WORKFLOW_EXECUTE",
+  "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65",
+  "issue_number": 65,
+  "workflow_path": "documentation/workflow/workflow.md",
+  "authoring_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
+  "execution_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
+  "proposed_execution_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
+  "execution_profile": "FULL_PATH",
+  "status": "ACTIVE_RELEASED_FOR_WORKFLOW_EXECUTE",
   "created_utc": "2026-06-14T00:00:00Z",
   "dependencies": [],
   "affected_areas": [
     "infra/config/node-providers/**",
     "src/tiny_swarm_world/domain/node_provider/**",
-    "src/tiny_swarm_world/application/services/platform/**",
+    "src/tiny_swarm_world/infrastructure/adapters/**",
     "tests/**",
     "documentation/**"
   ],
@@ -53,6 +54,5 @@
       "path": ".agents/skills/workflow-authoring/SKILL.md",
       "sha256": "5ef238ca8a98d08a3594906e5a30100649d4c09e64a01b377d690f6580b1ca03"
     }
-  ],
-  "branch": "feature/workflow-issue-64-backend-selection-order-20260614"
+  ]
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,11 +1,11 @@
-# Context Pack: Issue #64 Honor backend selection order
+# Context Pack: Issue #65 Make resource mapping backend aware
 
-- Workflow id: `issue-64-backend-selection-order-20260614`
-- Workflow path: `documentation/workflow/issues/issue-64/workflow.md`
-- Authoring branch: `feature/workflow-index-open-issues-20260614`
-- Proposed execution branch: `feature/workflow-issue-64-backend-selection-order-20260614`
-- Execution profile: `NORMAL_PATH`
-- Status: `ACTIVE_READY_FOR_WORKFLOW_EXECUTE`
+- Workflow id: `issue-65-backend-resource-mapping-20260614`
+- Workflow path: `documentation/workflow/issues/issue-65/workflow.md`
+- Execution branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`
+- Proposed execution branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`
+- Execution profile: `FULL_PATH`
+- Status: `ACTIVE_RELEASED_FOR_WORKFLOW_EXECUTE`
 - Dependencies: none
 - Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
   `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.

--- a/documentation/workflow/issues/issue-65/context-pack.json
+++ b/documentation/workflow/issues/issue-65/context-pack.json
@@ -4,10 +4,11 @@
   "issue": "https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65",
   "issue_number": 65,
   "workflow_path": "documentation/workflow/issues/issue-65/workflow.md",
-  "authoring_branch": "feature/workflow-index-open-issues-20260614",
+  "authoring_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
+  "execution_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
   "proposed_execution_branch": "feature/workflow-issue-65-backend-resource-mapping-20260614",
   "execution_profile": "FULL_PATH",
-  "status": "AUTHORED_INDEXED_NOT_ACTIVE",
+  "status": "ACTIVE_RELEASED_FOR_WORKFLOW_EXECUTE",
   "created_utc": "2026-06-14T00:00:00Z",
   "dependencies": [],
   "affected_areas": [

--- a/documentation/workflow/issues/issue-65/context-pack.md
+++ b/documentation/workflow/issues/issue-65/context-pack.md
@@ -2,10 +2,10 @@
 
 - Workflow id: `issue-65-backend-resource-mapping-20260614`
 - Workflow path: `documentation/workflow/issues/issue-65/workflow.md`
-- Authoring branch: `feature/workflow-index-open-issues-20260614`
+- Execution branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`
 - Proposed execution branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`
 - Execution profile: `FULL_PATH`
-- Status: `AUTHORED_INDEXED_NOT_ACTIVE`
+- Status: `ACTIVE_RELEASED_FOR_WORKFLOW_EXECUTE`
 - Dependencies: none
 - Quality commands: `git diff --check`, `python3 tools/quality_gate.py test`,
   `python3 tools/quality_gate.py arch-tests`, `python3 tools/quality_gate.py quality`.

--- a/documentation/workflow/issues/issue-65/workflow.md
+++ b/documentation/workflow/issues/issue-65/workflow.md
@@ -5,12 +5,12 @@ workflow_id: issue-65-backend-resource-mapping-20260614
 workflow_version: 1.0.0
 issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65
 issue_number: 65
-authoring_branch: feature/workflow-index-open-issues-20260614
+authoring_branch: feature/workflow-issue-65-backend-resource-mapping-20260614
 proposed_execution_branch: feature/workflow-issue-65-backend-resource-mapping-20260614
 indexed_workflow: true
-active_workflow: false
+active_workflow: true
 execution_profile: FULL_PATH
-released_for_workflow_execute: false
+released_for_workflow_execute: true
 created_utc: "2026-06-14T00:00:00Z"
 decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
 confidence: 88
@@ -214,10 +214,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -279,10 +279,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -340,10 +340,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -399,10 +399,10 @@ architecture_locks:
   - linux_wsl_only_runtime
 quality_gates:
   targeted:
-- git diff --check
-- python3 tools/quality_gate.py test
+    - git diff --check
+    - python3 tools/quality_gate.py test
   required:
-- python3 tools/quality_gate.py quality
+    - python3 tools/quality_gate.py quality
 documentation:
   arc42: checked-update-if-behavior-or-boundary-changes
   adr: checked-update-if-policy-or-architecture-decision-changes
@@ -525,7 +525,7 @@ or when acceptance criteria cannot be mapped to tests and documentation.
 
 Workflow authoring commit:
 
-- Branch: `feature/workflow-index-open-issues-20260614`.
+- Branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`.
 - Stage this issue workflow, its context pack, `workflow.index.md`, and the
   workflow-authoring skill update.
 - Run `git diff --check`.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,28 +1,28 @@
-# Workflow: Honor backend selection order
+# Workflow: Make resource mapping backend aware
 
 ```yaml
-workflow_id: issue-64-backend-selection-order-20260614
+workflow_id: issue-65-backend-resource-mapping-20260614
 workflow_version: 1.0.0
-issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/64
-issue_number: 64
-authoring_branch: feature/workflow-index-open-issues-20260614
-branch: feature/workflow-issue-64-backend-selection-order-20260614
-proposed_execution_branch: feature/workflow-issue-64-backend-selection-order-20260614
+issue: https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/issues/65
+issue_number: 65
+authoring_branch: feature/workflow-issue-65-backend-resource-mapping-20260614
+proposed_execution_branch: feature/workflow-issue-65-backend-resource-mapping-20260614
 indexed_workflow: true
 active_workflow: true
-execution_profile: NORMAL_PATH
+execution_profile: FULL_PATH
 released_for_workflow_execute: true
 created_utc: "2026-06-14T00:00:00Z"
 decision: PROCEED_WITH_ACCEPTED_ASSUMPTIONS
-confidence: 92
+confidence: 88
 dependencies: []
 ```
 
 ## Executive Summary
 
-Make backend selection deterministic: explicit override first, then configured candidate order, with diagnostics for selected and skipped candidates.
+Resolve network, storage, profile, image and related resource names through backend-aware configuration instead of unconditional LXD-specific mappings.
 
-This workflow has been promoted from the indexed workflow set and is active for `workflow execute` on branch `feature/workflow-issue-64-backend-selection-order-20260614`.
+This indexed workflow is authored for later promotion or explicit indexed
+execution. It does not replace `documentation/workflow/workflow.md`.
 
 ## Requirement Clarification Gate
 
@@ -35,17 +35,17 @@ Original request:
 
 Interpreted intent:
 
-- Create an executable workflow plan for Issue #64: Honor backend selection order.
+- Create an executable workflow plan for Issue #65: Make resource mapping backend aware.
 - Defer implementation until all indexed workflows are authored and the
   execution order is selected from `workflow.index.md`.
 
 Change type:
 
-- Workflow creation for future node-provider selection work.
+- Workflow creation for future provider resource configuration work.
 
 Affected process strand:
 
-- node-provider selection.
+- provider resource configuration.
 - Workflow execution with S3/S3D validation.
 - Documentation and quality-gate synchronization.
 
@@ -53,7 +53,7 @@ Affected architecture area:
 
 - `infra/config/node-providers/**`
 - `src/tiny_swarm_world/domain/node_provider/**`
-- `src/tiny_swarm_world/application/services/platform/**`
+- `src/tiny_swarm_world/infrastructure/adapters/**`
 - `tests/**`
 - `documentation/**`
 
@@ -106,13 +106,13 @@ Blocking questions:
 - None for workflow authoring. Any issue-specific decision is represented
   as an early executable decision slice when required.
 
-Confidence level: 92 percent.
+Confidence level: 88 percent.
 
 Decision: `PROCEED_WITH_ACCEPTED_ASSUMPTIONS`.
 
 ## Target Picture
 
-Issue #64 has an executable, test-backed implementation path that
+Issue #65 has an executable, test-backed implementation path that
 preserves Linux/WSL-only operation, Python 3.12 compatibility, hexagonal
 boundaries, and guarded live-infrastructure safety.
 
@@ -120,15 +120,16 @@ boundaries, and guarded live-infrastructure safety.
 
 - Root `AGENTS.md`, `QUALITY.md`, and `.agents/skills/workflow-authoring/SKILL.md`
   were checked during indexed workflow authoring.
-- The workflow is stored under `documentation/workflow/issues/issue-64/`.
-- This workflow has been promoted to the active workflow path for Issue #64 execution.
+- The workflow is stored under `documentation/workflow/issues/issue-65/`.
+- This workflow is not the active workflow until explicitly promoted or
+  selected by an indexed executor.
 
 ## Scope
 
 In scope:
 
 - Files and modules listed in the affected architecture area.
-- Tests and documentation needed to satisfy Issue #64.
+- Tests and documentation needed to satisfy Issue #65.
 - Quality gates from `QUALITY.md`.
 
 Out of scope:
@@ -182,32 +183,32 @@ any, remains terminal-oriented and routes through console/status UI skills.
 
 Purpose:
 
-- Requirement, repository baseline, and decision gate for Issue #64.
+- Requirement, repository baseline, and decision gate for Issue #65.
 
 ```yaml
 slice_id: S01
-profile: NORMAL_PATH
+profile: FULL_PATH
 owner: Senior Requirement Engineer
 secondary_reviewers:
   - Senior System Architect
   - Senior Tester
 affected_files:
-  - documentation/workflow/issues/issue-64/**
+  - documentation/workflow/issues/issue-65/**
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
 affected_modules:
-  - node-provider selection
+  - provider resource configuration
 affected_contracts:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 dependencies:
   []
-parallel_group: issue-64-group-1
+parallel_group: issue-65-group-1
 file_locks:
-  - documentation/workflow/issues/issue-64/**
+  - documentation/workflow/issues/issue-65/**
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
 contract_locks:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -243,11 +244,11 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Scoped implementation inside the declared architecture boundary for Issue #64.
+- Scoped implementation inside the declared architecture boundary for Issue #65.
 
 ```yaml
 slice_id: S02
-profile: NORMAL_PATH
+profile: FULL_PATH
 owner: Senior Python Automation Developer
 secondary_reviewers:
   - Senior System Architect
@@ -255,24 +256,24 @@ secondary_reviewers:
 affected_files:
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
-  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
   - tests/**
   - documentation/**
 affected_modules:
-  - node-provider selection
+  - provider resource configuration
 affected_contracts:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 dependencies:
   - S01
-parallel_group: issue-64-group-2
+parallel_group: issue-65-group-2
 file_locks:
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
-  - src/tiny_swarm_world/application/services/platform/**
+  - src/tiny_swarm_world/infrastructure/adapters/**
   - tests/**
   - documentation/**
 contract_locks:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -308,11 +309,11 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Focused regression and architecture tests for Issue #64.
+- Focused regression and architecture tests for Issue #65.
 
 ```yaml
 slice_id: S03
-profile: NORMAL_PATH
+profile: FULL_PATH
 owner: Senior Tester
 secondary_reviewers:
   - Senior System Architect
@@ -322,18 +323,18 @@ affected_files:
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
 affected_modules:
-  - node-provider selection
+  - provider resource configuration
 affected_contracts:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 dependencies:
   - S02
-parallel_group: issue-64-group-3
+parallel_group: issue-65-group-3
 file_locks:
   - tests/**
   - infra/config/node-providers/**
   - src/tiny_swarm_world/domain/node_provider/**
 contract_locks:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -369,11 +370,11 @@ python3 tools/quality_gate.py test
 
 Purpose:
 
-- Documentation synchronization and final quality evidence for Issue #64.
+- Documentation synchronization and final quality evidence for Issue #65.
 
 ```yaml
 slice_id: S04
-profile: NORMAL_PATH
+profile: FULL_PATH
 owner: Senior Documentation Engineer
 secondary_reviewers:
   - Senior System Architect
@@ -382,17 +383,17 @@ affected_files:
   - documentation/**
   - README.md
 affected_modules:
-  - node-provider selection
+  - provider resource configuration
 affected_contracts:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 dependencies:
   - S03
-parallel_group: issue-64-group-4
+parallel_group: issue-65-group-4
 file_locks:
   - documentation/**
   - README.md
 contract_locks:
-  - issue_64_backend_selection_order
+  - issue_65_backend_resource_mapping
 architecture_locks:
   - hexagonal_architecture
   - linux_wsl_only_runtime
@@ -437,7 +438,7 @@ Cross-workflow dependencies: none.
 - Can this workflow run in parallel? Only after S3D confirms disjoint file,
   contract, module, and architecture locks.
 - Conflicting workflows: see `documentation/workflow/workflow.index.md`.
-- Shared files: infra/config/node-providers/**, src/tiny_swarm_world/domain/node_provider/**, src/tiny_swarm_world/application/services/platform/**, tests/**, documentation/**.
+- Shared files: infra/config/node-providers/**, src/tiny_swarm_world/domain/node_provider/**, src/tiny_swarm_world/infrastructure/adapters/**, tests/**, documentation/**.
 - Shared infrastructure: none for default verification; live validation is
   serialized unless isolated infrastructure is explicitly provided.
 - Requires isolated worktree: yes for workflow execution streams.
@@ -524,7 +525,7 @@ or when acceptance criteria cannot be mapped to tests and documentation.
 
 Workflow authoring commit:
 
-- Branch: `feature/workflow-index-open-issues-20260614`.
+- Branch: `feature/workflow-issue-65-backend-resource-mapping-20260614`.
 - Stage this issue workflow, its context pack, `workflow.index.md`, and the
   workflow-authoring skill update.
 - Run `git diff --check`.
@@ -533,7 +534,7 @@ Workflow authoring commit:
 Future workflow execution:
 
 - Promote or explicitly select this indexed workflow.
-- Use proposed execution branch `feature/workflow-issue-64-backend-selection-order-20260614` unless a later
+- Use proposed execution branch `feature/workflow-issue-65-backend-resource-mapping-20260614` unless a later
   governance decision selects another branch.
 - Commit each executable slice separately.
 
@@ -542,13 +543,15 @@ Future workflow execution:
 Workflow authoring is done when this file, its context pack, and the index
 entry exist and pass documentation checks.
 
-Issue #64 implementation is done when acceptance criteria are satisfied
+Issue #65 implementation is done when acceptance criteria are satisfied
 by scoped code, tests, documentation, quality evidence, and merge-ready
 review.
 
 ## Handoff To Workflow Execute
 
-Run `workflow execute` from this branch and this worktree. The executor must verify S3/S3D metadata, locks, evidence, targeted checks, and quality gates before implementation.
+Do not run unqualified `workflow execute` for this indexed workflow. First
+promote it to `documentation/workflow/workflow.md` or extend the executor to
+accept an explicit indexed workflow path.
 
 ## arc42 Check Status
 

--- a/infra/config/node-providers/provider_config.yaml
+++ b/infra/config/node-providers/provider_config.yaml
@@ -90,9 +90,15 @@ profiles:
     live_mutation_consent_required: true
     blocks_mutation_when_missing: true
 provider_resource_resolution:
-  network_mappings:
-    control: lxdbr0
-  storage_pool: default
+  backends:
+    incus:
+      network_mappings:
+        control: incusbr0
+      storage_pool: default
+    lxd:
+      network_mappings:
+        control: lxdbr0
+      storage_pool: default
 verification_metadata:
   readiness_timeout_seconds: 5
   evidence_policy:

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_node_provider.py
@@ -23,6 +23,7 @@ from tiny_swarm_world.domain.node_provider import (
     ProviderSelection,
 )
 from tiny_swarm_world.infrastructure.adapters.repositories.node_provider_config_yaml_repository import (
+    ProviderBackendResourceResolution,
     NodeProviderConfig,
     NodeProviderNodeConfig,
     NodeProviderProfileRequirement,
@@ -196,7 +197,7 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
                 node_config,
                 self.image_references,
                 provider_resource_resolution=(
-                    config.provider_resource_resolution
+                    _selected_provider_resource_resolution(config, backend)
                     if _uses_provider_resource_resolution(config)
                     else None
                 ),
@@ -396,8 +397,9 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
         if "provider_resource_resolution" not in config.verification_metadata.checks:
             return None
         resource_resolution = config.provider_resource_resolution
+        backend_resource_resolution = _selected_provider_resource_resolution(config, backend)
         logical_networks = node_config.networks
-        if resource_resolution is None or not logical_networks:
+        if resource_resolution is None or backend_resource_resolution is None or not logical_networks:
             return _blocked(
                 node,
                 selection,
@@ -406,12 +408,13 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
                 extra_evidence=_resource_resolution_evidence(
                     node_config,
                     resource_resolution,
+                    backend=backend,
                 ),
             )
         unresolved_networks = tuple(
             network
             for network in logical_networks
-            if network not in resource_resolution.network_mappings
+            if network not in backend_resource_resolution.network_mappings
         )
         if unresolved_networks:
             return _blocked(
@@ -422,10 +425,11 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
                 extra_evidence=_resource_resolution_evidence(
                     node_config,
                     resource_resolution,
+                    backend=backend,
                 ),
             )
 
-        resolved_network = _resolved_network(node_config, resource_resolution)
+        resolved_network = _resolved_network(node_config, backend_resource_resolution)
         available_networks = await self._available_network_names(backend, config)
         if resolved_network not in available_networks:
             return _blocked(
@@ -436,12 +440,13 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
                 extra_evidence=_resource_resolution_evidence(
                     node_config,
                     resource_resolution,
+                    backend=backend,
                     available_networks=available_networks,
                 ),
             )
 
         available_storage_pools = await self._available_storage_pool_names(backend, config)
-        if resource_resolution.storage_pool not in available_storage_pools:
+        if backend_resource_resolution.storage_pool not in available_storage_pools:
             return _blocked(
                 node,
                 selection,
@@ -450,6 +455,7 @@ class LxcNodeProvider(PortNodeLifecycle, PortManagedNodeTeardown):
                 extra_evidence=_resource_resolution_evidence(
                     node_config,
                     resource_resolution,
+                    backend=backend,
                     available_networks=available_networks,
                     available_storage_pools=available_storage_pools,
                 ),
@@ -1098,7 +1104,7 @@ def _launch_args(
     node_config: NodeProviderNodeConfig,
     image_references: Mapping[str, str],
     *,
-    provider_resource_resolution: ProviderResourceResolution | None = None,
+    provider_resource_resolution: ProviderBackendResourceResolution | None = None,
 ) -> tuple[str, ...]:
     args: list[str] = [
         _BACKEND_CLI[backend],
@@ -1141,9 +1147,18 @@ def _uses_provider_resource_resolution(config: NodeProviderConfig) -> bool:
     return "provider_resource_resolution" in config.verification_metadata.checks
 
 
+def _selected_provider_resource_resolution(
+    config: NodeProviderConfig,
+    backend: ManagedLxcBackend,
+) -> ProviderBackendResourceResolution | None:
+    if config.provider_resource_resolution is None:
+        return None
+    return config.provider_resource_resolution.for_backend(backend)
+
+
 def _resolved_network(
     node_config: NodeProviderNodeConfig,
-    provider_resource_resolution: ProviderResourceResolution,
+    provider_resource_resolution: ProviderBackendResourceResolution,
 ) -> str:
     return provider_resource_resolution.network_mappings[node_config.networks[0]]
 
@@ -1356,25 +1371,32 @@ def _resource_resolution_evidence(
     node_config: NodeProviderNodeConfig,
     provider_resource_resolution: ProviderResourceResolution | None,
     *,
+    backend: ManagedLxcBackend,
     available_networks: Sequence[str] = (),
     available_storage_pools: Sequence[str] = (),
 ) -> dict[str, str]:
     logical_network = ",".join(node_config.networks)
-    resolved_network = (
-        _resolved_network(node_config, provider_resource_resolution)
+    backend_resource_resolution = (
+        provider_resource_resolution.for_backend(backend)
         if provider_resource_resolution is not None
+        else None
+    )
+    resolved_network = (
+        _resolved_network(node_config, backend_resource_resolution)
+        if backend_resource_resolution is not None
         and node_config.networks
-        and node_config.networks[0] in provider_resource_resolution.network_mappings
+        and node_config.networks[0] in backend_resource_resolution.network_mappings
         else ""
     )
     expected_storage_pool = (
-        provider_resource_resolution.storage_pool
-        if provider_resource_resolution is not None
+        backend_resource_resolution.storage_pool
+        if backend_resource_resolution is not None
         else ""
     )
     return {
         "expected_profile": node_config.profile,
         "available_profiles": "",
+        "backend": backend.value,
         "logical_network": logical_network,
         "resolved_network": resolved_network,
         "available_networks": ",".join(available_networks),
@@ -1383,6 +1405,7 @@ def _resource_resolution_evidence(
         "remediation_hint": _resource_resolution_remediation_hint(
             node_config,
             provider_resource_resolution,
+            backend=backend,
             available_networks=available_networks,
             available_storage_pools=available_storage_pools,
         ),
@@ -1393,20 +1416,24 @@ def _resource_resolution_remediation_hint(
     node_config: NodeProviderNodeConfig,
     provider_resource_resolution: ProviderResourceResolution | None,
     *,
+    backend: ManagedLxcBackend,
     available_networks: Sequence[str],
     available_storage_pools: Sequence[str],
 ) -> str:
     if provider_resource_resolution is None:
         return "Configure provider resource resolution for the LXC-native node inventory."
+    backend_resource_resolution = provider_resource_resolution.for_backend(backend)
+    if backend_resource_resolution is None:
+        return "Configure provider resource resolution for the selected backend."
     if not node_config.networks:
         return "Configure at least one logical network for the LXC-native node."
-    if node_config.networks[0] not in provider_resource_resolution.network_mappings:
-        return "Add an explicit logical-to-LXD network mapping for the inventory network."
-    resolved_network = _resolved_network(node_config, provider_resource_resolution)
+    if node_config.networks[0] not in backend_resource_resolution.network_mappings:
+        return "Add an explicit logical-to-backend network mapping for the inventory network."
+    resolved_network = _resolved_network(node_config, backend_resource_resolution)
     if resolved_network not in available_networks:
-        return "Create or configure the resolved LXD network before platform mutation."
-    if provider_resource_resolution.storage_pool not in available_storage_pools:
-        return "Create or configure the expected LXD storage pool before platform mutation."
+        return "Create or configure the resolved backend network before platform mutation."
+    if backend_resource_resolution.storage_pool not in available_storage_pools:
+        return "Create or configure the expected backend storage pool before platform mutation."
     return "Provider resource resolution is satisfied."
 
 

--- a/src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/repositories/node_provider_config_yaml_repository.py
@@ -65,7 +65,8 @@ _PROFILE_FIELDS = frozenset(
 )
 _VERIFICATION_FIELDS = frozenset(("readiness_timeout_seconds", "evidence_policy", "checks"))
 _EVIDENCE_POLICY_FIELDS = frozenset(("summary_only", "store_raw_output"))
-_PROVIDER_RESOURCE_RESOLUTION_FIELDS = frozenset(("network_mappings", "storage_pool"))
+_PROVIDER_RESOURCE_RESOLUTION_FIELDS = frozenset(("backends",))
+_PROVIDER_BACKEND_RESOURCE_RESOLUTION_FIELDS = frozenset(("network_mappings", "storage_pool"))
 
 _FORBIDDEN_KEY_PARTS = (
     "api_key",
@@ -145,9 +146,20 @@ class ProviderVerificationMetadata:
 
 
 @dataclass(frozen=True)
-class ProviderResourceResolution:
+class ProviderBackendResourceResolution:
     network_mappings: Mapping[str, str]
     storage_pool: str
+
+
+@dataclass(frozen=True)
+class ProviderResourceResolution:
+    backends: Mapping[ManagedLxcBackend, ProviderBackendResourceResolution]
+
+    def for_backend(
+        self,
+        backend: ManagedLxcBackend,
+    ) -> ProviderBackendResourceResolution | None:
+        return self.backends.get(backend)
 
 
 @dataclass(frozen=True)
@@ -388,6 +400,43 @@ def _provider_resource_resolution(
         _PROVIDER_RESOURCE_RESOLUTION_FIELDS,
         "provider_resource_resolution",
     )
+    backend_mapping = _required_mapping(
+        resolution,
+        "backends",
+        "provider_resource_resolution",
+    )
+    if not backend_mapping:
+        raise NodeProviderConfigError("provider backend resource mappings must not be empty")
+
+    backends: dict[ManagedLxcBackend, ProviderBackendResourceResolution] = {}
+    for backend_name, backend_resolution in backend_mapping.items():
+        backend = _optional_backend(backend_name)
+        if backend is None:
+            raise NodeProviderConfigError("provider backend resource mapping is invalid")
+        if backend in backends:
+            raise NodeProviderConfigError("provider backend resource mappings must be unique")
+        if not isinstance(backend_resolution, Mapping):
+            raise NodeProviderConfigError(
+                f"provider_resource_resolution.backends.{backend.value} must be a mapping"
+            )
+        backends[backend] = _provider_backend_resource_resolution(
+            backend,
+            backend_resolution,
+        )
+
+    return ProviderResourceResolution(backends=backends)
+
+
+def _provider_backend_resource_resolution(
+    backend: ManagedLxcBackend,
+    resolution: Mapping[str, Any],
+) -> ProviderBackendResourceResolution:
+    path = f"provider_resource_resolution.backends.{backend.value}"
+    _reject_unknown_fields(
+        resolution,
+        _PROVIDER_BACKEND_RESOURCE_RESOLUTION_FIELDS,
+        path,
+    )
     network_mappings = {
         _safe_identifier(logical_network, "logical provider network"): _safe_identifier(
             provider_network,
@@ -396,16 +445,16 @@ def _provider_resource_resolution(
         for logical_network, provider_network in _required_mapping(
             resolution,
             "network_mappings",
-            "provider_resource_resolution",
+            path,
         ).items()
     }
     if not network_mappings:
         raise NodeProviderConfigError("provider network mappings must not be empty")
 
-    return ProviderResourceResolution(
+    return ProviderBackendResourceResolution(
         network_mappings=network_mappings,
         storage_pool=_safe_identifier(
-            _required(resolution, "storage_pool", "provider_resource_resolution"),
+            _required(resolution, "storage_pool", path),
             "provider storage pool",
         ),
     )
@@ -421,19 +470,29 @@ def _validate_provider_resource_resolution(
     if provider_resource_resolution is None:
         raise NodeProviderConfigError("provider resource resolution is required")
 
-    mapped_networks = set(provider_resource_resolution.network_mappings)
-    missing_networks = sorted(
-        {
-            network
-            for node in nodes
-            for network in node.networks
-            if network not in mapped_networks
-        }
-    )
-    if missing_networks:
+    required_backends = {ManagedLxcBackend.INCUS, ManagedLxcBackend.LXD}
+    configured_backends = set(provider_resource_resolution.backends)
+    missing_backends = sorted(backend.value for backend in required_backends - configured_backends)
+    if missing_backends:
         raise NodeProviderConfigError(
-            f"node networks require provider resource mappings: {missing_networks}"
+            f"provider resource mappings are missing for backends: {missing_backends}"
         )
+
+    for backend, resolution in provider_resource_resolution.backends.items():
+        mapped_networks = set(resolution.network_mappings)
+        missing_networks = sorted(
+            {
+                network
+                for node in nodes
+                for network in node.networks
+                if network not in mapped_networks
+            }
+        )
+        if missing_networks:
+            raise NodeProviderConfigError(
+                f"{backend.value} node networks require provider resource mappings: "
+                f"{missing_networks}"
+            )
 
 
 def _provider(value: object) -> NodeProviderKind:

--- a/tests/infrastructure/adapters/clients/test_lxc_node_provider.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_node_provider.py
@@ -20,6 +20,7 @@ from tiny_swarm_world.infrastructure.adapters.repositories.node_provider_config_
     NodeProviderConfig,
     NodeProviderNodeConfig,
     NodeProviderProfileRequirement,
+    ProviderBackendResourceResolution,
     ProviderResourceResolution,
     ProviderVerificationMetadata,
 )
@@ -495,7 +496,7 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEvidenceIsSummaryOnly(result)
 
-    async def test_provider_resource_resolution_blocks_when_lxd_network_missing(self):
+    async def test_provider_resource_resolution_blocks_when_incus_network_missing(self):
         runner = _FakeRunner(
             _name_list("default"),
         )
@@ -506,10 +507,10 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(VerificationStatus.BLOCKED, result.status)
         self.assertEqual("network_missing", result.evidence["classification"])
         self.assertEqual("control", result.evidence["logical_network"])
-        self.assertEqual("lxdbr0", result.evidence["resolved_network"])
+        self.assertEqual("incusbr0", result.evidence["resolved_network"])
         self.assertEqual("default", result.evidence["available_networks"])
         self.assertEqual("default", result.evidence["expected_storage_pool"])
-        self.assertIn("resolved LXD network", result.evidence["remediation_hint"])
+        self.assertIn("resolved backend network", result.evidence["remediation_hint"])
         self.assertEqual(
             [
                 (("incus", "network", "list", "--format", "json"), 5.0),
@@ -520,7 +521,7 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
 
     async def test_provider_resource_resolution_blocks_when_storage_pool_missing(self):
         runner = _FakeRunner(
-            _name_list("lxdbr0"),
+            _name_list("incusbr0"),
             _name_list("other"),
         )
         provider = _provider(runner, config=_config(resolve_provider_resources=True))
@@ -529,10 +530,10 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(VerificationStatus.BLOCKED, result.status)
         self.assertEqual("storage_pool_missing", result.evidence["classification"])
-        self.assertEqual("lxdbr0", result.evidence["available_networks"])
+        self.assertEqual("incusbr0", result.evidence["available_networks"])
         self.assertEqual("default", result.evidence["expected_storage_pool"])
         self.assertEqual("other", result.evidence["available_storage_pools"])
-        self.assertIn("expected LXD storage pool", result.evidence["remediation_hint"])
+        self.assertIn("expected backend storage pool", result.evidence["remediation_hint"])
         self.assertEqual(
             [
                 (("incus", "network", "list", "--format", "json"), 5.0),
@@ -571,6 +572,63 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
         self.assertIn("fastpool", launch_call)
         self.assertEvidenceIsSummaryOnly(result)
 
+    async def test_provider_resource_resolution_uses_lxd_mapping_for_lxd_selection(self):
+        runner = _FakeRunner(
+            _name_list("lxdbr0"),
+            _name_list("lxdpool"),
+            _profile(),
+            _list(),
+            _ok(),
+            _list(_node("swarm-manager", "Running")),
+        )
+        provider = _provider(
+            runner,
+            config=_config(
+                resolve_provider_resources=True,
+                provider_network_mappings={
+                    ManagedLxcBackend.INCUS: {"control": "incusbr0"},
+                    ManagedLxcBackend.LXD: {"control": "lxdbr0"},
+                },
+                provider_storage_pools={
+                    ManagedLxcBackend.INCUS: "default",
+                    ManagedLxcBackend.LXD: "lxdpool",
+                },
+            ),
+        )
+
+        result = await provider.ensure_node(_node_spec(), _selection(ManagedLxcBackend.LXD))
+
+        self.assertEqual(VerificationStatus.VERIFIED, result.status)
+        launch_call = runner.calls[4][0]
+        self.assertEqual("lxc", launch_call[0])
+        self.assertIn("lxdbr0", launch_call)
+        self.assertIn("lxdpool", launch_call)
+        self.assertNotIn("incusbr0", launch_call)
+        self.assertEvidenceIsSummaryOnly(result)
+
+    async def test_provider_resource_resolution_blocks_missing_selected_backend_mapping(self):
+        runner = _FakeRunner()
+        provider = _provider(
+            runner,
+            config=_config(
+                resolve_provider_resources=True,
+                provider_network_mappings={
+                    ManagedLxcBackend.LXD: {"control": "lxdbr0"},
+                },
+                provider_storage_pools={
+                    ManagedLxcBackend.LXD: "default",
+                },
+            ),
+        )
+
+        result = await provider.ensure_node(_node_spec(), _selection(ManagedLxcBackend.INCUS))
+
+        self.assertEqual(VerificationStatus.BLOCKED, result.status)
+        self.assertEqual("inventory_mapping_missing", result.evidence["classification"])
+        self.assertEqual("incus", result.evidence["backend"])
+        self.assertIn("selected backend", result.evidence["remediation_hint"])
+        self.assertEqual([], runner.calls)
+
     async def test_provider_resource_resolution_blocks_unmapped_logical_network(self):
         runner = _FakeRunner()
         provider = _provider(
@@ -587,7 +645,7 @@ class TestLxcNodeProvider(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("inventory_mapping_missing", result.evidence["classification"])
         self.assertEqual("private", result.evidence["logical_network"])
         self.assertEqual("", result.evidence["resolved_network"])
-        self.assertIn("logical-to-LXD network mapping", result.evidence["remediation_hint"])
+        self.assertIn("logical-to-backend network mapping", result.evidence["remediation_hint"])
         self.assertEqual([], runner.calls)
 
     async def test_missing_provider_node_config_is_inventory_mapping_missing(self):
@@ -1069,7 +1127,10 @@ def _config(
     additional_profiles: tuple[str, ...] = (),
     resolve_provider_resources: bool = False,
     node_networks: tuple[str, ...] = ("control",),
-    provider_network_mappings: dict[str, str] | None = None,
+    provider_network_mappings: (
+        dict[ManagedLxcBackend, dict[str, str]] | dict[str, str] | None
+    ) = None,
+    provider_storage_pools: dict[ManagedLxcBackend, str] | None = None,
     provider_storage_pool: str = "default",
 ) -> NodeProviderConfig:
     profiles = [
@@ -1130,8 +1191,11 @@ def _config(
         profiles=tuple(profiles),
         provider_resource_resolution=(
             ProviderResourceResolution(
-                network_mappings=provider_network_mappings or {"control": "lxdbr0"},
-                storage_pool=provider_storage_pool,
+                backends=_backend_resource_resolution(
+                    provider_network_mappings,
+                    provider_storage_pools,
+                    provider_storage_pool,
+                ),
             )
             if resolve_provider_resources
             else None
@@ -1151,6 +1215,43 @@ def _config(
             ),
         ),
     )
+
+
+def _backend_resource_resolution(
+    provider_network_mappings: (
+        dict[ManagedLxcBackend, dict[str, str]] | dict[str, str] | None
+    ),
+    provider_storage_pools: dict[ManagedLxcBackend, str] | None,
+    provider_storage_pool: str,
+) -> dict[ManagedLxcBackend, ProviderBackendResourceResolution]:
+    typed_network_mappings: dict[ManagedLxcBackend, dict[str, str]]
+    if provider_network_mappings and all(
+        isinstance(key, ManagedLxcBackend) for key in provider_network_mappings
+    ):
+        typed_network_mappings = cast(
+            dict[ManagedLxcBackend, dict[str, str]],
+            provider_network_mappings,
+        )
+    else:
+        shared_network_mappings = cast(
+            dict[str, str] | None,
+            provider_network_mappings,
+        )
+        typed_network_mappings = {
+            ManagedLxcBackend.INCUS: shared_network_mappings or {"control": "incusbr0"},
+            ManagedLxcBackend.LXD: shared_network_mappings or {"control": "lxdbr0"},
+        }
+    storage_pools = provider_storage_pools or {
+        ManagedLxcBackend.INCUS: provider_storage_pool,
+        ManagedLxcBackend.LXD: provider_storage_pool,
+    }
+    return {
+        backend: ProviderBackendResourceResolution(
+            network_mappings=network_mappings,
+            storage_pool=storage_pools[backend],
+        )
+        for backend, network_mappings in typed_network_mappings.items()
+    }
 
 
 def _ok() -> LxcNodeCommandResult:

--- a/tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py
+++ b/tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py
@@ -48,10 +48,33 @@ class TestNodeProviderConfigYamlRepository(unittest.TestCase):
         if config.provider_resource_resolution is None:
             raise AssertionError("provider resource resolution must be configured")
         self.assertEqual(
-            {"control": "lxdbr0"},
-            dict(config.provider_resource_resolution.network_mappings),
+            {"control": "incusbr0"},
+            dict(
+                config.provider_resource_resolution.backends[
+                    ManagedLxcBackend.INCUS
+                ].network_mappings
+            ),
         )
-        self.assertEqual("default", config.provider_resource_resolution.storage_pool)
+        self.assertEqual(
+            {"control": "lxdbr0"},
+            dict(
+                config.provider_resource_resolution.backends[
+                    ManagedLxcBackend.LXD
+                ].network_mappings
+            ),
+        )
+        self.assertEqual(
+            "default",
+            config.provider_resource_resolution.backends[
+                ManagedLxcBackend.INCUS
+            ].storage_pool,
+        )
+        self.assertEqual(
+            "default",
+            config.provider_resource_resolution.backends[
+                ManagedLxcBackend.LXD
+            ].storage_pool,
+        )
 
     def test_committed_provider_config_matches_desired_inventory_nodes(self):
         config = NodeProviderConfigYamlRepository().load()
@@ -215,9 +238,18 @@ class TestNodeProviderConfigYamlRepository(unittest.TestCase):
         with self.assertRaises(NodeProviderConfigError):
             _repository_for(data).load()
 
+    def test_rejects_missing_backend_resource_mapping(self):
+        data = _valid_config_with_resource_resolution()
+        del data["provider_resource_resolution"]["backends"]["incus"]
+
+        with self.assertRaises(NodeProviderConfigError):
+            _repository_for(data).load()
+
     def test_rejects_unmapped_node_network_when_resource_resolution_is_enabled(self):
         data = _valid_config_with_resource_resolution()
-        data["nodes"][0]["networks"] = ["private"]
+        del data["provider_resource_resolution"]["backends"]["incus"]["network_mappings"][
+            "control"
+        ]
 
         with self.assertRaises(NodeProviderConfigError):
             _repository_for(data).load()
@@ -378,10 +410,20 @@ def _with_backend_candidate(backend: str) -> dict[str, Any]:
 def _valid_config_with_resource_resolution() -> dict[str, Any]:
     data = _valid_config()
     data["provider_resource_resolution"] = {
-        "network_mappings": {
-            "control": "lxdbr0",
+        "backends": {
+            "incus": {
+                "network_mappings": {
+                    "control": "incusbr0",
+                },
+                "storage_pool": "default",
+            },
+            "lxd": {
+                "network_mappings": {
+                    "control": "lxdbr0",
+                },
+                "storage_pool": "default",
+            },
         },
-        "storage_pool": "default",
     }
     data["verification_metadata"]["checks"].append("provider_resource_resolution")
     return data


### PR DESCRIPTION
## Summary

Closes #65.

- Moves provider resource resolution to backend-specific `provider_resource_resolution.backends.<backend>` configuration.
- Resolves network and storage names from the selected LXC backend before profiles, lookup, launch, or mutation.
- Fails closed for missing selected-backend mappings and keeps diagnostics summary-only.
- Updates tests, workflow evidence, and operator documentation.

## Local validation

- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_node_provider_config_yaml_repository tests.infrastructure.adapters.clients.test_lxc_node_provider`
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.infrastructure.adapters.preflight.test_lxc_provider_preflight tests.application.services.platform.test_node_provider_selection`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py typecheck`
- `python3 tools/quality_gate.py arch-tests`
- `python3 tools/quality_gate.py test`
- `python3 tools/quality_gate.py quality`
- `git diff --check`