### PR TITLE
Use host-specific install evidence directories

### DIFF
--- a/.codex/evidence/slice-69-consolidation.md
+++ b/.codex/evidence/slice-69-consolidation.md
@@ -1,0 +1,31 @@
+# Slice 69 Consolidation
+
+- workflow id: issue-69-host-evidence-directories-20260614
+- slice id: issue-69
+- slice title: Use host-specific evidence directories
+
+## Stream Results
+
+- runtime: `install.sh` now resolves `wsl2` or `native_linux` before creating installation evidence.
+- tests: focused wrapper and debugger tests cover native Linux and WSL2 evidence directory selection.
+- documentation: README, installation guide, and troubleshooting guide document the host-runtime evidence naming rule.
+
+## Review Results
+
+- accepted findings: the fixed WSL2 path lived in `install.sh`, `tools/install_debugger.py`, and matching tests/docs.
+- rejected findings: none.
+- files changed per stream:
+  - runtime: `install.sh`, `tools/install_debugger.py`
+  - tests: `tests/test_install_script.py`, `tests/test_install_debugger.py`
+  - documentation: `README.md`, `documentation/user_guide/installation.adoc`, `documentation/user_guide/troubleshooting.adoc`
+- conflicts found: none.
+- conflicts resolved: none.
+- SonarQube findings and fixes: pending CI; local slice contains no secret values or live infrastructure calls.
+- documentation updates: completed.
+- final integration decision: accepted pending full quality gate and push auto lifecycle.
+
+## Tests Executed
+
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 -m unittest tests.test_install_script tests.test_install_debugger"`: passed, 23 tests.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`: passed, with existing CRLF warnings for unrelated files.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`: passed; lint, arch-lint, arch-tests, typecheck, and 848 tests passed with 17 skipped.

--- a/.codex/evidence/slice-69-distribution.md
+++ b/.codex/evidence/slice-69-distribution.md
@@ -1,0 +1,26 @@
+# Slice 69 Distribution
+
+- workflow id: issue-69-host-evidence-directories-20260614
+- slice id: issue-69
+- slice title: Use host-specific evidence directories
+- affected areas: runtime, tests, documentation, quality
+- chosen execution mode: sequential
+- selected streams: runtime, tests, documentation
+- real subagents used: yes, read-only implementation-scope review by Chandrasekhar
+- fallback role-based review used: no
+- Git worktrees used: no
+- expected touched files/directories:
+  - install.sh
+  - tools/install_debugger.py
+  - tests/test_install_script.py
+  - tests/test_install_debugger.py
+  - README.md
+  - documentation/user_guide/installation.adoc
+  - documentation/user_guide/troubleshooting.adoc
+- conflict risks: shared install wrapper and installation documentation; no overlap with completed issues detected
+- quality gates to run:
+  - python3 -m unittest tests.test_install_script tests.test_install_debugger
+  - git diff --check
+  - python3 tools/quality_gate.py quality
+- consolidation plan: integrate runtime path selection, debugger lookup, regression tests, and documentation in one issue branch, then run focused and full gates before push auto.
+- parallelization decision: rejected because the shell wrapper, debugger, tests, and documentation describe one evidence-path contract and should be reviewed as a single coherent change.

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ confirm the wrapper's reset prompt with an explicit flag. The underlying reset
 workflow still uses `--confirm RESET_TINY_SWARM_PLATFORM`.
 
 The wrapper records run context, reset logs, setup logs, and exit codes under
-`.tiny-swarm-world/evidence/installation-tests/`. It loads or generates local
+`.tiny-swarm-world/evidence/installation-tests/<host-runtime>/`, where the
+stable host directory is `wsl2` or `native_linux`. It loads or generates local
 `TSW_*` secrets in `.tiny-swarm-world/local/live-installation.env` without
-printing secret values, runs the governed reset prelude, then calls the
+printing secret values, records the detected host type and selected evidence
+directory in `context.txt`, runs the governed reset prelude, then calls the
 canonical setup workflow.
 
 With live consent, it sequences setup preflight, platform, artifact,

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -225,9 +225,11 @@ replaced by an explicit flag:
 ----
 
 The wrapper writes run context, reset logs, setup logs and exit codes below
-`.tiny-swarm-world/evidence/installation-tests/wsl2/<UTC timestamp>/`,
-including `reset-run.log`, `reset-run.exit`, `setup-run.log`, and
-`setup-run.exit`.
+`.tiny-swarm-world/evidence/installation-tests/<host-runtime>/<UTC timestamp>/`.
+The stable host directory is `wsl2` for WSL2 and `native_linux` for native
+Linux. The run `context.txt` records `host_runtime_type`,
+`host_runtime_detection_source`, and `selected_evidence_directory` alongside
+`reset-run.log`, `reset-run.exit`, `setup-run.log`, and `setup-run.exit`.
 It loads or generates local `TSW_*` secrets in
 `.tiny-swarm-world/local/live-installation.env` without printing secret
 values.

--- a/documentation/user_guide/troubleshooting.adoc
+++ b/documentation/user_guide/troubleshooting.adoc
@@ -132,12 +132,15 @@ Check the reset evidence first:
 [source,bash]
 ----
 RUN_ID=20260604T120000Z
-EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/wsl2/$RUN_ID"
+HOST_RUNTIME=wsl2
+EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/$HOST_RUNTIME/$RUN_ID"
 cat "$EVIDENCE_DIR/reset-run.exit"
 cat "$EVIDENCE_DIR/setup-run.exit"
 ----
 
-Use the concrete run ID printed by the wrapper.
+Use the concrete host runtime and run ID printed by the wrapper. Supported
+host runtime directories are `wsl2` and `native_linux`; the run context file
+also records `host_runtime_type` and `selected_evidence_directory`.
 
 Then verify that the operator-provided `TSW_PORTAINER_USERNAME` and
 `TSW_PORTAINER_ADMIN_PASSWORD` values are the intended values for this local
@@ -147,8 +150,8 @@ committed documentation.
 == Installation Debugger For WSL2
 
 Use the installation debugger when `install.sh` aborts and the next question is
-whether the checkout, WSL2 host, systemd availability, service definitions, or
-evidence logs are the problem:
+whether the checkout, host runtime, WSL2 systemd availability, service
+definitions, or evidence logs are the problem:
 
 [source,bash]
 ----
@@ -157,9 +160,9 @@ python3 tools/install_debugger.py
 
 The default mode analyzes `install.sh`, repository permissions, ownership
 markers, WSL2/systemd indicators, systemd unit definitions, and the newest
-installation evidence directory. It also prints exact `grep`, `tail`,
-`systemctl`, and `journalctl` commands for finding the abort point after a
-`Service` log line.
+installation evidence directory across supported host directories. It also
+prints exact `grep`, `tail`, `systemctl`, and `journalctl` commands for finding
+the abort point after a `Service` log line.
 
 For live host diagnostics, including `systemctl is-system-running`, use:
 

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,11 @@ Optional environment:
       0 because the Infisical silent-bootstrap greenpath must not automate
       browser/UI clicks.
 The script is Linux/WSL-only. It writes evidence under:
-  .tiny-swarm-world/evidence/installation-tests/wsl2/<UTC timestamp>/
+  .tiny-swarm-world/evidence/installation-tests/<host-directory>/<UTC timestamp>/
+
+Supported host directories:
+  wsl2          WSL2 detected from WSL environment or kernel signals.
+  native_linux  Native Linux when no WSL signal is present.
 
 It runs the governed reset command before the canonical live setup command:
   PYTHONPATH=src python3 -m tiny_swarm_world platform reset --live --confirm RESET_TINY_SWARM_PLATFORM
@@ -84,6 +88,24 @@ is_wsl_environment() {
     return 0
   fi
   grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease /proc/version 2>/dev/null
+}
+
+host_runtime_type() {
+  if is_wsl_environment; then
+    printf 'wsl2\n'
+  else
+    printf 'native_linux\n'
+  fi
+}
+
+host_detection_source() {
+  if [[ -n "${WSL_DISTRO_NAME:-}" || -n "${WSL_INTEROP:-}" ]]; then
+    printf 'wsl_environment\n'
+  elif grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease /proc/version 2>/dev/null; then
+    printf 'kernel_signal\n'
+  else
+    printf 'uname_linux_without_wsl_signal\n'
+  fi
 }
 
 python_imports_available() {
@@ -245,6 +267,8 @@ write_context() {
   local evidence_dir="$1"
   local run_id="$2"
   local secrets_generated_count="$3"
+  local resolved_host_type="$4"
+  local detection_source="$5"
 
   {
     printf 'run_id=%s\n' "$run_id"
@@ -256,6 +280,9 @@ write_context() {
     printf 'fresh_install_reset=required\n'
     printf 'secret_env_file=%s\n' "$SECRET_ENV_FILE"
     printf 'secrets_generated_count=%s\n' "$secrets_generated_count"
+    printf 'host_runtime_type=%s\n' "$resolved_host_type"
+    printf 'host_runtime_detection_source=%s\n' "$detection_source"
+    printf 'selected_evidence_directory=%s\n' "$evidence_dir"
     printf 'platform_system=%s\n' "$(uname -s)"
     printf 'kernel_release=%s\n' "$(uname -r)"
     printf 'proc_osrelease=%s\n' "$(cat /proc/sys/kernel/osrelease 2>/dev/null || true)"
@@ -433,9 +460,11 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1 && \
 fi
 
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
-EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/wsl2/$RUN_ID"
+RESOLVED_HOST_TYPE="$(host_runtime_type)"
+HOST_DETECTION_SOURCE="$(host_detection_source)"
+EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/$RESOLVED_HOST_TYPE/$RUN_ID"
 mkdir -p "$EVIDENCE_DIR"
-write_context "$EVIDENCE_DIR" "$RUN_ID" "$secrets_generated_count"
+write_context "$EVIDENCE_DIR" "$RUN_ID" "$secrets_generated_count" "$RESOLVED_HOST_TYPE" "$HOST_DETECTION_SOURCE"
 
 cat <<EOF
 Tiny Swarm World live installation

--- a/tests/test_install_debugger.py
+++ b/tests/test_install_debugger.py
@@ -100,8 +100,14 @@ class TestInstallDebugger(unittest.TestCase):
     def test_log_guidance_points_to_latest_evidence_and_service_search(self):
         with tempfile.TemporaryDirectory() as tempdir:
             root = _minimal_repo(Path(tempdir))
-            older = root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2" / "20260101T000000Z"
-            newer = root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2" / "20260201T000000Z"
+            older = (
+                root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2"
+                / "20260101T000000Z"
+            )
+            newer = (
+                root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2"
+                / "20260201T000000Z"
+            )
             older.mkdir(parents=True)
             newer.mkdir(parents=True)
             (newer / "setup-run.log").write_text("Service failed\n", encoding="utf-8")
@@ -112,6 +118,41 @@ class TestInstallDebugger(unittest.TestCase):
         self.assertIn("20260201T000000Z", rendered)
         self.assertIn('grep -n -i "service"', rendered)
         self.assertIn("journalctl --no-pager -u '<unit>.service'", rendered)
+
+    def test_log_guidance_points_to_latest_evidence_across_host_directories(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = _minimal_repo(Path(tempdir))
+            older = (
+                root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2"
+                / "20260101T000000Z"
+            )
+            newer = (
+                root / ".tiny-swarm-world" / "evidence" / "installation-tests"
+                / "native_linux" / "20260201T000000Z"
+            )
+            older.mkdir(parents=True)
+            newer.mkdir(parents=True)
+            (newer / "setup-run.log").write_text("Service failed\n", encoding="utf-8")
+
+            guidance = install_debugger.log_guidance(root)
+
+        rendered = "\n".join(guidance)
+        self.assertIn("installation-tests/native_linux/20260201T000000Z", rendered)
+
+    def test_log_guidance_keeps_legacy_wsl2_evidence_readable(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = _minimal_repo(Path(tempdir))
+            legacy = (
+                root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2"
+                / "20260101T000000Z"
+            )
+            legacy.mkdir(parents=True)
+            (legacy / "setup-run.log").write_text("Service failed\n", encoding="utf-8")
+
+            guidance = install_debugger.log_guidance(root)
+
+        rendered = "\n".join(guidance)
+        self.assertIn("installation-tests/wsl2/20260101T000000Z", rendered)
 
 
 def _minimal_repo(root: Path) -> Path:
@@ -124,7 +165,7 @@ def _install_script_text() -> str:
         (
             "#!/usr/bin/env bash",
             "set -Eeuo pipefail",
-            "EVIDENCE_ROOT='.tiny-swarm-world/evidence/installation-tests/wsl2'",
+            "EVIDENCE_ROOT='.tiny-swarm-world/evidence/installation-tests'",
             "script -q -e -c 'PYTHONPATH=src python3 -m tiny_swarm_world platform reset --live'",
             "script -q -e -c 'PYTHONPATH=src python3 -m tiny_swarm_world setup run --live'",
         )

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -38,6 +38,15 @@ class TestInstallScript(unittest.TestCase):
             self.assertTrue((evidence_dir / "setup-run.log").is_file())
             context = (evidence_dir / "context.txt").read_text()
             self.assertIn("fresh_install_reset=required", context)
+            self.assertIn("host_runtime_type=native_linux", context)
+            self.assertIn(
+                "host_runtime_detection_source=uname_linux_without_wsl_signal",
+                context,
+            )
+            self.assertIn(
+                "selected_evidence_directory=.tiny-swarm-world/evidence/installation-tests/native_linux/",
+                context,
+            )
             self.assertIn("reset_confirmation_present=yes", context)
             self.assertIn("reset_confirmation_source=interactive_prompt", context)
             self.assertIn("reset_exit=0", context)
@@ -252,6 +261,33 @@ class TestInstallScript(unittest.TestCase):
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertFalse((fixture.root / ".tiny-swarm-world" / "install-venv").exists())
             self.assertIn("PYTHONPATH=src 'python3' -m tiny_swarm_world", fixture.recorded_commands()[0])
+            evidence_dir = fixture.single_evidence_dir("wsl2")
+            context = (evidence_dir / "context.txt").read_text()
+            self.assertIn("host_runtime_type=wsl2", context)
+            self.assertIn("host_runtime_detection_source=wsl_environment", context)
+
+    def test_native_linux_and_wsl2_use_distinct_evidence_directories(self):
+        with _install_script_fixture() as native_fixture:
+            native_result = native_fixture.run()
+
+            self.assertEqual(0, native_result.returncode, native_result.stderr)
+            native_evidence_dir = native_fixture.single_evidence_dir("native_linux")
+            self.assertIn(
+                ".tiny-swarm-world/evidence/installation-tests/native_linux/",
+                native_evidence_dir.as_posix(),
+            )
+
+        with _install_script_fixture(
+            extra_environment={"WSL_DISTRO_NAME": "Ubuntu"},
+        ) as wsl_fixture:
+            wsl_result = wsl_fixture.run()
+
+            self.assertEqual(0, wsl_result.returncode, wsl_result.stderr)
+            wsl_evidence_dir = wsl_fixture.single_evidence_dir("wsl2")
+            self.assertIn(
+                ".tiny-swarm-world/evidence/installation-tests/wsl2/",
+                wsl_evidence_dir.as_posix(),
+            )
 
 
 class _InstallScriptFixture:
@@ -342,8 +378,14 @@ class _InstallScriptFixture:
             return []
         return seed_file.read_text().splitlines()
 
-    def single_evidence_dir(self) -> Path:
-        evidence_root = self.root / ".tiny-swarm-world" / "evidence" / "installation-tests" / "wsl2"
+    def single_evidence_dir(self, host_directory: str = "native_linux") -> Path:
+        evidence_root = (
+            self.root
+            / ".tiny-swarm-world"
+            / "evidence"
+            / "installation-tests"
+            / host_directory
+        )
         evidence_dirs = tuple(evidence_root.iterdir())
         self_test = unittest.TestCase()
         self_test.assertEqual(1, len(evidence_dirs))

--- a/tools/install_debugger.py
+++ b/tools/install_debugger.py
@@ -17,7 +17,8 @@ from typing import Literal
 REPOSITORY_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SCRIPT = "install.sh"
 SECRET_ENV_FILE = ".tiny-swarm-world/local/live-installation.env"
-EVIDENCE_ROOT = ".tiny-swarm-world/evidence/installation-tests/wsl2"
+EVIDENCE_ROOT = ".tiny-swarm-world/evidence/installation-tests"
+SUPPORTED_EVIDENCE_HOST_DIRECTORIES = ("wsl2", "native_linux")
 INSTALL_SH_EXECUTABLE_LABEL = "install.sh executable"
 SECRET_FILE_MODE_LABEL = "Secret file mode"
 EXCLUDED_SCAN_DIRS = {
@@ -199,7 +200,7 @@ def check_install_script(
         ("platform reset --live", "fresh-install reset command"),
         ("setup run --live", "canonical setup command"),
         ("script -q -e -c", "terminal recording through script(1)"),
-        (EVIDENCE_ROOT, "WSL2 evidence directory"),
+        (EVIDENCE_ROOT, "host-specific evidence root"),
     ):
         findings.append(
             Finding(
@@ -420,7 +421,7 @@ def log_guidance(repo_root: Path) -> tuple[str, ...]:
     evidence_ref = (
         evidence_dir.relative_to(repo_root).as_posix()
         if evidence_dir is not None
-        else EVIDENCE_ROOT + "/<UTC timestamp>"
+        else EVIDENCE_ROOT + "/<host-runtime>/<UTC timestamp>"
     )
     return (
         f"EVIDENCE={evidence_ref}",
@@ -457,10 +458,24 @@ def latest_evidence_dir(repo_root: Path) -> Path | None:
     root = repo_root / EVIDENCE_ROOT
     if not root.is_dir():
         return None
-    candidates = tuple(path for path in root.iterdir() if path.is_dir())
+    candidates = tuple(_evidence_run_directories(root))
     if not candidates:
         return None
     return max(candidates, key=lambda path: path.name)
+
+
+def _evidence_run_directories(root: Path) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    for host_directory in SUPPORTED_EVIDENCE_HOST_DIRECTORIES:
+        host_root = root / host_directory
+        if host_root.is_dir():
+            candidates.extend(path for path in host_root.iterdir() if path.is_dir())
+    candidates.extend(
+        path
+        for path in root.iterdir()
+        if path.is_dir() and path.name[:4].isdigit()
+    )
+    return tuple(candidates)
 
 
 def _unit_compatibility_issues(text: str, systemd_state: SystemdState) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary
- Resolve install evidence directories from the detected host runtime (`wsl2` or `native_linux`) instead of always writing under `wsl2`.
- Record `host_runtime_type`, `host_runtime_detection_source`, and `selected_evidence_directory` in install context files.
- Update install debugger lookup, tests, and operator documentation for host-specific evidence paths while keeping existing WSL2 paths readable.

## Verification
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 -m unittest tests.test_install_script tests.test_install_debugger"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`

Closes #69