### PR TITLE
Separate installer live approval modes

### DIFF
--- a/.codex/evidence/slice-68-consolidation.md
+++ b/.codex/evidence/slice-68-consolidation.md
@@ -1,0 +1,33 @@
+# Slice 68 Consolidation
+
+- workflow id: issue-68-explicit-live-approval-20260614
+- slice id: issue-68
+- slice title: Replace piped installer approval with explicit flag
+
+## Stream Results
+
+- runtime: `install.sh` no longer pipes `y` into recorded CLI commands.
+- CLI: `--approve-live` provides explicit non-interactive live approval while preserving fail-closed `--live` behavior.
+- tests: wrapper and entrypoint tests cover interactive approval, explicit automation approval, and missing/negative/EOF consent paths.
+- documentation: README and installation guide explain the consent modes.
+
+## Review Results
+
+- accepted findings: the previous blanket pipe blurred interactive and automation consent; the new flags separate those modes and record them in evidence.
+- rejected findings: none.
+- files changed per stream:
+  - runtime: `install.sh`
+  - CLI/backend: `src/tiny_swarm_world/__main__.py`
+  - tests: `tests/test_install_script.py`, `tests/test_package_entrypoint.py`
+  - documentation: `README.md`, `documentation/user_guide/installation.adoc`
+- conflicts found: none.
+- conflicts resolved: none.
+- SonarQube findings and fixes: pending CI; local slice contains no secret values or live infrastructure calls.
+- documentation updates: completed.
+- final integration decision: accepted pending full quality gate and push auto lifecycle.
+
+## Tests Executed
+
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && PYTHONPATH=src python3 -m unittest tests.test_install_script tests.test_package_entrypoint"`: passed, 48 tests.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`: passed, with existing CRLF warnings for unrelated files.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`: passed; lint, arch-lint, arch-tests, typecheck, and 850 tests passed with 17 skipped.

--- a/.codex/evidence/slice-68-distribution.md
+++ b/.codex/evidence/slice-68-distribution.md
@@ -1,0 +1,25 @@
+# Slice 68 Distribution
+
+- workflow id: issue-68-explicit-live-approval-20260614
+- slice id: issue-68
+- slice title: Replace piped installer approval with explicit flag
+- affected areas: runtime, CLI, tests, documentation, quality
+- chosen execution mode: sequential
+- selected streams: runtime, backend, tests, documentation
+- real subagents used: yes, read-only implementation-scope review by Jason
+- fallback role-based review used: no
+- Git worktrees used: no
+- expected touched files/directories:
+  - install.sh
+  - src/tiny_swarm_world/__main__.py
+  - tests/test_install_script.py
+  - tests/test_package_entrypoint.py
+  - README.md
+  - documentation/user_guide/installation.adoc
+- conflict risks: shared install wrapper and live-consent CLI contract; no safe parallel split because wrapper, CLI, tests, and docs describe one consent contract.
+- quality gates to run:
+  - PYTHONPATH=src python3 -m unittest tests.test_install_script tests.test_package_entrypoint
+  - git diff --check
+  - python3 tools/quality_gate.py quality
+- consolidation plan: integrate CLI approval flag, wrapper forwarding, evidence metadata, focused tests, and operator documentation in one issue branch before full quality and push auto.
+- parallelization decision: rejected because the implementation and tests share the same live-consent contract and must remain coherent.

--- a/README.md
+++ b/README.md
@@ -149,14 +149,18 @@ wrapper:
 For deliberate test-system automation, use `./install.sh --confirm-reset` to
 confirm the wrapper's reset prompt with an explicit flag. The underlying reset
 workflow still uses `--confirm RESET_TINY_SWARM_PLATFORM`.
+Use `./install.sh --non-interactive-live-approval` only for deliberate
+automation that must pass the CLI live-consent prompt without terminal input;
+otherwise the recorded live commands ask for interactive confirmation.
 
 The wrapper records run context, reset logs, setup logs, and exit codes under
 `.tiny-swarm-world/evidence/installation-tests/<host-runtime>/`, where the
 stable host directory is `wsl2` or `native_linux`. It loads or generates local
 `TSW_*` secrets in `.tiny-swarm-world/local/live-installation.env` without
 printing secret values, records the detected host type and selected evidence
-directory in `context.txt`, runs the governed reset prelude, then calls the
-canonical setup workflow.
+directory in `context.txt`, records whether live approval came from an operator
+prompt or explicit automation flag, runs the governed reset prelude, then calls
+the canonical setup workflow.
 
 With live consent, it sequences setup preflight, platform, artifact,
 deployment, and final verification phases. Current live behavior remains
@@ -174,6 +178,10 @@ controls before application services are constructed:
 
 - `--live`
 - answering `y` at the short live-infrastructure confirmation prompt
+
+Non-interactive automation may replace the prompt with `--approve-live` on the
+CLI or `--non-interactive-live-approval` on `install.sh`. The flag is a separate
+explicit approval source; it does not remove the `--live` requirement.
 
 The current default provider is `lxc_native`. `platform init` selects the
 LXD/Incus provider path after provider readiness checks and blocks before

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -224,12 +224,26 @@ replaced by an explicit flag:
 ./install.sh --confirm-reset
 ----
 
+The CLI live-infrastructure prompt is separate from the reset prompt. Normal
+wrapper runs keep that prompt interactive inside the terminal recorder. For
+deliberate non-interactive automation, pass an explicit live-approval flag:
+
+[source,bash]
+----
+./install.sh --non-interactive-live-approval
+PYTHONPATH=src python3 -m tiny_swarm_world setup run --live --approve-live
+----
+
+The automation flag is an approval source; it does not remove the `--live`
+requirement.
+
 The wrapper writes run context, reset logs, setup logs and exit codes below
 `.tiny-swarm-world/evidence/installation-tests/<host-runtime>/<UTC timestamp>/`.
 The stable host directory is `wsl2` for WSL2 and `native_linux` for native
 Linux. The run `context.txt` records `host_runtime_type`,
-`host_runtime_detection_source`, and `selected_evidence_directory` alongside
-`reset-run.log`, `reset-run.exit`, `setup-run.log`, and `setup-run.exit`.
+`host_runtime_detection_source`, `selected_evidence_directory`,
+`live_execution_mode`, and `live_approval_source` alongside `reset-run.log`,
+`reset-run.exit`, `setup-run.log`, and `setup-run.exit`.
 It loads or generates local `TSW_*` secrets in
 `.tiny-swarm-world/local/live-installation.env` without printing secret
 values.

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ GENERATED_SECRET_ENV_FILE="${TSW_GENERATED_SECRET_ENV_FILE:-.tiny-swarm/secrets/
 NATIVE_LINUX_VENV="${TSW_NATIVE_LINUX_VENV:-.tiny-swarm-world/install-venv}"
 RESET_CONFIRMATION="RESET_TINY_SWARM_PLATFORM"
 RESET_CONFIRMED_BY_FLAG=0
+NON_INTERACTIVE_LIVE_APPROVAL=0
 
 REQUIRED_SECRETS=(
   TSW_PORTAINER_ADMIN_PASSWORD
@@ -31,12 +32,16 @@ usage() {
 Tiny Swarm World live installation wrapper.
 
 Usage:
-  ./install.sh [--service-profile NAME] [--no-generate-secrets] [--confirm-reset]
+  ./install.sh [--service-profile NAME] [--no-generate-secrets] [--confirm-reset] [--non-interactive-live-approval]
 
 Options:
   --service-profile NAME   Service profile passed to setup run (default: service-access).
   --no-generate-secrets    Fail if required TSW_* secrets are missing.
   --confirm-reset          Confirm the governed fresh-install reset without prompting.
+  --non-interactive-live-approval
+                           Pass explicit non-interactive live approval to the CLI.
+                           Without this flag, recorded live commands ask for the
+                           CLI's interactive live confirmation.
   -h, --help               Show this help.
 
 Optional environment:
@@ -269,6 +274,8 @@ write_context() {
   local secrets_generated_count="$3"
   local resolved_host_type="$4"
   local detection_source="$5"
+  local live_execution_mode="$6"
+  local live_approval_source="$7"
 
   {
     printf 'run_id=%s\n' "$run_id"
@@ -283,6 +290,8 @@ write_context() {
     printf 'host_runtime_type=%s\n' "$resolved_host_type"
     printf 'host_runtime_detection_source=%s\n' "$detection_source"
     printf 'selected_evidence_directory=%s\n' "$evidence_dir"
+    printf 'live_execution_mode=%s\n' "$live_execution_mode"
+    printf 'live_approval_source=%s\n' "$live_approval_source"
     printf 'platform_system=%s\n' "$(uname -s)"
     printf 'kernel_release=%s\n' "$(uname -r)"
     printf 'proc_osrelease=%s\n' "$(cat /proc/sys/kernel/osrelease 2>/dev/null || true)"
@@ -308,7 +317,7 @@ run_recorded_command() {
     effective_command="sg ${TSW_INSTALL_COMMAND_GROUP} -c $(shell_quote "$command_line")"
   fi
 
-  printf 'y\n' | script -q -e -c "$effective_command" "$log_file"
+  script -q -e -c "$effective_command" "$log_file"
 }
 
 configure_native_linux_command_group() {
@@ -370,6 +379,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --confirm-reset)
       RESET_CONFIRMED_BY_FLAG=1
+      shift
+      ;;
+    --non-interactive-live-approval)
+      NON_INTERACTIVE_LIVE_APPROVAL=1
       shift
       ;;
     -h|--help)
@@ -462,9 +475,25 @@ fi
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
 RESOLVED_HOST_TYPE="$(host_runtime_type)"
 HOST_DETECTION_SOURCE="$(host_detection_source)"
+if (( NON_INTERACTIVE_LIVE_APPROVAL == 1 )); then
+  LIVE_EXECUTION_MODE="non_interactive"
+  LIVE_APPROVAL_SOURCE="explicit_automation_flag"
+  LIVE_APPROVAL_ARGUMENT=" --approve-live"
+else
+  LIVE_EXECUTION_MODE="interactive"
+  LIVE_APPROVAL_SOURCE="operator_prompt"
+  LIVE_APPROVAL_ARGUMENT=""
+fi
 EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/$RESOLVED_HOST_TYPE/$RUN_ID"
 mkdir -p "$EVIDENCE_DIR"
-write_context "$EVIDENCE_DIR" "$RUN_ID" "$secrets_generated_count" "$RESOLVED_HOST_TYPE" "$HOST_DETECTION_SOURCE"
+write_context \
+  "$EVIDENCE_DIR" \
+  "$RUN_ID" \
+  "$secrets_generated_count" \
+  "$RESOLVED_HOST_TYPE" \
+  "$HOST_DETECTION_SOURCE" \
+  "$LIVE_EXECUTION_MODE" \
+  "$LIVE_APPROVAL_SOURCE"
 
 cat <<EOF
 Tiny Swarm World live installation
@@ -487,8 +516,8 @@ else
   printf 'reset_confirmation_source=interactive_prompt\n' >>"$EVIDENCE_DIR/context.txt"
 fi
 
-reset_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world platform reset --live --confirm $RESET_CONFIRMATION --service-profile $(shell_quote "$SERVICE_PROFILE")"
-setup_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world setup run --live --service-profile $(shell_quote "$SERVICE_PROFILE")"
+reset_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world platform reset --live${LIVE_APPROVAL_ARGUMENT} --confirm $RESET_CONFIRMATION --service-profile $(shell_quote "$SERVICE_PROFILE")"
+setup_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world setup run --live${LIVE_APPROVAL_ARGUMENT} --service-profile $(shell_quote "$SERVICE_PROFILE")"
 
 printf 'Starting fresh-install reset. Terminal UI is visible and recorded at: %s/reset-run.log\n' "$EVIDENCE_DIR"
 set +e

--- a/src/tiny_swarm_world/__main__.py
+++ b/src/tiny_swarm_world/__main__.py
@@ -120,6 +120,14 @@ def parse_args(argv: Sequence[str] | None = None) -> Namespace:
         help="Allow live infrastructure execution after the required consent checks pass.",
     )
     parser.add_argument(
+        "--approve-live",
+        action="store_true",
+        help=(
+            "Explicit non-interactive approval for --live infrastructure changes. "
+            "Without this flag, --live asks for interactive confirmation."
+        ),
+    )
+    parser.add_argument(
         "--confirm",
         help="Exact confirmation phrase required by destructive workflows.",
     )
@@ -404,13 +412,14 @@ def _blocked_workflow_result(workflow: CliWorkflow) -> dict[str, object]:
 
 
 def _live_consent_from_args(args: Namespace) -> LiveConsent:
-    confirmed = False
+    confirmed = bool(args.approve_live)
     if args.live:
-        try:
-            answer = input(f"{LIVE_CONSENT_PROMPT} ")
-            confirmed = answer.strip().lower() in LIVE_CONSENT_YES_VALUES
-        except EOFError:
-            confirmed = False
+        if not confirmed:
+            try:
+                answer = input(f"{LIVE_CONSENT_PROMPT} ")
+                confirmed = answer.strip().lower() in LIVE_CONSENT_YES_VALUES
+            except EOFError:
+                confirmed = False
     return LiveConsent(live_flag=args.live, confirmed=confirmed)
 
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -47,6 +47,8 @@ class TestInstallScript(unittest.TestCase):
                 "selected_evidence_directory=.tiny-swarm-world/evidence/installation-tests/native_linux/",
                 context,
             )
+            self.assertIn("live_execution_mode=interactive", context)
+            self.assertIn("live_approval_source=operator_prompt", context)
             self.assertIn("reset_confirmation_present=yes", context)
             self.assertIn("reset_confirmation_source=interactive_prompt", context)
             self.assertIn("reset_exit=0", context)
@@ -214,12 +216,39 @@ class TestInstallScript(unittest.TestCase):
             self.assertIn("TSW_TRAEFIK_TLS_CERT_SECRET_NAME='tsw_traefik_tls_cert'", secret_content)
             self.assertIn("TSW_TRAEFIK_TLS_KEY_SECRET_NAME='tsw_traefik_tls_key'", secret_content)
 
-    def test_install_answers_each_recorded_live_consent_once(self):
+    def test_interactive_install_does_not_pipe_live_consent_into_cli_prompt(self):
         with _install_script_fixture() as fixture:
             result = fixture.run()
 
             self.assertEqual(0, result.returncode, result.stderr)
-            self.assertEqual(["y", "y"], fixture.recorded_live_confirmations())
+            self.assertEqual(["", ""], fixture.recorded_live_confirmations())
+
+    def test_noninteractive_live_approval_flag_passes_explicit_cli_approval(self):
+        with _install_script_fixture(
+            extra_args=("--non-interactive-live-approval",),
+        ) as fixture:
+            result = fixture.run()
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                [
+                    (
+                        "PYTHONPATH=src 'python3' -m tiny_swarm_world platform reset "
+                        "--live --approve-live --confirm RESET_TINY_SWARM_PLATFORM "
+                        "--service-profile 'service-access'"
+                    ),
+                    (
+                        "PYTHONPATH=src 'python3' -m tiny_swarm_world setup run "
+                        "--live --approve-live --service-profile 'service-access'"
+                    ),
+                ],
+                fixture.recorded_commands(),
+            )
+            evidence_dir = fixture.single_evidence_dir()
+            context = (evidence_dir / "context.txt").read_text()
+            self.assertIn("live_execution_mode=non_interactive", context)
+            self.assertIn("live_approval_source=explicit_automation_flag", context)
+            self.assertEqual(["", ""], fixture.recorded_live_confirmations())
 
     def test_install_disables_infisical_item_seed_by_default(self):
         with _install_script_fixture() as fixture:

--- a/tests/test_package_entrypoint.py
+++ b/tests/test_package_entrypoint.py
@@ -165,6 +165,18 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         workflows.init.run.assert_awaited_once_with()
         self.assertIn('"workflow": "platform init"', output.getvalue())
 
+    async def test_mutating_workflow_accepts_explicit_noninteractive_live_approval(self):
+        services, workflows = _application_services_with_platform_workflows()
+        output = io.StringIO()
+
+        with patch("builtins.input", side_effect=AssertionError("prompt must not run")):
+            with patch.object(entrypoint, "build_application_services", return_value=services):
+                with redirect_stdout(output):
+                    await entrypoint.main(["platform", "init", "--live", "--approve-live"])
+
+        workflows.init.run.assert_awaited_once_with()
+        self.assertIn('"workflow": "platform init"', output.getvalue())
+
     async def test_mutating_workflow_refuses_noninteractive_eof(self):
         output = io.StringIO()
 


### PR DESCRIPTION
## Summary
- Add CLI `--approve-live` for explicit non-interactive live approval while preserving fail-closed `--live` behavior.
- Add installer `--non-interactive-live-approval`, remove the blanket piped `y`, and record `live_execution_mode` plus `live_approval_source` in evidence.
- Update wrapper/entrypoint tests and operator documentation for the consent model.

## Verification
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && PYTHONPATH=src python3 -m unittest tests.test_install_script tests.test_package_entrypoint"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`

Closes #68