### PR TITLE
Add headless install execution mode

### DIFF
--- a/.codex/evidence/slice-81-consolidation.md
+++ b/.codex/evidence/slice-81-consolidation.md
@@ -1,0 +1,31 @@
+# Slice 81 Consolidation
+
+- workflow id: issue-81-headless-install-20260614
+- slice id: issue-81
+- slice title: Make install.sh complete without requiring the console TUI
+
+## Stream Results
+
+- runtime: `install.sh --headless` and `TSW_INSTALL_HEADLESS=1` run the same governed reset/setup commands without `script(1)`.
+- tests: wrapper tests cover headless success, reset failure exit-code preservation, evidence logs, and setup skip after reset failure.
+- documentation: README and installation guide document headless mode and evidence metadata.
+
+## Review Results
+
+- accepted findings: `script -q -e -c` should remain available as terminal recording, but not be required for install completion.
+- rejected findings: none.
+- files changed per stream:
+  - runtime: `install.sh`
+  - tests: `tests/test_install_script.py`
+  - documentation: `README.md`, `documentation/user_guide/installation.adoc`
+- conflicts found: none.
+- conflicts resolved: none.
+- SonarQube findings and fixes: pending CI; local slice contains no secret values or live infrastructure calls.
+- documentation updates: completed.
+- final integration decision: accepted pending push auto lifecycle.
+
+## Tests Executed
+
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && PYTHONPATH=src python3 -m unittest tests.test_install_script"`: passed, 19 tests.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`: passed, with existing CRLF warnings for unrelated files.
+- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`: passed; lint, arch-lint, arch-tests, typecheck, and 853 tests passed with 17 skipped.

--- a/.codex/evidence/slice-81-distribution.md
+++ b/.codex/evidence/slice-81-distribution.md
@@ -1,0 +1,23 @@
+# Slice 81 Distribution
+
+- workflow id: issue-81-headless-install-20260614
+- slice id: issue-81
+- slice title: Make install.sh complete without requiring the console TUI
+- affected areas: runtime, tests, documentation, quality
+- chosen execution mode: sequential
+- selected streams: runtime, tests, documentation
+- real subagents used: attempted read-only review by Helmholtz; timed out before completion and was closed
+- fallback role-based review used: yes, main-thread Senior DevOps/Tester review
+- Git worktrees used: no
+- expected touched files/directories:
+  - install.sh
+  - tests/test_install_script.py
+  - README.md
+  - documentation/user_guide/installation.adoc
+- conflict risks: shared install wrapper and evidence contract; no safe parallel split because headless execution, exit codes, and logs are one behavior.
+- quality gates to run:
+  - PYTHONPATH=src python3 -m unittest tests.test_install_script
+  - git diff --check
+  - python3 tools/quality_gate.py quality
+- consolidation plan: integrate headless execution flag, direct log capture, regression tests, and documentation in one issue branch before full quality and push auto.
+- parallelization decision: rejected because the implementation changes one shell execution primitive and its tests/documentation must move together.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ workflow still uses `--confirm RESET_TINY_SWARM_PLATFORM`.
 Use `./install.sh --non-interactive-live-approval` only for deliberate
 automation that must pass the CLI live-consent prompt without terminal input;
 otherwise the recorded live commands ask for interactive confirmation.
+Use `./install.sh --headless` or `TSW_INSTALL_HEADLESS=1 ./install.sh` when the
+same governed reset/setup flow must run without the terminal recorder/TUI
+presentation. Headless mode still writes reset/setup logs and preserves command
+exit codes.
 
 The wrapper records run context, reset logs, setup logs, and exit codes under
 `.tiny-swarm-world/evidence/installation-tests/<host-runtime>/`, where the
@@ -159,8 +163,9 @@ stable host directory is `wsl2` or `native_linux`. It loads or generates local
 `TSW_*` secrets in `.tiny-swarm-world/local/live-installation.env` without
 printing secret values, records the detected host type and selected evidence
 directory in `context.txt`, records whether live approval came from an operator
-prompt or explicit automation flag, runs the governed reset prelude, then calls
-the canonical setup workflow.
+prompt or explicit automation flag, records whether command output came from
+the terminal recorder or headless logging, runs the governed reset prelude, then
+calls the canonical setup workflow.
 
 With live consent, it sequences setup preflight, platform, artifact,
 deployment, and final verification phases. Current live behavior remains

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -237,13 +237,27 @@ PYTHONPATH=src python3 -m tiny_swarm_world setup run --live --approve-live
 The automation flag is an approval source; it does not remove the `--live`
 requirement.
 
+Terminal recording is optional presentation. For headless systems that cannot
+or should not start the terminal recorder/TUI surface, use:
+
+[source,bash]
+----
+./install.sh --headless
+TSW_INSTALL_HEADLESS=1 ./install.sh
+----
+
+Headless mode executes the same governed reset and setup commands, writes the
+same `reset-run.log`, `reset-run.exit`, `setup-run.log`, and `setup-run.exit`
+evidence files, and preserves command exit codes.
+
 The wrapper writes run context, reset logs, setup logs and exit codes below
 `.tiny-swarm-world/evidence/installation-tests/<host-runtime>/<UTC timestamp>/`.
 The stable host directory is `wsl2` for WSL2 and `native_linux` for native
 Linux. The run `context.txt` records `host_runtime_type`,
 `host_runtime_detection_source`, `selected_evidence_directory`,
-`live_execution_mode`, and `live_approval_source` alongside `reset-run.log`,
-`reset-run.exit`, `setup-run.log`, and `setup-run.exit`.
+`live_execution_mode`, `live_approval_source`, and `terminal_recording_mode`
+alongside `reset-run.log`, `reset-run.exit`, `setup-run.log`, and
+`setup-run.exit`.
 It loads or generates local `TSW_*` secrets in
 `.tiny-swarm-world/local/live-installation.env` without printing secret
 values.

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ NATIVE_LINUX_VENV="${TSW_NATIVE_LINUX_VENV:-.tiny-swarm-world/install-venv}"
 RESET_CONFIRMATION="RESET_TINY_SWARM_PLATFORM"
 RESET_CONFIRMED_BY_FLAG=0
 NON_INTERACTIVE_LIVE_APPROVAL=0
+HEADLESS_INSTALL="${TSW_INSTALL_HEADLESS:-0}"
 
 REQUIRED_SECRETS=(
   TSW_PORTAINER_ADMIN_PASSWORD
@@ -32,7 +33,7 @@ usage() {
 Tiny Swarm World live installation wrapper.
 
 Usage:
-  ./install.sh [--service-profile NAME] [--no-generate-secrets] [--confirm-reset] [--non-interactive-live-approval]
+  ./install.sh [--service-profile NAME] [--no-generate-secrets] [--confirm-reset] [--non-interactive-live-approval] [--headless]
 
 Options:
   --service-profile NAME   Service profile passed to setup run (default: service-access).
@@ -42,6 +43,8 @@ Options:
                            Pass explicit non-interactive live approval to the CLI.
                            Without this flag, recorded live commands ask for the
                            CLI's interactive live confirmation.
+  --headless               Disable terminal recorder/TUI presentation and capture
+                           command stdout/stderr directly to evidence logs.
   -h, --help               Show this help.
 
 Optional environment:
@@ -276,6 +279,7 @@ write_context() {
   local detection_source="$5"
   local live_execution_mode="$6"
   local live_approval_source="$7"
+  local terminal_recording_mode="$8"
 
   {
     printf 'run_id=%s\n' "$run_id"
@@ -292,6 +296,7 @@ write_context() {
     printf 'selected_evidence_directory=%s\n' "$evidence_dir"
     printf 'live_execution_mode=%s\n' "$live_execution_mode"
     printf 'live_approval_source=%s\n' "$live_approval_source"
+    printf 'terminal_recording_mode=%s\n' "$terminal_recording_mode"
     printf 'platform_system=%s\n' "$(uname -s)"
     printf 'kernel_release=%s\n' "$(uname -r)"
     printf 'proc_osrelease=%s\n' "$(cat /proc/sys/kernel/osrelease 2>/dev/null || true)"
@@ -317,7 +322,11 @@ run_recorded_command() {
     effective_command="sg ${TSW_INSTALL_COMMAND_GROUP} -c $(shell_quote "$command_line")"
   fi
 
-  script -q -e -c "$effective_command" "$log_file"
+  if (( HEADLESS_INSTALL == 1 )); then
+    bash -lc "$effective_command" >"$log_file" 2>&1
+  else
+    script -q -e -c "$effective_command" "$log_file"
+  fi
 }
 
 configure_native_linux_command_group() {
@@ -385,6 +394,10 @@ while [[ $# -gt 0 ]]; do
       NON_INTERACTIVE_LIVE_APPROVAL=1
       shift
       ;;
+    --headless)
+      HEADLESS_INSTALL=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -409,7 +422,9 @@ cd "$SCRIPT_DIR"
 [[ "$(uname -s)" == "Linux" ]] || fail "Tiny Swarm World installation is supported only on Linux/WSL."
 [[ -d src/tiny_swarm_world ]] || fail "Run this script from the Tiny Swarm World repository root."
 require_command python3
-require_command script
+if (( HEADLESS_INSTALL != 1 )); then
+  require_command script
+fi
 
 PYTHON_BIN="$(ensure_native_linux_python_environment)"
 configure_native_linux_command_group
@@ -484,6 +499,11 @@ else
   LIVE_APPROVAL_SOURCE="operator_prompt"
   LIVE_APPROVAL_ARGUMENT=""
 fi
+if (( HEADLESS_INSTALL == 1 )); then
+  TERMINAL_RECORDING_MODE="headless"
+else
+  TERMINAL_RECORDING_MODE="terminal_recorder"
+fi
 EVIDENCE_DIR=".tiny-swarm-world/evidence/installation-tests/$RESOLVED_HOST_TYPE/$RUN_ID"
 mkdir -p "$EVIDENCE_DIR"
 write_context \
@@ -493,7 +513,8 @@ write_context \
   "$RESOLVED_HOST_TYPE" \
   "$HOST_DETECTION_SOURCE" \
   "$LIVE_EXECUTION_MODE" \
-  "$LIVE_APPROVAL_SOURCE"
+  "$LIVE_APPROVAL_SOURCE" \
+  "$TERMINAL_RECORDING_MODE"
 
 cat <<EOF
 Tiny Swarm World live installation
@@ -519,7 +540,11 @@ fi
 reset_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world platform reset --live${LIVE_APPROVAL_ARGUMENT} --confirm $RESET_CONFIRMATION --service-profile $(shell_quote "$SERVICE_PROFILE")"
 setup_command="PYTHONPATH=src $(shell_quote "$PYTHON_BIN") -m tiny_swarm_world setup run --live${LIVE_APPROVAL_ARGUMENT} --service-profile $(shell_quote "$SERVICE_PROFILE")"
 
-printf 'Starting fresh-install reset. Terminal UI is visible and recorded at: %s/reset-run.log\n' "$EVIDENCE_DIR"
+if (( HEADLESS_INSTALL == 1 )); then
+  printf 'Starting fresh-install reset. Headless output is recorded at: %s/reset-run.log\n' "$EVIDENCE_DIR"
+else
+  printf 'Starting fresh-install reset. Terminal UI is visible and recorded at: %s/reset-run.log\n' "$EVIDENCE_DIR"
+fi
 set +e
 run_recorded_command "$reset_command" "$EVIDENCE_DIR/reset-run.log"
 reset_exit=$?
@@ -538,7 +563,11 @@ if (( reset_exit != 0 )); then
   exit "$reset_exit"
 fi
 
-printf 'Starting live setup. Terminal UI is visible and recorded at: %s/setup-run.log\n' "$EVIDENCE_DIR"
+if (( HEADLESS_INSTALL == 1 )); then
+  printf 'Starting live setup. Headless output is recorded at: %s/setup-run.log\n' "$EVIDENCE_DIR"
+else
+  printf 'Starting live setup. Terminal UI is visible and recorded at: %s/setup-run.log\n' "$EVIDENCE_DIR"
+fi
 set +e
 run_recorded_command "$setup_command" "$EVIDENCE_DIR/setup-run.log"
 setup_exit=$?

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -49,6 +49,7 @@ class TestInstallScript(unittest.TestCase):
             )
             self.assertIn("live_execution_mode=interactive", context)
             self.assertIn("live_approval_source=operator_prompt", context)
+            self.assertIn("terminal_recording_mode=terminal_recorder", context)
             self.assertIn("reset_confirmation_present=yes", context)
             self.assertIn("reset_confirmation_source=interactive_prompt", context)
             self.assertIn("reset_exit=0", context)
@@ -249,6 +250,66 @@ class TestInstallScript(unittest.TestCase):
             self.assertIn("live_execution_mode=non_interactive", context)
             self.assertIn("live_approval_source=explicit_automation_flag", context)
             self.assertEqual(["", ""], fixture.recorded_live_confirmations())
+
+    def test_headless_install_runs_governed_commands_without_terminal_recorder(self):
+        with _install_script_fixture(
+            extra_args=("--headless", "--non-interactive-live-approval"),
+        ) as fixture:
+            result = fixture.run()
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual(
+                [
+                    (
+                        "PYTHONPATH=src python3 -m tiny_swarm_world platform reset "
+                        "--live --approve-live --confirm RESET_TINY_SWARM_PLATFORM "
+                        "--service-profile service-access"
+                    ),
+                    (
+                        "PYTHONPATH=src python3 -m tiny_swarm_world setup run "
+                        "--live --approve-live --service-profile service-access"
+                    ),
+                ],
+                fixture.recorded_commands(),
+            )
+            evidence_dir = fixture.single_evidence_dir()
+            context = (evidence_dir / "context.txt").read_text()
+            self.assertIn("terminal_recording_mode=headless", context)
+            self.assertIn("live_execution_mode=non_interactive", context)
+            self.assertEqual("0", (evidence_dir / "reset-run.exit").read_text().strip())
+            self.assertEqual("0", (evidence_dir / "setup-run.exit").read_text().strip())
+            self.assertIn("fake headless command", (evidence_dir / "reset-run.log").read_text())
+            self.assertIn("fake headless command", (evidence_dir / "setup-run.log").read_text())
+            self.assertFalse(fixture.recorded_live_confirmations())
+
+    def test_headless_install_preserves_reset_failure_exit_code_and_skips_setup(self):
+        with _install_script_fixture(
+            reset_exit=17,
+            extra_args=("--headless", "--non-interactive-live-approval"),
+        ) as fixture:
+            result = fixture.run()
+
+            self.assertEqual(17, result.returncode)
+            self.assertEqual(1, len(fixture.recorded_commands()))
+            evidence_dir = fixture.single_evidence_dir()
+            self.assertEqual("17", (evidence_dir / "reset-run.exit").read_text().strip())
+            self.assertFalse((evidence_dir / "setup-run.exit").exists())
+            self.assertFalse(fixture.recorded_live_confirmations())
+
+    def test_headless_install_can_be_enabled_by_environment(self):
+        with _install_script_fixture(
+            extra_args=("--non-interactive-live-approval",),
+            extra_environment={"TSW_INSTALL_HEADLESS": "1"},
+        ) as fixture:
+            result = fixture.run()
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            evidence_dir = fixture.single_evidence_dir()
+            context = (evidence_dir / "context.txt").read_text()
+            self.assertIn("terminal_recording_mode=headless", context)
+            self.assertIn("fake headless command", (evidence_dir / "reset-run.log").read_text())
+            self.assertIn("fake headless command", (evidence_dir / "setup-run.log").read_text())
+            self.assertFalse(fixture.recorded_live_confirmations())
 
     def test_install_disables_infisical_item_seed_by_default(self):
         with _install_script_fixture() as fixture:
@@ -544,6 +605,21 @@ exit 44
 SH
           chmod 755 "$target/bin/python"
           exit 0
+        fi
+        if [[ "${1:-}" == "-m" && "${2:-}" == "tiny_swarm_world" ]]; then
+          printf 'PYTHONPATH=%s python3 %s\\n' "${PYTHONPATH:-}" "$*" >>"$TSW_FAKE_SCRIPT_COMMANDS"
+          printf 'fake headless command for %s\\n' "$*"
+          case "$*" in
+            *" platform reset "*)
+              exit "$TSW_FAKE_RESET_EXIT"
+              ;;
+            *" setup run "*)
+              exit "$TSW_FAKE_SETUP_EXIT"
+              ;;
+            *)
+              exit 99
+              ;;
+          esac
         fi
         printf 'fake python3 should be invoked only through fake script or secret generation\\n' >&2
         exit 43


### PR DESCRIPTION
## Summary
- Add `install.sh --headless` and `TSW_INSTALL_HEADLESS=1` to run governed reset/setup without the terminal recorder/TUI surface.
- Preserve reset/setup command construction, evidence logs, and exit-code behavior in headless mode.
- Add wrapper regression tests and update operator documentation.

## Verification
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && PYTHONPATH=src python3 -m unittest tests.test_install_script"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && git diff --check"`
- `wsl.exe bash -lc "cd /mnt/d/Projects/Tiny-Swarm-World && python3 tools/quality_gate.py quality"`

Closes #81