### PR TITLE
Define configuration value ownership

### DIFF
--- a/.codex/evidence/slice-76-consolidation.md
+++ b/.codex/evidence/slice-76-consolidation.md
@@ -1,0 +1,54 @@
+# Slice 76 Consolidation Evidence
+
+- Workflow id: `issue-76-configuration-value-ownership-20260614`
+- Slice id: `76`
+- Slice title: Define configuration value ownership
+
+## Stream Results
+
+- Secret ownership model: `SecretManifestEntry` now exposes owner, storage, and lifecycle metadata derived from manifest source categories.
+- Installer integration: the Python installer derives required local bootstrap values from `infra/config/secrets/infisical-secrets.yaml` instead of maintaining a separate required-secret list.
+- Manifest alignment: `TSW_INFISICAL_REDIS_PASSWORD` is required in the manifest because the installer/runtime path requires it for local bootstrap/recovery exports.
+- Tests: secret-management and installer tests cover required manifest entries, ownership metadata, and isolated installer fixture behavior.
+- Documentation: configuration contract, inventory, README, and installation guide document local env, bootstrap, recovery, Infisical-managed, and external secret-name ownership.
+
+## Subagent Review
+
+- Carver reviewed the branch read-only.
+- Accepted findings:
+  - Avoid importing the full deployment secret-management service into the minimal installer test fixture.
+  - Add a real ownership model beyond loose source strings.
+  - Remove duplicated required-secret ownership from installer code.
+  - Separate bootstrap/runtime/local/recovery/Infisical/external secret-name responsibilities in docs and tests.
+  - Treat recovery files as first-class governed artifacts.
+- Rejected findings: none.
+
+## Files Changed Per Stream
+
+- Secret model: `src/tiny_swarm_world/application/services/deployment/secret_management.py`, `infra/config/secrets/infisical-secrets.yaml`
+- Installer: `src/tiny_swarm_world/installer.py`
+- Tests: `tests/application/services/deployment/test_secret_management.py`, `tests/test_installer.py`, `tests/test_install_script.py`
+- Documentation: `documentation/configuration/config-contract-inventory.md`, `documentation/configuration/operator-configuration-contract.md`, `documentation/user_guide/installation.adoc`, `README.md`
+- Evidence: `.codex/evidence/slice-76-distribution.md`, `.codex/evidence/slice-76-consolidation.md`
+
+## Conflicts
+
+- Conflicts found: none.
+- Conflicts resolved: not applicable.
+
+## Tests Executed
+
+- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_secret_management tests.test_installer tests.test_install_script` - passed.
+- `python3 tools/quality_gate.py lint` - passed.
+- `python3 tools/quality_gate.py typecheck` - passed.
+- `python3 -m ruff check src/tiny_swarm_world/installer.py tests/test_installer.py` - passed.
+- `PYTHONPATH=src python3 -m py_compile src/tiny_swarm_world/installer.py` - passed.
+- `python3 tools/quality_gate.py quality` - passed, including lint, arch-lint, arch-tests, typecheck, and 862 tests with 17 skipped.
+
+## SonarQube
+
+- No local SonarQube run was executed. The push-auto lifecycle must verify or explicitly skip the remote SonarCloud check according to current CI behavior.
+
+## Final Integration Decision
+
+- Accepted for final full quality gate and `push auto` lifecycle.

--- a/.codex/evidence/slice-76-distribution.md
+++ b/.codex/evidence/slice-76-distribution.md
@@ -1,0 +1,37 @@
+# Slice 76 Distribution Evidence
+
+- Workflow id: `issue-76-configuration-value-ownership-20260614`
+- Slice id: `76`
+- Slice title: Define configuration value ownership
+- Affected areas: secrets, configuration, Python automation, tests, documentation, security
+- Chosen execution mode: sequential
+- Selected streams: secret ownership model, installer integration, tests, documentation
+- Real subagents used: yes, Carver performed read-only review
+- Fallback role-based review used: no
+- Git worktrees used: no
+- Expected touched files/directories:
+  - `src/tiny_swarm_world/installer.py`
+  - `src/tiny_swarm_world/application/services/deployment/secret_management.py`
+  - `infra/config/secrets/infisical-secrets.yaml`
+  - `tests/**`
+  - `documentation/configuration/**`
+  - `documentation/user_guide/**`
+  - `README.md`
+- Conflict risks:
+  - Recent issue #67 moved installer policy into Python.
+  - Secret ownership touches installer and deployment sync code.
+  - Tests must not expose or create real secrets.
+- Quality gates:
+  - `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_secret_management tests.test_installer tests.test_install_script`
+  - `python3 tools/quality_gate.py lint`
+  - `python3 tools/quality_gate.py typecheck`
+  - `python3 -m ruff check src/tiny_swarm_world/installer.py tests/test_installer.py`
+  - `PYTHONPATH=src python3 -m py_compile src/tiny_swarm_world/installer.py`
+  - `python3 tools/quality_gate.py quality`
+- Consolidation plan:
+  - Keep implementation sequential because installer, manifest, secret sync, and docs share the same contract.
+  - Accept read-only subagent findings before final quality gate.
+  - Publish through guarded PR lifecycle only after full local and remote checks pass.
+- Parallelization decision:
+  - Rejected for write work due to overlapping ownership contracts and shared secret files.
+  - Accepted for read-only subagent review.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ directory in `context.txt`, records whether live approval came from an operator
 prompt or explicit automation flag, records whether command output came from
 the terminal recorder or headless logging, runs the governed reset prelude, then
 calls the canonical setup workflow.
+Required local bootstrap values are derived from
+`infra/config/secrets/infisical-secrets.yaml`; the installer does not keep a
+separate required-secret list.
 
 With live consent, it sequences setup preflight, platform, artifact,
 deployment, and final verification phases. Current live behavior remains

--- a/documentation/configuration/config-contract-inventory.md
+++ b/documentation/configuration/config-contract-inventory.md
@@ -19,9 +19,9 @@ evidence.
 
 The current configuration surface is spread across these repository areas:
 
-- `install.sh`: installer-local env file paths, generated secret behavior,
-  required secret bootstrap, default Traefik secret names, and setup invocation
-  flags.
+- `src/tiny_swarm_world/installer.py`: installer-local env file paths,
+  generated secret behavior, required secret bootstrap derived from the secret
+  manifest, default Traefik secret names, and setup invocation flags.
 - `src/tiny_swarm_world/infrastructure/composition.py`: deployment and
   artifact wiring that reads operator config through helper functions or direct
   environment access.
@@ -78,19 +78,19 @@ are secret values unless explicitly noted otherwise.
 
 | Key | Service | Requiredness | Value kind | Source |
 |---|---|---|---|---|
-| `TSW_PORTAINER_ADMIN_PASSWORD` | Portainer | Required | secret value | `setup_manifest.py`, `install.sh`, composition |
-| `TSW_NEXUS_ADMIN_PASSWORD` | Nexus | Required | secret value | `setup_manifest.py`, `install.sh`, composition |
-| `TSW_JENKINS_ADMIN_PASSWORD` | Jenkins | Required | secret value | `setup_manifest.py`, `install.sh`, compose |
-| `TSW_RABBITMQ_PASSWORD` | RabbitMQ | Required | secret value | `setup_manifest.py`, `install.sh`, compose |
-| `TSW_SONARQUBE_ADMIN_PASSWORD` | SonarQube | Required | secret value | `setup_manifest.py`, `install.sh`, composition |
-| `TSW_POSTGRES_PASSWORD` | SonarQube PostgreSQL | Required | secret value | `setup_manifest.py`, `install.sh`, compose |
-| `TSW_SONARQUBE_POSTGRES_PASSWORD` | SonarQube PostgreSQL | Required by installer/deployment env | secret value | `install.sh`, composition, compose |
-| `TSW_INFISICAL_LOGIN_EMAIL` | Infisical admin login | Required for service-access profile | non-secret identity value | `setup_manifest.py`, `install.sh`, composition, compose |
-| `TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD` | Infisical admin login | Required for service-access profile | secret value | `setup_manifest.py`, `install.sh`, composition, compose |
-| `TSW_INFISICAL_ENCRYPTION_KEY` | Infisical | Required for service-access profile | secret value | `setup_manifest.py`, `install.sh`, composition, compose |
-| `TSW_INFISICAL_AUTH_SECRET` | Infisical | Required for service-access profile | secret value | `setup_manifest.py`, `install.sh`, composition, compose |
-| `TSW_INFISICAL_POSTGRES_PASSWORD` | Infisical PostgreSQL | Required for service-access profile | secret value | `setup_manifest.py`, `install.sh`, composition, compose |
-| `TSW_INFISICAL_REDIS_PASSWORD` | Infisical Redis | Required by installer/deployment env | secret value | `install.sh`, composition |
+| `TSW_PORTAINER_ADMIN_PASSWORD` | Portainer | Required | secret value | `setup_manifest.py`, `installer.py`, composition |
+| `TSW_NEXUS_ADMIN_PASSWORD` | Nexus | Required | secret value | `setup_manifest.py`, `installer.py`, composition |
+| `TSW_JENKINS_ADMIN_PASSWORD` | Jenkins | Required | secret value | `setup_manifest.py`, `installer.py`, compose |
+| `TSW_RABBITMQ_PASSWORD` | RabbitMQ | Required | secret value | `setup_manifest.py`, `installer.py`, compose |
+| `TSW_SONARQUBE_ADMIN_PASSWORD` | SonarQube | Required | secret value | `setup_manifest.py`, `installer.py`, composition |
+| `TSW_POSTGRES_PASSWORD` | SonarQube PostgreSQL | Required | secret value | `setup_manifest.py`, `installer.py`, compose |
+| `TSW_SONARQUBE_POSTGRES_PASSWORD` | SonarQube PostgreSQL | Required by installer/deployment env | secret value | `installer.py`, composition, compose |
+| `TSW_INFISICAL_LOGIN_EMAIL` | Infisical admin login | Required for service-access profile | non-secret identity value | `setup_manifest.py`, `installer.py`, composition, compose |
+| `TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD` | Infisical admin login | Required for service-access profile | secret value | `setup_manifest.py`, `installer.py`, composition, compose |
+| `TSW_INFISICAL_ENCRYPTION_KEY` | Infisical | Required for service-access profile | secret value | `setup_manifest.py`, `installer.py`, composition, compose |
+| `TSW_INFISICAL_AUTH_SECRET` | Infisical | Required for service-access profile | secret value | `setup_manifest.py`, `installer.py`, composition, compose |
+| `TSW_INFISICAL_POSTGRES_PASSWORD` | Infisical PostgreSQL | Required for service-access profile | secret value | `setup_manifest.py`, `installer.py`, composition, compose |
+| `TSW_INFISICAL_REDIS_PASSWORD` | Infisical Redis | Required by installer/deployment env | secret value | `installer.py`, composition |
 
 ## Runtime And Deployment Overrides
 
@@ -105,7 +105,7 @@ logic. Defaults are listed only when visible from committed source.
 | `TSW_JENKINS_ADMIN_USERNAME` | `admin` | Optional | identifier | `composition.py` |
 | `TSW_NEXUS_ADMIN_USERNAME` | `admin` | Optional | identifier | `composition.py`, docs |
 | `TSW_RABBITMQ_USERNAME` | `admin` | Optional | identifier | `composition.py` |
-| `TSW_SEED_INFISICAL_ITEMS` | `0` in installer | Optional | boolean flag as `0`/`1` | `install.sh`, `composition.py` |
+| `TSW_SEED_INFISICAL_ITEMS` | `0` in installer | Optional | boolean flag as `0`/`1` | `installer.py`, `composition.py` |
 | `TSW_LXC_DOCKER_REGISTRY_MIRROR` | auto-detected when possible | Optional | URL reachable from managed nodes | `install.sh`, `composition.py`, docs |
 | `TSW_LXC_PROXY_LISTEN_ADDRESS` | implementation default | Optional | listen address | `composition.py` |
 | `TSW_SWARM_REGISTRY_ENDPOINT` | implementation default | Optional | registry endpoint | `composition.py` |
@@ -211,9 +211,9 @@ local values from the user's runtime environment.
 - Add a typed allowlist for supported operator keys, including requiredness,
   source precedence, value kind, defaults, and redaction classification.
 - Reconcile setup-manifest required secrets with installer/runtime-required
-  secrets. Current gaps are `TSW_SONARQUBE_POSTGRES_PASSWORD` and
-  `TSW_INFISICAL_REDIS_PASSWORD`, which are required by installer/runtime paths
-  but are not currently listed in `default_setup_manifest`.
+  secrets. `TSW_INFISICAL_REDIS_PASSWORD` is now required in the secret
+  manifest and consumed by the Python installer; setup-manifest ownership should
+  still be reviewed when service-profile validation is expanded.
 - Decide whether documented but currently hardcoded or test-only overrides such
   as `TSW_PORTAINER_URL`, `TSW_PORTAINER_ENDPOINT`,
   `TSW_NEXUS_INITIAL_PASSWORD_PATH`, `TSW_NEXUS_MAX_ATTEMPTS`, and

--- a/documentation/configuration/operator-configuration-contract.md
+++ b/documentation/configuration/operator-configuration-contract.md
@@ -19,6 +19,26 @@ ignored by Git, and must not be committed. The parser accepts simple
 `KEY=value` and `export KEY=value` assignments, ignores non-`TSW_*` keys, and
 fails closed on duplicate `TSW_*` keys or unsupported shell syntax.
 
+## Ownership And Lifecycle
+
+| Value group | Owner | Storage | Lifecycle |
+|---|---|---|---|
+| Operator runtime secrets | Operator | `.tiny-swarm-world/local/live-installation.env` or process environment | Created before install, reused across reruns, edited or rotated by the operator. |
+| Generated local bootstrap secrets | Python installer | `.tiny-swarm-world/local/live-installation.env` | Generated only when missing and secret generation is enabled; existing values are kept. |
+| Infisical bootstrap runtime file | Python installer | `.tiny-swarm/secrets/bootstrap.local.env` | Rewritten from the resolved local values for the self-hosted Infisical stack; ignored by Git. |
+| Generated recovery file | Secret sync service | `.tiny-swarm/secrets/generated.local.env` | Stores generated values needed for idempotent Infisical sync or recovery; ignored by Git and mode `0600` when written by automation. |
+| Infisical-managed values | Infisical sync service | Infisical project/environment | Synchronized from generated or operator-supplied local values; existing Infisical values are kept unless a manifest entry explicitly requests rotation. |
+| External Docker secret names | Operator | `.tiny-swarm-world/local/live-installation.env`, process environment, or defaults | Names identify externally managed Docker secrets and are not secret material. |
+
+The Python installer derives required local bootstrap values from
+`infra/config/secrets/infisical-secrets.yaml`. Installer code must not keep a
+separate required-secret list. Values whose manifest source is
+`generated_local_secret` or `placeholder_only` and whose entry is required must
+be present before live setup; missing generated values may be created locally
+when secret generation is enabled. Values whose source is
+`external_user_secret` identify external resources and are not generated as
+secret values by the installer.
+
 ## Required Values
 
 The default contract requires these keys before setup execution:

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -267,6 +267,9 @@ alongside `reset-run.log`, `reset-run.exit`, `setup-run.log`, and
 It loads or generates local `TSW_*` secrets in
 `.tiny-swarm-world/local/live-installation.env` without printing secret
 values.
+Required local bootstrap values are derived from
+`infra/config/secrets/infisical-secrets.yaml`; installer code does not maintain
+a separate required-secret list.
 Use `.env.example` as the tracked placeholder template. Before live setup,
 copy the needed keys into `.tiny-swarm-world/local/live-installation.env` or
 export them in the process environment. Process environment values override

--- a/infra/config/secrets/infisical-secrets.yaml
+++ b/infra/config/secrets/infisical-secrets.yaml
@@ -51,9 +51,9 @@ secrets:
     service: infisical
     type: generated_secret
     environment: local
-    description: Reserved Redis password key for Infisical local runtime compatibility
+    description: Redis password reserved for Infisical local runtime compatibility and recovery exports
     source: generated_local_secret
-    required: false
+    required: true
     policy: keep_existing
   - key: TSW_POSTGRES_PASSWORD
     service: postgres

--- a/src/tiny_swarm_world/application/services/deployment/secret_management.py
+++ b/src/tiny_swarm_world/application/services/deployment/secret_management.py
@@ -80,6 +80,9 @@ class SecretManifestEntry:
     source: str
     required: bool
     policy: SecretPolicy = "keep_existing"
+    owner: str = ""
+    storage: str = ""
+    lifecycle: str = ""
 
 
 @dataclass(frozen=True)
@@ -357,16 +360,52 @@ def _manifest_entry(item: object) -> SecretManifestEntry:
     policy = str(item.get("policy", "keep_existing"))
     if policy not in {"keep_existing", "rotate"}:
         raise SecretManagementBlocker("manifest_schema_invalid", f"Invalid secret policy for {key}: {policy}")
+    source = str(item.get("source", ""))
     return SecretManifestEntry(
         key=key,
         service=str(item.get("service", "")),
         type=entry_type,  # type: ignore[arg-type]
         environment=str(item.get("environment", "local")),
         description=str(item.get("description", "")),
-        source=str(item.get("source", "")),
+        source=source,
         required=bool(item.get("required", False)),
         policy=policy,  # type: ignore[arg-type]
+        owner=str(item.get("owner", _manifest_owner(source))),
+        storage=str(item.get("storage", _manifest_storage(source))),
+        lifecycle=str(item.get("lifecycle", _manifest_lifecycle(source))),
     )
+
+
+def _manifest_owner(source: str) -> str:
+    if source == "external_user_secret":
+        return "operator"
+    if source == "infisical_bootstrap_identity":
+        return "infisical_sync"
+    if source in {"generated_local_secret", "placeholder_only"}:
+        return "python_installer"
+    return "unknown"
+
+
+def _manifest_storage(source: str) -> str:
+    if source == "external_user_secret":
+        return "external_docker_secret_or_operator_env"
+    if source == "infisical_bootstrap_identity":
+        return ".tiny-swarm/secrets/generated.local.env"
+    if source in {"generated_local_secret", "placeholder_only"}:
+        return ".tiny-swarm-world/local/live-installation.env"
+    return "unknown"
+
+
+def _manifest_lifecycle(source: str) -> str:
+    if source == "external_user_secret":
+        return "operator_created_and_rotated"
+    if source == "infisical_bootstrap_identity":
+        return "created_during_infisical_sync_and_reused"
+    if source == "generated_local_secret":
+        return "generated_when_missing_and_kept_existing"
+    if source == "placeholder_only":
+        return "operator_supplied_and_kept_existing"
+    return "unknown"
 
 
 def _candidate_files(repo_root: Path) -> tuple[Path, ...]:

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -19,21 +19,8 @@ DEFAULT_SECRET_ENV_FILE = ".tiny-swarm-world/local/live-installation.env"
 DEFAULT_INFISICAL_SECRET_ENV_FILE = ".tiny-swarm/secrets/bootstrap.local.env"
 DEFAULT_GENERATED_SECRET_ENV_FILE = ".tiny-swarm/secrets/generated.local.env"
 DEFAULT_NATIVE_LINUX_VENV = ".tiny-swarm-world/install-venv"
-REQUIRED_SECRETS = (
-    "TSW_PORTAINER_ADMIN_PASSWORD",
-    "TSW_NEXUS_ADMIN_PASSWORD",
-    "TSW_JENKINS_ADMIN_PASSWORD",
-    "TSW_RABBITMQ_PASSWORD",
-    "TSW_SONARQUBE_ADMIN_PASSWORD",
-    "TSW_POSTGRES_PASSWORD",
-    "TSW_SONARQUBE_POSTGRES_PASSWORD",
-    "TSW_INFISICAL_LOGIN_EMAIL",
-    "TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD",
-    "TSW_INFISICAL_ENCRYPTION_KEY",
-    "TSW_INFISICAL_AUTH_SECRET",
-    "TSW_INFISICAL_POSTGRES_PASSWORD",
-    "TSW_INFISICAL_REDIS_PASSWORD",
-)
+DEFAULT_SECRET_MANIFEST_PATH = Path("infra/config/secrets/infisical-secrets.yaml")
+INSTALLER_REQUIRED_SOURCES = {"generated_local_secret", "placeholder_only"}
 
 
 @dataclass(frozen=True)
@@ -57,6 +44,13 @@ class InstallerPaths:
 class HostRuntime:
     name: str
     detection_source: str
+
+
+@dataclass(frozen=True)
+class InstallerSecretEntry:
+    key: str
+    source: str
+    required: bool
 
 
 class InstallerError(RuntimeError):
@@ -127,11 +121,12 @@ def run(
     install_env.update(_load_export_file(paths.secret_env_file))
     install_env.update(_load_export_file(paths.infisical_secret_env_file))
 
-    missing = [name for name in REQUIRED_SECRETS if not install_env.get(name)]
+    required_entries = _required_installer_secret_entries(cwd / DEFAULT_SECRET_MANIFEST_PATH)
+    missing = [entry for entry in required_entries if not install_env.get(entry.key)]
     secrets_generated_count = 0
     if missing:
         if not options.generate_secrets:
-            _print_missing_secrets(missing)
+            _print_missing_secrets([entry.key for entry in missing])
             raise InstallerError(
                 f"Provide the missing values in {paths.secret_env_file.as_posix()} "
                 "or remove --no-generate-secrets."
@@ -266,6 +261,37 @@ def _require_repository(cwd: Path) -> None:
         raise InstallerError("Run this script from the Tiny Swarm World repository root.")
 
 
+def _required_installer_secret_entries(manifest_path: Path) -> tuple[InstallerSecretEntry, ...]:
+    try:
+        import yaml
+
+        payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise InstallerError(f"Secret manifest is invalid: {error}") from error
+    if not isinstance(payload, dict) or not isinstance(payload.get("secrets"), list):
+        raise InstallerError("Secret manifest is invalid: expected a secrets list.")
+    entries = tuple(_installer_secret_entry(item) for item in payload["secrets"])
+    return tuple(
+        entry
+        for entry in entries
+        if entry.required and entry.source in INSTALLER_REQUIRED_SOURCES
+    )
+
+
+def _installer_secret_entry(item: object) -> InstallerSecretEntry:
+    if not isinstance(item, dict):
+        raise InstallerError("Secret manifest is invalid: secret entries must be mappings.")
+    key = str(item.get("key", ""))
+    source = str(item.get("source", ""))
+    if not key.startswith("TSW_"):
+        raise InstallerError(f"Secret manifest is invalid: unsupported key {key!r}.")
+    return InstallerSecretEntry(
+        key=key,
+        source=source,
+        required=bool(item.get("required", False)),
+    )
+
+
 def detect_host_runtime(env: Mapping[str, str]) -> HostRuntime:
     test_runtime = env.get("TSW_INSTALL_TEST_HOST_RUNTIME")
     if env.get("TSW_INSTALL_TEST_MODE") == "1" and test_runtime in {"wsl2", "native_linux"}:
@@ -380,9 +406,10 @@ def _load_export_file(path: Path) -> dict[str, str]:
     return values
 
 
-def _generated_secret_values(names: Sequence[str]) -> dict[str, str]:
+def _generated_secret_values(entries: Sequence[InstallerSecretEntry]) -> dict[str, str]:
     generated: dict[str, str] = {}
-    for name in names:
+    for entry in entries:
+        name = entry.key
         if name == "TSW_INFISICAL_ENCRYPTION_KEY":
             generated[name] = secrets.token_hex(16)
         elif name == "TSW_INFISICAL_LOGIN_EMAIL":

--- a/tests/application/services/deployment/test_secret_management.py
+++ b/tests/application/services/deployment/test_secret_management.py
@@ -64,6 +64,35 @@ class TestSecretManagement(unittest.TestCase):
         self.assertEqual("infisical_bootstrap_identity", entry.source)
         self.assertFalse(entry.required)
 
+    def test_committed_manifest_marks_infisical_redis_password_required(self):
+        entries = SecretManifestRenderer(Path("infra/config/secrets/infisical-secrets.yaml")).run()
+        entries_by_key = {entry.key: entry for entry in entries}
+
+        entry = entries_by_key["TSW_INFISICAL_REDIS_PASSWORD"]
+
+        self.assertEqual("infisical", entry.service)
+        self.assertEqual("generated_secret", entry.type)
+        self.assertEqual("generated_local_secret", entry.source)
+        self.assertTrue(entry.required)
+
+    def test_manifest_entries_expose_ownership_storage_and_lifecycle(self):
+        entries = SecretManifestRenderer(Path("infra/config/secrets/infisical-secrets.yaml")).run()
+        entries_by_key = {entry.key: entry for entry in entries}
+
+        generated = entries_by_key["TSW_NEXUS_ADMIN_PASSWORD"]
+        external = entries_by_key["TSW_TRAEFIK_TLS_CERT_SECRET_NAME"]
+        bootstrap = entries_by_key["TSW_INFISICAL_BOOTSTRAP_TOKEN"]
+
+        self.assertEqual("python_installer", generated.owner)
+        self.assertEqual(".tiny-swarm-world/local/live-installation.env", generated.storage)
+        self.assertEqual("generated_when_missing_and_kept_existing", generated.lifecycle)
+        self.assertEqual("operator", external.owner)
+        self.assertEqual("external_docker_secret_or_operator_env", external.storage)
+        self.assertEqual("operator_created_and_rotated", external.lifecycle)
+        self.assertEqual("infisical_sync", bootstrap.owner)
+        self.assertEqual(".tiny-swarm/secrets/generated.local.env", bootstrap.storage)
+        self.assertEqual("created_during_infisical_sync_and_reused", bootstrap.lifecycle)
+
     def test_committed_manifest_tracks_required_infisical_login_identity(self):
         entries = SecretManifestRenderer(Path("infra/config/secrets/infisical-secrets.yaml")).run()
         entries_by_key = {entry.key: entry for entry in entries}

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -497,6 +497,11 @@ class _InstallScriptFixture:
             REPOSITORY_ROOT / "src" / "tiny_swarm_world" / "installer.py",
             self.root / "src" / "tiny_swarm_world" / "installer.py",
         )
+        (self.root / "infra" / "config" / "secrets").mkdir(parents=True)
+        shutil.copy2(
+            REPOSITORY_ROOT / "infra" / "config" / "secrets" / "infisical-secrets.yaml",
+            self.root / "infra" / "config" / "secrets" / "infisical-secrets.yaml",
+        )
         self.fake_bin.mkdir()
         _write_executable(self.fake_bin / "python3", _fake_python3())
         _write_executable(self.fake_bin / "grep", _fake_grep())

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -77,6 +77,19 @@ class TestInstaller(unittest.TestCase):
             values,
         )
 
+    def test_required_installer_secret_entries_come_from_manifest(self):
+        entries = installer._required_installer_secret_entries(
+            Path("infra/config/secrets/infisical-secrets.yaml")
+        )
+        keys = {entry.key for entry in entries}
+
+        self.assertIn("TSW_PORTAINER_ADMIN_PASSWORD", keys)
+        self.assertIn("TSW_INFISICAL_REDIS_PASSWORD", keys)
+        self.assertNotIn("TSW_TRAEFIK_TLS_CERT_SECRET_NAME", keys)
+        self.assertTrue(
+            all(entry.source in installer.INSTALLER_REQUIRED_SOURCES for entry in entries)
+        )
+
     def test_confirm_reset_reports_missing_noninteractive_input(self):
         options = installer.InstallerOptions(
             service_profile="service-access",


### PR DESCRIPTION
## Summary
- Add owner/storage/lifecycle metadata to secret manifest entries and document the local/bootstrap/recovery/Infisical ownership boundary.
- Derive installer-required local bootstrap values from `infra/config/secrets/infisical-secrets.yaml` instead of a separate installer list.
- Align `TSW_INFISICAL_REDIS_PASSWORD` as required for installer/runtime recovery exports and update regression tests/evidence.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_secret_management tests.test_installer tests.test_install_script`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py typecheck`
- `python3 -m ruff check src/tiny_swarm_world/installer.py tests/test_installer.py`
- `PYTHONPATH=src python3 -m py_compile src/tiny_swarm_world/installer.py`
- `python3 tools/quality_gate.py quality`

Closes #76.