### PR TITLE
Clarify command runner responsibility

### DIFF
--- a/.codex/evidence/slice-70-consolidation.md
+++ b/.codex/evidence/slice-70-consolidation.md
@@ -1,0 +1,23 @@
+# Slice 70 Consolidation Evidence
+
+- Workflow id: `issue-70-command-runner-responsibility-20260614`
+- Slice id: `70`
+- Slice title: Clarify command runner responsibility
+- Branch: `feature/workflow-issue-70-command-runner-responsibility-20260614`
+- Subagent review: Beauvoir, read-only
+- Subagent findings incorporated:
+  - `CommandWorkflow.verify_config_contract` now classifies unsupported runner factory failures as `BLOCKED` contract validation evidence.
+  - `CommandRunnerFactory` is covered by direct tests for async-only selection and REST/Ansible rejection.
+  - Placeholder REST and Ansible runners are covered by fail-closed tests.
+  - Domain/application runner documentation and arc42 concepts now state that only the async shell runner is selectable by active workflows.
+- Implementation summary:
+  - Active command workflows can select only `CommandRunnerType.ASYNC`.
+  - Legacy `REST` and `ANSIBLE` enum values remain for compatibility but cannot enter active workflow wiring.
+  - Directly instantiated REST and Ansible placeholder runners raise `NotImplementedError` and mark status as `Unsupported`.
+  - LXC-native adapter paths remain independent from Ansible abstractions.
+- Local verification:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract tests.infrastructure.test_composition tests.infrastructure.adapters.clients.test_lxc_node_provider tests.infrastructure.adapters.clients.test_lxc_container_docker_runtime tests.infrastructure.adapters.clients.test_lxc_container_swarm_bootstrap` passed, 137 tests.
+  - `python3 tools/quality_gate.py lint` passed.
+  - `python3 tools/quality_gate.py typecheck` passed.
+  - `python3 tools/quality_gate.py quality` passed, 866 tests, 17 skipped.
+- Live infrastructure commands: not run.

--- a/.codex/evidence/slice-70-distribution.md
+++ b/.codex/evidence/slice-70-distribution.md
@@ -1,0 +1,33 @@
+# Slice 70 Distribution Evidence
+
+- Workflow id: `issue-70-command-runner-responsibility-20260614`
+- Slice id: `70`
+- Slice title: Clarify command runner responsibility
+- Affected areas: command runner infrastructure, domain command metadata, tests, documentation, architecture
+- Chosen execution mode: sequential
+- Selected streams: command runner factory, placeholder runner behavior, tests, documentation
+- Real subagents used: yes, Beauvoir completed read-only review
+- Fallback role-based review used: no
+- Git worktrees used: no
+- Expected touched files/directories:
+  - `src/tiny_swarm_world/domain/command/**`
+  - `src/tiny_swarm_world/application/ports/commands/**`
+  - `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+  - `tests/infrastructure/adapters/command_runner/**`
+  - `documentation/architecture/**`
+- Conflict risks:
+  - Issue #71 and #72 depend on this runner responsibility decision.
+  - REST and Ansible enum values are retained as legacy compatibility, but must not be active workflow selections.
+  - Placeholder runners must fail closed instead of reporting success.
+- Quality gates:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner`
+  - `python3 tools/quality_gate.py lint`
+  - `python3 tools/quality_gate.py typecheck`
+  - `python3 tools/quality_gate.py quality`
+- Consolidation plan:
+  - Keep implementation sequential because factory behavior, placeholder behavior, and documentation define one policy.
+  - Incorporated read-only subagent findings before final commit.
+  - Publish through guarded PR lifecycle after local and remote checks pass.
+- Parallelization decision:
+  - Rejected for write work due to overlapping command-runner policy files.
+  - Accepted only for read-only subagent review.

--- a/documentation/arc42/08_concepts.adoc
+++ b/documentation/arc42/08_concepts.adoc
@@ -25,6 +25,14 @@ Infrastructure owns YAML parsing and file lookup. Application command building
 passes the active workflow identifier through the command port and validates
 catalog entries before runner-specific executable commands are created.
 
+Current active workflows may select only the `async` shell command runner.
+`rest` and `ansible` remain legacy compatibility enum values, but
+`CommandRunnerFactory` rejects them for active Tiny Swarm World workflows.
+Their placeholder adapters fail closed if instantiated directly and must not
+report success without a real, tested implementation. Reintroducing either
+runner as supported runtime surface requires an explicit workflow with
+implementation, tests, and documentation.
+
 Tests and quality gates parse and validate command YAML without running live
 LXD, Incus, LXC container lifecycle, Docker Swarm, netplan, socat,
 compose, Portainer, Nexus, Jenkins, RabbitMQ, SonarQube, or Swagger/NGINX

--- a/documentation/architecture/command-runner-responsibility.adoc
+++ b/documentation/architecture/command-runner-responsibility.adoc
@@ -1,0 +1,21 @@
+= Command Runner Responsibility
+
+Tiny Swarm World is LXC-native Python automation. The active command runner
+surface is intentionally narrow:
+
+* `async` is the only selectable runner type for current production workflows.
+* `rest` and `ansible` are legacy compatibility enum values only.
+* REST and Ansible runner adapters must not be selected by
+  `CommandRunnerFactory` for active workflows.
+* Legacy placeholder adapters must fail closed if instantiated directly; they
+  must not report success without performing real work.
+
+The generic command-runner path remains bounded to infrastructure adapters.
+Application services depend on the command-runner port and must not construct
+concrete command-runner adapters directly. Reintroducing REST or Ansible as a
+supported runner requires an explicit future workflow with real implementation,
+tests for success and failure behavior, documentation, and quality-gate
+coverage.
+
+This decision keeps the current LXC-native setup path independent from
+Ansible-specific abstractions and from placeholder REST behavior.

--- a/src/tiny_swarm_world/application/ports/commands/executable_command.py
+++ b/src/tiny_swarm_world/application/ports/commands/executable_command.py
@@ -16,7 +16,7 @@ class ExecutableCommandEntity(BaseModel):
     :param vm_instance_name: VM instance name
     :param description: Description of the command
     :param command: The actual executable command
-    :param runner: CommandRunner type (async, rest, ansible, ...)
+    :param runner: CommandRunner implementation selected by the active workflow.
     """
 
     index: Optional[int] = Field(default=None)

--- a/src/tiny_swarm_world/domain/command/command_entity.py
+++ b/src/tiny_swarm_world/domain/command/command_entity.py
@@ -128,7 +128,7 @@ class CommandEntity(BaseModel):
     :param effects: Declared side effects or read effects
     :param verify: Verification specification for the command
     :param command: The actual command template
-    :param runner: CommandRunner type (async, rest, ansible, ...)
+    :param runner: CommandRunner type. Current active workflows select async only.
     :param command_type: Command type (HOSTOS, VM, ...)
     :param vm_type: VM types (worker, manager, ...)
     """

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/ansible_runner.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/ansible_runner.py
@@ -4,6 +4,7 @@ from tiny_swarm_world.application.ports.commands.port_command_runner import Port
 
 
 class AnsiblePortCommandRunner(PortCommandRunner):
+    """Legacy placeholder retained for compatibility; not selectable by active workflows."""
 
     def __init__(self):
         super().__init__()
@@ -12,11 +13,8 @@ class AnsiblePortCommandRunner(PortCommandRunner):
 
     async def run(self, command: str) -> str:
         async with self.lock:
-            self.status["current_step"] = "Executing command"
-            self.status["result"] = "Running..."
-
-        # do something
-        async with self.lock:
-            self.status["result"] = "Success"
-
-        return ""
+            self.status["current_step"] = "Unsupported command runner"
+            self.status["result"] = "Unsupported"
+        raise NotImplementedError(
+            "Ansible command runner is unsupported in active Tiny Swarm World workflows."
+        )

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_runner_factory.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_runner_factory.py
@@ -1,17 +1,14 @@
 from tiny_swarm_world.application.ports.commands.port_command_runner_factory import PortCommandRunnerFactory
 from tiny_swarm_world.application.ports.commands.port_command_runner import PortCommandRunner
 from tiny_swarm_world.domain.command.command_runner_type_enum import CommandRunnerType
-from tiny_swarm_world.infrastructure.adapters.command_runner.ansible_runner import AnsiblePortCommandRunner
 from tiny_swarm_world.infrastructure.adapters.command_runner.async_command_runner import AsyncPortCommandRunner
-from tiny_swarm_world.infrastructure.adapters.command_runner.rest_api_runner import RestApiPortCommandRunner
 
 
 class CommandRunnerFactory(PortCommandRunnerFactory):
     def get_runner(self, runner_type: CommandRunnerType) -> PortCommandRunner:
         if runner_type == CommandRunnerType.ASYNC:
             return AsyncPortCommandRunner()
-        if runner_type == CommandRunnerType.REST:
-            return RestApiPortCommandRunner()
-        if runner_type == CommandRunnerType.ANSIBLE:
-            return AnsiblePortCommandRunner()
-        raise ValueError(f"Unsupported runner type: {runner_type}")
+        raise ValueError(
+            f"Unsupported runner type for active Tiny Swarm World workflows: {runner_type.value}. "
+            "Only the async shell command runner is selectable."
+        )

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
@@ -97,7 +97,7 @@ class CommandWorkflow(PortCommandWorkflow):
                 parameter,
                 workflow_id=workflow_id,
             )
-        except (CommandCatalogValidationError, TypeError):
+        except (CommandCatalogValidationError, TypeError, ValueError):
             return VerificationResult(
                 target_id=target_id,
                 status=VerificationStatus.BLOCKED,

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/rest_api_runner.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/rest_api_runner.py
@@ -4,6 +4,7 @@ from tiny_swarm_world.application.ports.commands.port_command_runner import Port
 
 
 class RestApiPortCommandRunner(PortCommandRunner):
+    """Legacy placeholder retained for compatibility; not selectable by active workflows."""
 
     def __init__(self):
         super().__init__()
@@ -12,11 +13,8 @@ class RestApiPortCommandRunner(PortCommandRunner):
 
     async def run(self, command: str) -> str:
         async with self.lock:
-            self.status["current_step"] = "Executing command"
-            self.status["result"] = "Running..."
-
-        # do something
-        async with self.lock:
-            self.status["result"] = "Success"
-
-        return ""
+            self.status["current_step"] = "Unsupported command runner"
+            self.status["result"] = "Unsupported"
+        raise NotImplementedError(
+            "REST command runner is unsupported in active Tiny Swarm World workflows."
+        )

--- a/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
+++ b/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
@@ -1,0 +1,99 @@
+import asyncio
+import unittest
+
+from tiny_swarm_world.domain.command.command_entity import (
+    CommandEffect,
+    CommandEntity,
+    CommandSafetyClass,
+    CommandScope,
+    CommandVerifySpec,
+    CommandVerifyType,
+    CommandWorkflowId,
+    CommandExecutionMode,
+)
+from tiny_swarm_world.domain.command.command_runner_type_enum import CommandRunnerType
+from tiny_swarm_world.domain.command.command_type_enum import CommandType
+from tiny_swarm_world.domain.command.vm_type import VmType
+from tiny_swarm_world.domain.inventory import VerificationStatus
+from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import (
+    CommandWorkflow,
+)
+from tiny_swarm_world.infrastructure.adapters.command_runner.ansible_runner import (
+    AnsiblePortCommandRunner,
+)
+from tiny_swarm_world.infrastructure.adapters.command_runner.async_command_runner import (
+    AsyncPortCommandRunner,
+)
+from tiny_swarm_world.infrastructure.adapters.command_runner.command_runner_factory import (
+    CommandRunnerFactory,
+)
+from tiny_swarm_world.infrastructure.adapters.command_runner.rest_api_runner import (
+    RestApiPortCommandRunner,
+)
+
+
+class TestCommandRunnerFactory(unittest.TestCase):
+    def test_factory_selects_only_async_runner_for_active_workflows(self):
+        runner = CommandRunnerFactory().get_runner(CommandRunnerType.ASYNC)
+
+        self.assertIsInstance(runner, AsyncPortCommandRunner)
+
+    def test_factory_rejects_ansible_and_rest_runner_types(self):
+        factory = CommandRunnerFactory()
+
+        for runner_type in (CommandRunnerType.ANSIBLE, CommandRunnerType.REST):
+            with self.subTest(runner_type=runner_type):
+                with self.assertRaisesRegex(ValueError, "Only the async shell command runner"):
+                    factory.get_runner(runner_type)
+
+    def test_placeholder_runners_fail_closed_when_instantiated_directly(self):
+        for runner in (AnsiblePortCommandRunner(), RestApiPortCommandRunner()):
+            with self.subTest(runner=runner.__class__.__name__):
+                with self.assertRaises(NotImplementedError):
+                    asyncio.run(runner.run("echo unsafe"))
+                self.assertEqual("Unsupported", runner.status["result"])
+
+    def test_verify_config_contract_blocks_unsupported_runner_types(self):
+        workflow = CommandWorkflow(command_repository_factory=lambda _: _FakeCommandRepository("rest"))
+
+        result = workflow.verify_config_contract(
+            "synthetic.yaml",
+            workflow_id=CommandWorkflowId.PLATFORM_INIT.value,
+            target_id="commands:synthetic",
+        )
+
+        self.assertEqual(VerificationStatus.BLOCKED, result.status)
+        self.assertEqual("catalog_validation_failed", result.evidence["reason"])
+
+
+class _FakeCommandRepository:
+    def __init__(self, runner: str):
+        self.runner = runner
+
+    def get_all_commands(self):
+        return {
+            1: CommandEntity(
+                id="synthetic.command",
+                index=1,
+                description="Synthetic command",
+                intent="verify unsupported runner handling",
+                execution_mode=CommandExecutionMode.SHELL,
+                safety_class=CommandSafetyClass.SAFE_READ,
+                scope=CommandScope.HOST,
+                allowed_workflows=[CommandWorkflowId.PLATFORM_INIT.value],
+                parameters=[],
+                effects=[CommandEffect.READ.value],
+                verify=CommandVerifySpec(
+                    type=CommandVerifyType.NONE,
+                    description="Read-only command.",
+                ),
+                command="echo ok",
+                runner=self.runner,
+                command_type=CommandType.HOSTOS,
+                vm_type=[VmType.NONE],
+            )
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restrict active command runner selection to the async shell runner
- make legacy REST and Ansible placeholder runners fail closed
- add command runner responsibility docs, arc42 concept notes, and slice evidence
- add regression coverage for factory rejection, placeholder behavior, and workflow BLOCKED classification

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract tests.infrastructure.test_composition tests.infrastructure.adapters.clients.test_lxc_node_provider tests.infrastructure.adapters.clients.test_lxc_container_docker_runtime tests.infrastructure.adapters.clients.test_lxc_container_swarm_bootstrap` passed, 137 tests
- `python3 tools/quality_gate.py lint` passed
- `python3 tools/quality_gate.py typecheck` passed
- `python3 tools/quality_gate.py quality` passed, 866 tests, 17 skipped

Closes #70