### PR TITLE
Disable placeholder Ansible runner path

### DIFF
--- a/.codex/evidence/slice-71-consolidation.md
+++ b/.codex/evidence/slice-71-consolidation.md
@@ -1,0 +1,22 @@
+# Slice 71 Consolidation Evidence
+
+- Workflow id: `issue-71-disable-ansible-runner-20260614`
+- Slice id: `71`
+- Slice title: Remove placeholder automation runner
+- Branch: `feature/workflow-issue-71-disable-ansible-runner-20260614`
+- Subagent review: Einstein, read-only
+- Subagent findings incorporated:
+  - `verify_config_contract` coverage now includes `runner="ansible"` as unsupported configuration.
+  - Architecture documentation now states that Ansible is not a current node-provider path.
+- Implementation summary:
+  - Active workflow contract verification now explicitly covers `ansible` as an unsupported runner type.
+  - The existing Ansible placeholder remains a legacy compatibility adapter but cannot be selected through `CommandRunnerFactory`.
+  - Direct placeholder execution remains fail-closed through `NotImplementedError` and `Unsupported` status evidence.
+  - Architecture documentation now states that Tiny Swarm World's current node-provider path is managed LXC through LXD or Incus, not Ansible, and that Ansible is not an operator-selectable backend.
+- Local verification:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory` passed, 4 tests.
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract` passed, 23 tests.
+  - `python3 tools/quality_gate.py lint` passed.
+  - `python3 tools/quality_gate.py typecheck` passed.
+  - `python3 tools/quality_gate.py quality` passed, 866 tests, 17 skipped.
+- Live infrastructure commands: not run.

--- a/.codex/evidence/slice-71-distribution.md
+++ b/.codex/evidence/slice-71-distribution.md
@@ -1,0 +1,31 @@
+# Slice 71 Distribution Evidence
+
+- Workflow id: `issue-71-disable-ansible-runner-20260614`
+- Slice id: `71`
+- Slice title: Remove placeholder automation runner
+- Affected areas: command runner infrastructure, command-runner tests, architecture documentation
+- Chosen execution mode: sequential
+- Selected streams: Ansible runner safety, unsupported-runner contract tests, documentation
+- Real subagents used: yes, Einstein completed read-only review
+- Fallback role-based review used: no
+- Git worktrees used: no
+- Expected touched files/directories:
+  - `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+  - `tests/infrastructure/adapters/command_runner/**`
+  - `documentation/architecture/**`
+- Conflict risks:
+  - Issue #71 depends on Issue #70 command-runner responsibility and must not undo the legacy compatibility decision.
+  - Removing the `ansible` enum would broaden the compatibility surface beyond this slice.
+  - Active workflow configuration must fail closed before any placeholder runner can report success.
+- Quality gates:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory`
+  - `python3 tools/quality_gate.py lint`
+  - `python3 tools/quality_gate.py typecheck`
+  - `python3 tools/quality_gate.py quality`
+- Consolidation plan:
+  - Keep implementation sequential because the remaining #71 gap is an Ansible-specific refinement of the #70 policy.
+  - Incorporated read-only subagent findings before final commit.
+  - Publish through guarded PR lifecycle after local and remote checks pass.
+- Parallelization decision:
+  - Rejected for write work due to overlapping command-runner policy/test files.
+  - Accepted only for read-only subagent review.

--- a/documentation/arc42/08_concepts.adoc
+++ b/documentation/arc42/08_concepts.adoc
@@ -26,6 +26,8 @@ passes the active workflow identifier through the command port and validates
 catalog entries before runner-specific executable commands are created.
 
 Current active workflows may select only the `async` shell command runner.
+Tiny Swarm World's current node-provider path is managed LXC through LXD or
+Incus, not Ansible.
 `rest` and `ansible` remain legacy compatibility enum values, but
 `CommandRunnerFactory` rejects them for active Tiny Swarm World workflows.
 Their placeholder adapters fail closed if instantiated directly and must not

--- a/documentation/architecture/command-runner-responsibility.adoc
+++ b/documentation/architecture/command-runner-responsibility.adoc
@@ -1,12 +1,14 @@
 = Command Runner Responsibility
 
-Tiny Swarm World is LXC-native Python automation. The active command runner
-surface is intentionally narrow:
+Tiny Swarm World is LXC-native Python automation. Its current node-provider
+path is managed LXC through LXD or Incus, not Ansible. The active command
+runner surface is intentionally narrow:
 
 * `async` is the only selectable runner type for current production workflows.
 * `rest` and `ansible` are legacy compatibility enum values only.
 * REST and Ansible runner adapters must not be selected by
-  `CommandRunnerFactory` for active workflows.
+  `CommandRunnerFactory` for active workflows or exposed as operator-selectable
+  node-provider backends.
 * Legacy placeholder adapters must fail closed if instantiated directly; they
   must not report success without performing real work.
 

--- a/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
+++ b/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
@@ -54,16 +54,22 @@ class TestCommandRunnerFactory(unittest.TestCase):
                 self.assertEqual("Unsupported", runner.status["result"])
 
     def test_verify_config_contract_blocks_unsupported_runner_types(self):
-        workflow = CommandWorkflow(command_repository_factory=lambda _: _FakeCommandRepository("rest"))
+        for runner in ("ansible", "rest"):
+            with self.subTest(runner=runner):
+                workflow = CommandWorkflow(
+                    command_repository_factory=lambda _, runner=runner: _FakeCommandRepository(
+                        runner
+                    )
+                )
 
-        result = workflow.verify_config_contract(
-            "synthetic.yaml",
-            workflow_id=CommandWorkflowId.PLATFORM_INIT.value,
-            target_id="commands:synthetic",
-        )
+                result = workflow.verify_config_contract(
+                    "synthetic.yaml",
+                    workflow_id=CommandWorkflowId.PLATFORM_INIT.value,
+                    target_id="commands:synthetic",
+                )
 
-        self.assertEqual(VerificationStatus.BLOCKED, result.status)
-        self.assertEqual("catalog_validation_failed", result.evidence["reason"])
+                self.assertEqual(VerificationStatus.BLOCKED, result.status)
+                self.assertEqual("catalog_validation_failed", result.evidence["reason"])
 
 
 class _FakeCommandRepository:


### PR DESCRIPTION
## Summary
- extend unsupported runner contract coverage to include `ansible`
- document that Ansible is not a current Tiny Swarm World node-provider path
- record slice distribution and consolidation evidence for #71

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory` passed, 4 tests
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract` passed, 23 tests
- `python3 tools/quality_gate.py lint` passed
- `python3 tools/quality_gate.py typecheck` passed
- `python3 tools/quality_gate.py quality` passed, 866 tests, 17 skipped

Closes #71