### PR TITLE
Disable placeholder REST runner path

### DIFF
--- a/.codex/evidence/slice-72-consolidation.md
+++ b/.codex/evidence/slice-72-consolidation.md
@@ -1,0 +1,22 @@
+# Slice 72 Consolidation Evidence
+
+- Workflow id: `issue-72-rest-runner-decision-20260614`
+- Slice id: `72`
+- Slice title: Implement or disable REST command runner
+- Branch: `feature/workflow-issue-72-rest-runner-decision-20260614`
+- Subagent review: Kant, read-only
+- Subagent findings incorporated:
+  - Confirmed no REST-specific gaps remain with the current changes.
+  - Confirmed active configuration does not contain `runner: rest`.
+  - Confirmed REST placeholder execution records `Unsupported` and raises instead of returning empty success.
+- Implementation summary:
+  - The chosen path is disabled REST command execution, not a partial REST implementation.
+  - `RestApiPortCommandRunner` remains a legacy compatibility placeholder and is not selectable through `CommandRunnerFactory`.
+  - Direct REST placeholder execution raises `NotImplementedError`, records `Unsupported`, and cannot return empty success.
+  - Architecture documentation now states that active workflows do not define REST HTTP method, URL, headers/body, timeout, response-validation, or error-mapping semantics.
+- Local verification:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract` passed, 24 tests.
+  - `python3 tools/quality_gate.py lint` passed.
+  - `python3 tools/quality_gate.py typecheck` passed.
+  - `python3 tools/quality_gate.py quality` passed, 867 tests, 17 skipped.
+- Live infrastructure commands: not run.

--- a/.codex/evidence/slice-72-distribution.md
+++ b/.codex/evidence/slice-72-distribution.md
@@ -1,0 +1,32 @@
+# Slice 72 Distribution Evidence
+
+- Workflow id: `issue-72-rest-runner-decision-20260614`
+- Slice id: `72`
+- Slice title: Implement or disable REST command runner
+- Affected areas: command runner infrastructure, command-runner tests, architecture documentation
+- Chosen execution mode: sequential
+- Selected streams: REST runner safety, unsupported-runner contract tests, documentation
+- Real subagents used: yes, Kant completed read-only review
+- Fallback role-based review used: no
+- Git worktrees used: no
+- Expected touched files/directories:
+  - `src/tiny_swarm_world/infrastructure/adapters/command_runner/**`
+  - `tests/infrastructure/adapters/command_runner/**`
+  - `documentation/architecture/**`
+  - `documentation/arc42/**`
+- Conflict risks:
+  - Issue #72 depends on Issue #70 command-runner responsibility and must not re-enable placeholder REST execution.
+  - Implementing a real REST adapter would require a broader port contract for method, URL, headers, body, timeout, response validation, and error mapping.
+  - Active LXC-native workflows must not depend on REST placeholder execution.
+- Quality gates:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory`
+  - `python3 tools/quality_gate.py lint`
+  - `python3 tools/quality_gate.py typecheck`
+  - `python3 tools/quality_gate.py quality`
+- Consolidation plan:
+  - Keep implementation sequential because the chosen path is disabling REST command execution explicitly.
+  - Incorporated read-only subagent findings before final commit.
+  - Publish through guarded PR lifecycle after local and remote checks pass.
+- Parallelization decision:
+  - Rejected for write work due to overlapping command-runner policy/test files.
+  - Accepted only for read-only subagent review.

--- a/documentation/arc42/08_concepts.adoc
+++ b/documentation/arc42/08_concepts.adoc
@@ -34,6 +34,9 @@ Their placeholder adapters fail closed if instantiated directly and must not
 report success without a real, tested implementation. Reintroducing either
 runner as supported runtime surface requires an explicit workflow with
 implementation, tests, and documentation.
+Because REST command execution is currently disabled, active workflows do not
+define REST HTTP method, URL, header/body, timeout, response-validation, or
+error-mapping semantics.
 
 Tests and quality gates parse and validate command YAML without running live
 LXD, Incus, LXC container lifecycle, Docker Swarm, netplan, socat,

--- a/documentation/architecture/command-runner-responsibility.adoc
+++ b/documentation/architecture/command-runner-responsibility.adoc
@@ -19,5 +19,11 @@ supported runner requires an explicit future workflow with real implementation,
 tests for success and failure behavior, documentation, and quality-gate
 coverage.
 
+REST command execution is disabled rather than partially implemented. Current
+workflows therefore do not define REST command HTTP methods, URLs, headers,
+bodies, timeouts, response validation, retry behavior, or non-success response
+mapping. Those semantics belong to a future infrastructure adapter and port
+contract if REST command execution is reintroduced.
+
 This decision keeps the current LXC-native setup path independent from
 Ansible-specific abstractions and from placeholder REST behavior.

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/rest_api_runner.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/rest_api_runner.py
@@ -4,7 +4,7 @@ from tiny_swarm_world.application.ports.commands.port_command_runner import Port
 
 
 class RestApiPortCommandRunner(PortCommandRunner):
-    """Legacy placeholder retained for compatibility; not selectable by active workflows."""
+    """Legacy REST placeholder retained for compatibility; not selectable."""
 
     def __init__(self):
         super().__init__()

--- a/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
+++ b/tests/infrastructure/adapters/command_runner/test_command_runner_factory.py
@@ -53,6 +53,15 @@ class TestCommandRunnerFactory(unittest.TestCase):
                     asyncio.run(runner.run("echo unsafe"))
                 self.assertEqual("Unsupported", runner.status["result"])
 
+    def test_rest_placeholder_does_not_return_empty_success(self):
+        runner = RestApiPortCommandRunner()
+
+        with self.assertRaisesRegex(NotImplementedError, "REST command runner is unsupported"):
+            asyncio.run(runner.run("GET https://example.invalid/health"))
+
+        self.assertEqual("Unsupported command runner", runner.status["current_step"])
+        self.assertEqual("Unsupported", runner.status["result"])
+
     def test_verify_config_contract_blocks_unsupported_runner_types(self):
         for runner in ("ansible", "rest"):
             with self.subTest(runner=runner):


### PR DESCRIPTION
## Summary
- make the disabled REST command-runner decision explicit
- add REST placeholder coverage proving it raises unsupported instead of returning empty success
- document that active workflows do not define REST HTTP method, URL, header/body, timeout, response-validation, or error-mapping semantics
- record slice distribution and consolidation evidence for #72

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.command_runner.test_command_runner_factory tests.infrastructure.adapters.command_runner.test_async_command_runner tests.infrastructure.adapters.repositories.test_command_repository_yaml_contract` passed, 24 tests
- `python3 tools/quality_gate.py lint` passed
- `python3 tools/quality_gate.py typecheck` passed
- `python3 tools/quality_gate.py quality` passed, 867 tests, 17 skipped

Closes #72