### PR TITLE
Make preflight provider aware

### DIFF
--- a/.codex/evidence/slice-74-consolidation.md
+++ b/.codex/evidence/slice-74-consolidation.md
@@ -1,0 +1,24 @@
+# Slice 74 Consolidation Evidence
+
+- Workflow id: `issue-74-provider-aware-preflight-20260614`
+- Slice id: `74`
+- Slice title: Make preflight provider aware
+- Branch: `feature/workflow-issue-74-provider-aware-preflight-20260614`
+- Subagent review: Ohm, read-only
+- Subagent findings incorporated:
+  - `_preflight_configuration_for_provider` now uses `NodeProviderSelectionRequest`.
+  - Incus requests require the `incus` CLI; LXD requests require the `lxc` CLI.
+  - Candidate order is honored when both backend CLIs are available.
+  - Missing backend candidates fail loudly instead of silently falling back.
+  - Preflight service tests prove backend-specific dependencies surface as checks.
+- Implementation summary:
+  - Added provider preflight metadata to the preflight configuration model.
+  - Kept generic checks separated from provider-specific checks in metadata.
+  - Recorded daemon, network, storage, and Docker Swarm profile expectations as metadata without running live daemon probes.
+  - Documented the provider-aware preflight selection model.
+- Local verification:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.application.services.platform.test_preflight_service tests.infrastructure.adapters.preflight.test_lxc_provider_preflight` passed, 112 tests.
+  - `python3 tools/quality_gate.py lint` passed.
+  - `python3 tools/quality_gate.py typecheck` passed.
+  - `python3 tools/quality_gate.py quality` passed, 872 tests, 17 skipped.
+- Live infrastructure commands: not run.

--- a/.codex/evidence/slice-74-distribution.md
+++ b/.codex/evidence/slice-74-distribution.md
@@ -1,0 +1,33 @@
+# Slice 74 Distribution Evidence
+
+- Workflow id: `issue-74-provider-aware-preflight-20260614`
+- Slice id: `74`
+- Slice title: Make preflight provider aware
+- Affected areas: preflight configuration, infrastructure composition, platform preflight tests, documentation
+- Chosen execution mode: sequential
+- Selected streams: provider/backend configuration selection, tests, documentation
+- Real subagents used: yes, Ohm completed read-only review
+- Fallback role-based review used: no
+- Git worktrees used: no
+- Expected touched files/directories:
+  - `src/tiny_swarm_world/domain/preflight/**`
+  - `src/tiny_swarm_world/infrastructure/composition.py`
+  - `tests/infrastructure/test_composition.py`
+  - `tests/application/services/platform/test_preflight_service.py`
+  - `documentation/system/lxc-native-setup.adoc`
+- Conflict risks:
+  - Preflight must not run live LXD, Incus, LXC, Docker, Swarm, or networking mutations during wiring or tests.
+  - Incus-only and LXD-only hosts must not be blocked by requiring both backend CLIs when a backend is selected.
+  - Provider readiness and static host preflight must remain separate.
+- Quality gates:
+  - `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.application.services.platform.test_preflight_service tests.infrastructure.adapters.preflight.test_lxc_provider_preflight`
+  - `python3 tools/quality_gate.py lint`
+  - `python3 tools/quality_gate.py typecheck`
+  - `python3 tools/quality_gate.py quality`
+- Consolidation plan:
+  - Keep implementation sequential because the composition and preflight tests share the same selection contract.
+  - Incorporate read-only subagent findings before final commit.
+  - Publish through guarded PR lifecycle after local and remote checks pass.
+- Parallelization decision:
+  - Rejected for write work due to overlapping composition/preflight files.
+  - Accepted only for read-only subagent review.

--- a/documentation/system/lxc-native-setup.adoc
+++ b/documentation/system/lxc-native-setup.adoc
@@ -121,6 +121,17 @@ PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend lxd --preflight
 PYTHONPATH=src python3 -m tiny_swarm_world --lxc-backend incus --preflight
 ----
 
+Preflight selection is provider-aware. Generic host, Python, Docker CLI,
+resource, port, secret, and ignore-policy checks remain shared. The selected
+managed LXC backend contributes provider-specific checks: `incus` requires the
+`incus` CLI, and `lxd` requires the `lxc` CLI. If no backend is explicitly
+selected, Tiny Swarm World honors the configured backend candidate order and
+the executable available on `PATH` without running daemon-mutating commands.
+Provider preflight metadata records the selected backend plus the daemon,
+network, storage, and Docker Swarm profile expectations that later read-only
+provider checks must verify. A missing backend candidate definition blocks
+configuration construction instead of falling back silently.
+
 The default live setup command is:
 
 [source,bash]

--- a/src/tiny_swarm_world/domain/preflight/__init__.py
+++ b/src/tiny_swarm_world/domain/preflight/__init__.py
@@ -24,6 +24,7 @@ from tiny_swarm_world.domain.preflight.preflight_check import (
 from tiny_swarm_world.domain.preflight.preflight_configuration import (
     ForbiddenSecretFingerprint,
     PreflightConfiguration,
+    ProviderPreflightMetadata,
     RequiredDependency,
     RequiredRuntimeReadiness,
     RequiredPort,
@@ -57,6 +58,7 @@ __all__ = [
     "PreflightCategory",
     "PreflightCheck",
     "PreflightConfiguration",
+    "ProviderPreflightMetadata",
     "PreflightResult",
     "PreflightSeverity",
     "PreflightStatus",

--- a/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
@@ -60,6 +60,17 @@ class ResourceThresholds:
 
 
 @dataclass(frozen=True)
+class ProviderPreflightMetadata:
+    provider: str
+    backend: str | None = None
+    generic_checks: tuple[str, ...] = ()
+    provider_checks: tuple[str, ...] = ()
+    daemon_checks: tuple[str, ...] = ()
+    network_checks: tuple[str, ...] = ()
+    resource_expectations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class PreflightConfiguration:
     setup_profile: SetupProfile
     setup_manifest: SetupManifest
@@ -72,6 +83,19 @@ class PreflightConfiguration:
     required_ignored_paths: tuple[str, ...]
     resources: ResourceThresholds
     minimum_python_version: tuple[int, int]
+    provider_metadata: ProviderPreflightMetadata = field(
+        default_factory=lambda: ProviderPreflightMetadata(
+            provider="generic",
+            generic_checks=(
+                "python",
+                "docker-cli",
+                "host-environment",
+                "service-ports",
+                "required-secrets",
+                "resource-thresholds",
+            ),
+        )
+    )
 
 
 def default_preflight_configuration(

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -132,8 +132,10 @@ from tiny_swarm_world.domain.node_provider import (
 from tiny_swarm_world.domain.preflight import (
     LiveConsent,
     PreflightConfiguration,
+    ProviderPreflightMetadata,
     default_setup_manifest,
     default_preflight_configuration,
+    RequiredDependency,
 )
 from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import CommandWorkflow
 from tiny_swarm_world.infrastructure.adapters.clients.lxc_node_provider import (
@@ -963,10 +965,10 @@ def build_platform_services(
 
     command_workflow = CommandWorkflow()
     verification_evidence_repository = VerificationEvidenceLocalRepository()
-    preflight = _build_preflight_service_for_request(service_profile, node_provider_request)
+    preflight = _build_preflight_service_for_request(service_profile, provider_request)
     post_install_preflight = _build_post_install_preflight_service_for_request(
         service_profile,
-        node_provider_request,
+        provider_request,
     )
     lxc_runner = AsyncLxcNodeCommandRunner()
     lxc_node_provider = LxcNodeProvider(
@@ -1621,9 +1623,60 @@ def _node_provider_request_from_config(
 
 def _preflight_configuration_for_provider(
     service_profile: ServiceStackProfile | str,
-    _node_provider_request: NodeProviderSelectionRequest | None,
+    node_provider_request: NodeProviderSelectionRequest | None,
 ) -> PreflightConfiguration:
-    return default_preflight_configuration(service_profile=service_profile)
+    configuration = default_preflight_configuration(service_profile=service_profile)
+    provider_request = node_provider_request or _default_node_provider_request()
+    if provider_request.requested_provider is not NodeProviderKind.LXC_NATIVE:
+        return replace(
+            configuration,
+            provider_metadata=ProviderPreflightMetadata(
+                provider=provider_request.requested_provider.value,
+                generic_checks=configuration.provider_metadata.generic_checks,
+            ),
+        )
+    backend = _lxc_backend_for_provider_request(provider_request)
+    if backend is None:
+        if not provider_request.backend_candidates:
+            raise ValueError(
+                "LXC-native preflight requires at least one managed backend candidate."
+            )
+        provider_dependencies = tuple(
+            RequiredDependency(_LXC_BACKEND_CLI[candidate])
+            for candidate in provider_request.backend_candidates
+        )
+        backend_label = "auto"
+        provider_checks = tuple(
+            f"backend-cli:{_LXC_BACKEND_CLI[candidate]}"
+            for candidate in provider_request.backend_candidates
+        )
+    else:
+        provider_dependencies = (RequiredDependency(_LXC_BACKEND_CLI[backend]),)
+        backend_label = backend.value
+        provider_checks = (f"backend-cli:{_LXC_BACKEND_CLI[backend]}",)
+    return replace(
+        configuration,
+        required_dependencies=(
+            *configuration.required_dependencies,
+            *provider_dependencies,
+        ),
+        provider_metadata=ProviderPreflightMetadata(
+            provider=provider_request.requested_provider.value,
+            backend=backend_label,
+            generic_checks=configuration.provider_metadata.generic_checks,
+            provider_checks=provider_checks,
+            daemon_checks=(
+                "managed-lxc-daemon-selected-backend",
+            ),
+            network_checks=(
+                "selected-backend-control-network",
+            ),
+            resource_expectations=(
+                "selected-backend-storage-pool",
+                "docker-swarm-profile",
+            ),
+        ),
+    )
 
 
 def _platform_init_steps(

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -20,6 +20,7 @@ from tiny_swarm_world.domain.preflight import (
     PreflightSeverity,
     PreflightStatus,
     RequiredPort,
+    RequiredDependency,
     RequiredSecret,
     SetupPath,
     SetupManifest,
@@ -56,6 +57,26 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("LIVE-CONSENT", check_ids)
         self.assertNotIn("RUNTIME-MULTIPASS", check_ids)
         self.assertFalse(any(check_id.startswith("RUNTIME-") for check_id in check_ids))
+
+    async def test_preflight_reports_selected_provider_backend_dependency(self):
+        configuration = replace(
+            default_preflight_configuration(),
+            required_dependencies=(
+                RequiredDependency("python3"),
+                RequiredDependency("docker"),
+                RequiredDependency("lxc"),
+            ),
+        )
+
+        result = await PreflightService(
+            _fake_probe(executable_availability={"lxc": False}),
+            configuration,
+        ).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        self.assertIn("DEPENDENCY-lxc", failed_by_id)
+        self.assertEqual(PreflightStatus.FAILED, failed_by_id["DEPENDENCY-lxc"].status)
+        self.assertIn("lxc", failed_by_id["DEPENDENCY-lxc"].remediation)
 
     async def test_configuration_contract_checks_are_reported_as_preflight_checks(self):
         result = await PreflightService(

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -1385,6 +1385,77 @@ class TestComposition(unittest.TestCase):
 
         self.assertEqual(composition.ManagedLxcBackend.LXD, backend)
 
+    def test_preflight_configuration_for_incus_requires_incus_cli(self):
+        request = composition.NodeProviderSelectionRequest(
+            preferred_backend=composition.ManagedLxcBackend.INCUS,
+        )
+
+        configuration = composition._preflight_configuration_for_provider(
+            composition.ServiceStackProfile.SERVICE_ACCESS,
+            request,
+        )
+
+        dependency_names = {item.name for item in configuration.required_dependencies}
+        self.assertIn("incus", dependency_names)
+        self.assertNotIn("lxc", dependency_names)
+        self.assertEqual("lxc_native", configuration.provider_metadata.provider)
+        self.assertEqual("incus", configuration.provider_metadata.backend)
+        self.assertIn(
+            "selected-backend-control-network",
+            configuration.provider_metadata.network_checks,
+        )
+
+    def test_preflight_configuration_for_lxd_requires_lxc_cli(self):
+        request = composition.NodeProviderSelectionRequest(
+            preferred_backend=composition.ManagedLxcBackend.LXD,
+        )
+
+        configuration = composition._preflight_configuration_for_provider(
+            composition.ServiceStackProfile.SERVICE_ACCESS,
+            request,
+        )
+
+        dependency_names = {item.name for item in configuration.required_dependencies}
+        self.assertIn("lxc", dependency_names)
+        self.assertNotIn("incus", dependency_names)
+        self.assertEqual("lxd", configuration.provider_metadata.backend)
+        self.assertEqual(
+            ("backend-cli:lxc",),
+            configuration.provider_metadata.provider_checks,
+        )
+
+    def test_preflight_configuration_honors_backend_candidate_order(self):
+        def which(name: str):
+            return f"/usr/bin/{name}" if name in {"incus", "lxc"} else None
+
+        request = composition.NodeProviderSelectionRequest(
+            backend_candidates=(
+                composition.ManagedLxcBackend.LXD,
+                composition.ManagedLxcBackend.INCUS,
+            )
+        )
+
+        with patch.object(composition.shutil, "which", side_effect=which):
+            configuration = composition._preflight_configuration_for_provider(
+                composition.ServiceStackProfile.SERVICE_ACCESS,
+                request,
+            )
+
+        dependency_names = {item.name for item in configuration.required_dependencies}
+        self.assertIn("lxc", dependency_names)
+        self.assertNotIn("incus", dependency_names)
+        self.assertEqual("lxd", configuration.provider_metadata.backend)
+
+    def test_preflight_configuration_blocks_missing_lxc_backend_candidates(self):
+        request = composition.NodeProviderSelectionRequest(backend_candidates=())
+
+        with patch.object(composition.shutil, "which", return_value=None):
+            with self.assertRaisesRegex(ValueError, "requires at least one"):
+                composition._preflight_configuration_for_provider(
+                    composition.ServiceStackProfile.SERVICE_ACCESS,
+                    request,
+                )
+
     def test_default_node_provider_request_uses_committed_candidate_order(self):
         request = composition._default_node_provider_request()
 


### PR DESCRIPTION
## Summary
- select preflight configuration from the node provider/backend request
- add provider preflight metadata that separates generic and backend-specific checks
- require `incus` for Incus and `lxc` for LXD without running live daemon probes
- fail loudly when LXC-native preflight has no backend candidates
- document the provider-aware preflight selection model

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition tests.application.services.platform.test_preflight_service tests.infrastructure.adapters.preflight.test_lxc_provider_preflight` passed, 112 tests
- `python3 tools/quality_gate.py lint` passed
- `python3 tools/quality_gate.py typecheck` passed
- `python3 tools/quality_gate.py quality` passed, 872 tests, 17 skipped

Closes #74