### PR TITLE
Decouple deployment gateway adapter

### DIFF
--- a/.codex/evidence/slice-77-consolidation.md
+++ b/.codex/evidence/slice-77-consolidation.md
@@ -1,0 +1,14 @@
+# Slice 77 Consolidation
+
+- workflow id: issue-77-deployment-gateway-port-20260614
+- slice id: issue-77
+- stream results: main implementation completed; Aquinas read-only review accepted
+- accepted findings: application stack services must depend on a provider-neutral deployment gateway; Portainer endpoint IDs, stack IDs, Swarm IDs, and API fallbacks must remain in infrastructure adapter code; older `EnsurePortainerStack` and `EnsureNexusStack` duplication must be migrated too
+- rejected findings with reason: none
+- files changed per stream: deployment application port, deployment services, service stack plan, Portainer HTTP adapter, composition wiring, unit tests, architecture/deployment docs, evidence
+- conflicts found: architecture test still encoded `PortPortainerClient` as Nexus stack lifecycle port
+- conflicts resolved: updated architecture expectation to `PortDeploymentGateway`; application tests now assert `DeploymentStackRequest` and gateway registration instead of Portainer IDs
+- tests executed: `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_ensure_service_stack tests.application.services.deployment.test_service_stack_plan tests.application.services.deployment.test_ensure_portainer_stack tests.application.services.deployment.test_ensure_nexus_stack tests.infrastructure.adapters.clients.test_portainer_http_client tests.infrastructure.test_composition`; `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.clients.test_lxc_swarm_runtime tests.infrastructure.adapters.clients.test_portainer_http_client`; `python3 tools/quality_gate.py arch-tests`; `python3 tools/quality_gate.py quality`
+- SonarQube findings and fixes: no local SonarQube run; remote PR lifecycle must verify configured checks
+- documentation updates: README, arc42 building blocks/runtime/deployment view, deployment system guide
+- final integration decision: accepted for push auto after final diff review

--- a/.codex/evidence/slice-77-distribution.md
+++ b/.codex/evidence/slice-77-distribution.md
@@ -1,0 +1,16 @@
+# Slice 77 Distribution
+
+- workflow id: issue-77-deployment-gateway-port-20260614
+- slice id: issue-77
+- slice title: Decouple deployment gateway adapter
+- affected areas: backend, runtime, tests, documentation, architecture
+- chosen execution mode: sequential
+- selected streams: main implementation with read-only subagent boundary review
+- real subagents used: yes, Aquinas performed read-only deployment boundary review
+- fallback role-based review used: no
+- Git worktrees used: no
+- expected touched files/directories: src/tiny_swarm_world/application/ports/clients, src/tiny_swarm_world/application/services/deployment, src/tiny_swarm_world/infrastructure/adapters/clients, src/tiny_swarm_world/infrastructure/composition.py, tests, documentation, .codex/evidence
+- conflict risks: deployment stack services, Portainer adapter mapping, and composition wiring share the same live-infrastructure safety boundary
+- quality gates to run: targeted deployment unittest, git diff --check, python3 tools/quality_gate.py test, python3 tools/quality_gate.py quality
+- consolidation plan: introduce provider-neutral deployment gateway port, migrate application stack services and plan builder, keep Portainer ID/API mapping in infrastructure, update tests and documentation, then run quality gates before push auto
+- parallelization decision: rejected because the same application services, adapter, and composition wiring must change coherently

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ observed-state contracts and report blocked or failed phase evidence when live
 prerequisites are unavailable.
 Deployment bootstrap starts Portainer, activates admin access, and registers
 the local Docker endpoint before later stacks use Portainer as the deployment
-gateway.
+gateway implementation behind the deployment gateway port.
 
 `platform reset` and `platform destroy` additionally require
 `RESET_TINY_SWARM_PLATFORM` or `DESTROY_TINY_SWARM_PLATFORM` through

--- a/documentation/arc42/05_building_blocks.adoc
+++ b/documentation/arc42/05_building_blocks.adoc
@@ -42,15 +42,16 @@ microservices:
   service namespace now owns `EnsurePortainerStack`, `EnsureNexusStack`, and
   the generic `EnsureServiceStack` contract for the base runnable-service
   stack set plus the service-access setup profile.
-  `EnsurePortainerStack` is a post-bootstrap Portainer API contract for
-  compose lookup plus stack create/update through `PortComposeFileRepository`
-  and `PortPortainerClient`. The compose repository also exposes service names
-  and published ports parsed from each stack's `docker-compose.yml`. Stack
-  mutation is owned by live-consent-gated workflow execution, not by service
-  construction. `deployment apply` and `deployment verify` can evaluate
-  configured stack, external-input, and readiness contracts, but live success
-  still depends on observable registry, Portainer, Swarm and service-readiness
-  evidence.
+  Stack application services express deployment intent through
+  `PortDeploymentGateway` using target stack, compose content, stack
+  environment, and update policy. Portainer endpoint IDs, stack IDs, Swarm IDs
+  and API fallbacks stay inside the infrastructure gateway adapter. The compose
+  repository also exposes service names and published ports parsed from each
+  stack's `docker-compose.yml`. Stack mutation is owned by live-consent-gated
+  workflow execution, not by service construction. `deployment apply` and
+  `deployment verify` can evaluate configured stack, external-input, and
+  readiness contracts, but live success still depends on observable registry,
+  Portainer, Swarm and service-readiness evidence.
 * `ApplicationServices` aggregates `platform`, `artifacts`, and `deployment`
   instead of aliasing `PlatformServices`.
 

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -88,11 +88,12 @@ The current artifact and deployment runtime flow is deliberately fail-closed:
 * `deployment apply` requires live consent, dispatches to
   `DeploymentApplyWorkflow`, and can run configured stack apply contracts only
   when they expose verify-after-apply evidence. The tested
-  `EnsureServiceStack` contract can create or update Portainer-managed stacks
-  and then verify stack registration through `PortPortainerClient`. The
-  default `lxc_native` path wires Portainer-admin bootstrap, stack contracts,
-  service-access external-input checks, and service-readiness verification
-  through deployment workflow ports.
+  `EnsureServiceStack` contract applies stack intent through the deployment
+  gateway port and verifies stack registration without depending on Portainer
+  endpoint IDs, stack IDs, or Swarm IDs. The current infrastructure gateway is
+  Portainer-backed. The default `lxc_native` path wires Portainer-admin
+  bootstrap, stack contracts, service-access external-input checks, and
+  service-readiness verification through deployment workflow ports.
 * `deployment verify` dispatches without live consent and returns `blocked`
   or `failed_to_verify` when observed stack or service-readiness evidence is
   missing. It does not claim container or service health from endpoint

--- a/documentation/arc42/07_deployment_view.adoc
+++ b/documentation/arc42/07_deployment_view.adoc
@@ -27,15 +27,16 @@ This keeps the current local deployment model deterministic in tests: the
 Python composition root can construct deployment workflow objects without
 contacting Portainer, contacting Nexus, building images, pushing registries, or
 changing Docker Swarm state. Tests use fakes for Portainer and compose
-repositories. Artifact contract tests use fake Nexus clients and patched Docker
+gateway behavior plus compose repositories. Portainer API mapping is covered by
+infrastructure adapter tests. Artifact contract tests use fake Nexus clients and patched Docker
 CLI calls only; they do not contact Nexus, build images, log in, or push.
 Base service stack contracts cover Portainer, Nexus, Jenkins, RabbitMQ,
 SonarQube, and Swagger/NGINX. The full guided setup selects the service-access
 profile by default and adds the `service-access` stack. The
 Portainer-managed plan excludes Portainer itself to avoid a bootstrap cycle
 and can exclude bootstrap-owned Nexus. Stack apply checks record Portainer
-stack-registration context only; service readiness is verified separately
-through observed Swarm service evidence. The service-access deployment path
+gateway stack-registration context only; service readiness is verified
+separately through observed Swarm service evidence. The service-access deployment path
 uses allowlisted stack environment values and records only neutral
 presence/source classifications in verification evidence.
 

--- a/documentation/deployment/system.adoc
+++ b/documentation/deployment/system.adoc
@@ -54,11 +54,12 @@ Portainer stack and admin credentials are available, the bootstrap workflow
 ensures the local Docker endpoint named `local` exists in Portainer before
 Portainer-managed application stacks are applied.
 
-The Deployment boundary now contains a tested post-bootstrap
-`EnsurePortainerStack` application service and a sanitized Portainer HTTP
-adapter contract. The CLI composition root does not wire that contract as a
-successful live `deployment apply` path yet, because first-time Portainer
-bootstrap and verify-after-apply evidence remain incomplete.
+The Deployment boundary now contains tested post-bootstrap stack application
+services and a provider-neutral deployment gateway port. The current
+infrastructure implementation is Portainer-backed, but Portainer endpoint IDs,
+stack IDs, Swarm IDs, and API fallback behavior remain inside the adapter. The
+CLI composition root wires this boundary only after first-time Portainer
+bootstrap and verify-after-apply evidence are available.
 
 The Deployment boundary also contains a generic `EnsureServiceStack` contract
 and stack plans for the default service set plus selected service profiles.
@@ -67,7 +68,7 @@ and Swagger/NGINX. The full guided setup selects the service-access profile by
 default, which adds the `service-access` management stack. The
 Portainer-managed plan intentionally excludes the Portainer stack itself to
 avoid a bootstrap cycle and can exclude bootstrap-owned Nexus. These
-contracts can apply a stack through the Portainer port, then record
+contracts can apply a stack through the deployment gateway port, then record
 stack-registration context. They do not claim container health or application
 readiness; readiness remains separate observed-state verification.
 

--- a/src/tiny_swarm_world/application/ports/clients/port_deployment_gateway.py
+++ b/src/tiny_swarm_world/application/ports/clients/port_deployment_gateway.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+
+from tiny_swarm_world.domain.deployment import StackDefinition
+
+
+class DeploymentStackUpdatePolicy(str, Enum):
+    CREATE_OR_UPDATE = "create_or_update"
+
+
+@dataclass(frozen=True)
+class DeploymentStackRequest:
+    target_stack: str
+    stack_definition: StackDefinition
+    stack_environment: Mapping[str, str] = field(default_factory=dict)
+    update_policy: DeploymentStackUpdatePolicy = DeploymentStackUpdatePolicy.CREATE_OR_UPDATE
+
+
+class PortDeploymentGateway(ABC):
+    @abstractmethod
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        pass
+
+    @abstractmethod
+    def stack_registered(self, stack_name: str) -> bool:
+        pass

--- a/src/tiny_swarm_world/application/services/deployment/__init__.py
+++ b/src/tiny_swarm_world/application/services/deployment/__init__.py
@@ -1,8 +1,9 @@
 """Stack and service deployment application service namespace.
 
 Deployment owns stack lifecycle behavior such as ensuring that the Nexus stack
-exists through compose definitions and Portainer stack APIs. The old Nexus
-import path remains as a compatibility facade.
+exists through compose definitions and the deployment gateway port. Portainer is
+the current infrastructure gateway implementation. The old Nexus import path
+remains as a compatibility facade.
 """
 
 from tiny_swarm_world.application.services.deployment.ensure_external_swarm_secret import (

--- a/src/tiny_swarm_world/application/services/deployment/ensure_nexus_stack.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_nexus_stack.py
@@ -1,6 +1,9 @@
 import logging
 
-from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import PortComposeFileRepository
 
 
@@ -8,25 +11,20 @@ class EnsureNexusStack:
     def __init__(
         self,
         compose_repository: PortComposeFileRepository,
-        portainer_client: PortPortainerClient,
+        deployment_gateway: PortDeploymentGateway,
         stack_name: str,
-        endpoint_name: str,
     ):
         self.compose_repository = compose_repository
-        self.portainer_client = portainer_client
+        self.deployment_gateway = deployment_gateway
         self.stack_name = stack_name
-        self.endpoint_name = endpoint_name
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def run(self) -> None:
         stack_definition = self.compose_repository.get_compose_of(self.stack_name)
-        endpoint_id = self.portainer_client.get_endpoint_id_by_name(self.endpoint_name)
-        stack_id = self.portainer_client.find_stack_id_by_name(stack_definition.name)
-
-        if stack_id is None:
-            self.logger.info(f"Creating Nexus stack '{stack_definition.name}' on endpoint {endpoint_id}.")
-            self.portainer_client.create_stack(stack_definition, endpoint_id)
-            return
-
-        self.logger.info(f"Updating Nexus stack '{stack_definition.name}' with stack id {stack_id}.")
-        self.portainer_client.update_stack(stack_id, stack_definition, endpoint_id)
+        self.logger.info("Applying deployment stack '%s'.", stack_definition.name)
+        self.deployment_gateway.apply_stack(
+            DeploymentStackRequest(
+                target_stack=self.stack_name,
+                stack_definition=stack_definition,
+            )
+        )

--- a/src/tiny_swarm_world/application/services/deployment/ensure_portainer_stack.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_portainer_stack.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
 
-from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import (
     PortComposeFileRepository,
 )
@@ -13,26 +16,21 @@ class EnsurePortainerStack:
     def __init__(
         self,
         compose_repository: PortComposeFileRepository,
-        portainer_client: PortPortainerClient,
+        deployment_gateway: PortDeploymentGateway,
         stack_name: str,
-        endpoint_name: str,
     ):
         self.compose_repository = compose_repository
-        self.portainer_client = portainer_client
+        self.deployment_gateway = deployment_gateway
         self.stack_name = stack_name
-        self.endpoint_name = endpoint_name
         self.logger = logging.getLogger(self.__class__.__name__)
 
     async def run(self) -> None:
         await asyncio.sleep(0)
         stack_definition = self.compose_repository.get_compose_of(self.stack_name)
-        endpoint_id = self.portainer_client.get_endpoint_id_by_name(self.endpoint_name)
-        stack_id = self.portainer_client.find_stack_id_by_name(stack_definition.name)
-
-        if stack_id is None:
-            self.logger.info("Creating Portainer-managed stack '%s'.", stack_definition.name)
-            self.portainer_client.create_stack(stack_definition, endpoint_id)
-            return
-
-        self.logger.info("Updating Portainer-managed stack '%s'.", stack_definition.name)
-        self.portainer_client.update_stack(stack_id, stack_definition, endpoint_id)
+        self.logger.info("Applying deployment stack '%s'.", stack_definition.name)
+        self.deployment_gateway.apply_stack(
+            DeploymentStackRequest(
+                target_stack=self.stack_name,
+                stack_definition=stack_definition,
+            )
+        )

--- a/src/tiny_swarm_world/application/services/deployment/ensure_service_stack.py
+++ b/src/tiny_swarm_world/application/services/deployment/ensure_service_stack.py
@@ -4,7 +4,10 @@ import asyncio
 import logging
 from collections.abc import Mapping
 
-from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import (
     PortComposeFileRepository,
 )
@@ -16,21 +19,19 @@ class EnsureServiceStack:
     def __init__(
         self,
         compose_repository: PortComposeFileRepository,
-        portainer_client: PortPortainerClient,
+        deployment_gateway: PortDeploymentGateway,
         service_stack: ServiceStackContract,
-        endpoint_name: str,
         stack_environment: Mapping[str, str] | None = None,
         verify_attempts: int = 3,
         verify_wait_seconds: float = 5.0,
     ):
         if verify_attempts <= 0:
-            raise ValueError("Portainer stack verify attempts must be positive.")
+            raise ValueError("Deployment stack verify attempts must be positive.")
         if verify_wait_seconds < 0:
-            raise ValueError("Portainer stack verify wait seconds must not be negative.")
+            raise ValueError("Deployment stack verify wait seconds must not be negative.")
         self.compose_repository = compose_repository
-        self.portainer_client = portainer_client
+        self.deployment_gateway = deployment_gateway
         self.service_stack = service_stack
-        self.endpoint_name = endpoint_name
         self.stack_environment = dict(stack_environment or {})
         self.verify_attempts = verify_attempts
         self.verify_wait_seconds = verify_wait_seconds
@@ -43,29 +44,14 @@ class EnsureServiceStack:
         stack_definition = self.compose_repository.get_compose_of(self.service_stack.stack_name)
         if stack_definition.name != self.service_stack.stack_name:
             raise ValueError("compose stack definition name does not match the service stack contract")
-        endpoint_id = self.portainer_client.get_endpoint_id_by_name(self.endpoint_name)
-        stack_id = self.portainer_client.find_stack_id_by_name(stack_definition.name)
-
-        if stack_id is None:
-            self.logger.info("Creating Portainer-managed stack '%s'.", stack_definition.name)
-            try:
-                self.portainer_client.create_stack(
-                    stack_definition,
-                    endpoint_id,
-                    self.stack_environment,
-                )
-            except Exception:
-                if not await self._stack_is_registered_after_apply_error():
-                    raise
-            return
-
-        self.logger.info("Updating Portainer-managed stack '%s'.", stack_definition.name)
+        self.logger.info("Applying deployment stack '%s'.", stack_definition.name)
         try:
-            self.portainer_client.update_stack(
-                stack_id,
-                stack_definition,
-                endpoint_id,
-                self.stack_environment,
+            self.deployment_gateway.apply_stack(
+                DeploymentStackRequest(
+                    target_stack=self.service_stack.stack_name,
+                    stack_definition=stack_definition,
+                    stack_environment=self.stack_environment,
+                )
             )
         except Exception:
             if not await self._stack_is_registered_after_apply_error():
@@ -76,16 +62,18 @@ class EnsureServiceStack:
         for attempt in range(1, self.verify_attempts + 1):
             await asyncio.sleep(0 if attempt == 1 else self.verify_wait_seconds)
             try:
-                stack_id = self.portainer_client.find_stack_id_by_name(self.service_stack.stack_name)
+                registered = self.deployment_gateway.stack_registered(
+                    self.service_stack.stack_name
+                )
             except Exception as exc:
                 last_exception = exc
                 continue
-            if stack_id is not None:
+            if registered:
                 return VerificationResult(
                     target_id=self.verification_target_id,
                     status=VerificationStatus.VERIFIED,
                     message=(
-                        "Portainer stack is registered; service readiness remains a "
+                        "Deployment stack is registered; service readiness remains a "
                         "separate observed-state verification."
                     ),
                     evidence=_stack_registration_evidence(
@@ -100,7 +88,7 @@ class EnsureServiceStack:
                 target_id=self.verification_target_id,
                 status=VerificationStatus.FAILED_TO_VERIFY,
                 message=(
-                    "Portainer stack registration verification failed: "
+                    "Deployment stack registration verification failed: "
                     f"{last_exception.__class__.__name__}"
                 ),
                 evidence=_stack_registration_evidence(
@@ -115,7 +103,7 @@ class EnsureServiceStack:
         return VerificationResult(
             target_id=self.verification_target_id,
             status=VerificationStatus.FAILED_TO_VERIFY,
-            message="Portainer stack is missing after apply.",
+            message="Deployment stack is missing after apply.",
             evidence=_stack_registration_evidence(
                 self.service_stack,
                 stack_registered="false",
@@ -140,7 +128,7 @@ def _stack_registration_evidence(
     evidence = {
         "phase": "verify",
         "readiness_observed": "false",
-        "registration_scope": "portainer_stack",
+        "registration_scope": "deployment_gateway_stack",
         "required_service_count": str(len(service_stack.required_services)),
         "required_services": ",".join(service_stack.required_services),
         "stack_registered": stack_registered,

--- a/src/tiny_swarm_world/application/services/deployment/service_stack_plan.py
+++ b/src/tiny_swarm_world/application/services/deployment/service_stack_plan.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import (
     PortComposeFileRepository,
 )
@@ -18,20 +20,17 @@ DEFAULT_PORTAINER_ENDPOINT_NAME = "local"
 
 def build_default_service_stack_steps(
     compose_repository: PortComposeFileRepository,
-    portainer_client: PortPortainerClient,
-    endpoint_name: str = DEFAULT_PORTAINER_ENDPOINT_NAME,
+    deployment_gateway: PortDeploymentGateway,
 ) -> tuple[EnsureServiceStack, ...]:
     return build_service_stack_steps(
         compose_repository=compose_repository,
-        portainer_client=portainer_client,
-        endpoint_name=endpoint_name,
+        deployment_gateway=deployment_gateway,
     )
 
 
 def build_service_stack_steps(
     compose_repository: PortComposeFileRepository,
-    portainer_client: PortPortainerClient,
-    endpoint_name: str = DEFAULT_PORTAINER_ENDPOINT_NAME,
+    deployment_gateway: PortDeploymentGateway,
     *,
     service_profile: ServiceStackProfile | str = ServiceStackProfile.DEFAULT,
     excluded_stack_names: tuple[str, ...] = (),
@@ -47,9 +46,8 @@ def build_service_stack_steps(
     return tuple(
         EnsureServiceStack(
             compose_repository=compose_repository,
-            portainer_client=portainer_client,
+            deployment_gateway=deployment_gateway,
             service_stack=service_stack,
-            endpoint_name=endpoint_name,
             stack_environment=environments.get(service_stack.stack_name),
         )
         for service_stack in contracts

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_swarm_runtime.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/lxc_swarm_runtime.py
@@ -17,6 +17,10 @@ from tiny_swarm_world.application.ports.clients.port_container_image_publisher i
 from tiny_swarm_world.application.ports.clients.port_container_runtime import (
     PortContainerRuntime,
 )
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.clients.port_nexus_client import PortNexusClient
 from tiny_swarm_world.application.ports.clients.port_portainer_admin_client import (
     PortainerAdminInitializationRejected,
@@ -451,7 +455,7 @@ class LxcNexusHttpClient(PortNexusClient):
         )
 
 
-class LxcPortainerHttpClient(PortPortainerClient):
+class LxcPortainerHttpClient(PortPortainerClient, PortDeploymentGateway):
     def __init__(
         self,
         *,
@@ -510,6 +514,26 @@ class LxcPortainerHttpClient(PortPortainerClient):
             endpoint_id,
             stack_environment,
         )
+
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        endpoint_id = self.get_endpoint_id_by_name("local")
+        stack_id = self.find_stack_id_by_name(request.stack_definition.name)
+        if stack_id is None:
+            self.create_stack(
+                request.stack_definition,
+                endpoint_id,
+                request.stack_environment,
+            )
+            return
+        self.update_stack(
+            stack_id,
+            request.stack_definition,
+            endpoint_id,
+            request.stack_environment,
+        )
+
+    def stack_registered(self, stack_name: str) -> bool:
+        return self.find_stack_id_by_name(stack_name) is not None
 
     def _ensure_external_overlay_networks(self, stack_definition: StackDefinition) -> None:
         for network_name in _external_overlay_network_names(stack_definition):

--- a/src/tiny_swarm_world/infrastructure/adapters/clients/portainer_http_client.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/clients/portainer_http_client.py
@@ -3,12 +3,16 @@ from urllib.parse import urlparse
 
 import requests
 
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
 from tiny_swarm_world.domain.deployment.stack_definition import StackDefinition
 from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
 
 
-class PortainerHttpClient(PortPortainerClient):
+class PortainerHttpClient(PortPortainerClient, PortDeploymentGateway):
     def __init__(
         self,
         base_url: str,
@@ -17,6 +21,7 @@ class PortainerHttpClient(PortPortainerClient):
         session: requests.Session | None = None,
         request_timeout_seconds: int = 30,
         stack_request_timeout_seconds: int = 180,
+        deployment_endpoint_name: str = "local",
     ):
         parsed_base_url = urlparse(base_url)
         if parsed_base_url.username or parsed_base_url.password:
@@ -32,6 +37,7 @@ class PortainerHttpClient(PortPortainerClient):
         self.session = session or requests.Session()
         self.request_timeout_seconds = request_timeout_seconds
         self.stack_request_timeout_seconds = stack_request_timeout_seconds
+        self.deployment_endpoint_name = deployment_endpoint_name
         self.logger = LoggerFactory.get_logger(self.__class__)
         self._jwt_token: str | None = None
 
@@ -121,6 +127,26 @@ class PortainerHttpClient(PortPortainerClient):
             },
         )
         self._ensure_success(response, f"update Portainer stack '{stack_definition.name}'")
+
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        endpoint_id = self.get_endpoint_id_by_name(self.deployment_endpoint_name)
+        stack_id = self.find_stack_id_by_name(request.stack_definition.name)
+        if stack_id is None:
+            self.create_stack(
+                request.stack_definition,
+                endpoint_id,
+                request.stack_environment,
+            )
+            return
+        self.update_stack(
+            stack_id,
+            request.stack_definition,
+            endpoint_id,
+            request.stack_environment,
+        )
+
+    def stack_registered(self, stack_name: str) -> bool:
+        return self.find_stack_id_by_name(stack_name) is not None
 
     def _fetch_endpoints(self, action: str) -> tuple[Mapping[str, object], ...]:
         response = self._send("GET", "/api/endpoints")

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -1371,8 +1371,7 @@ def build_lxc_deployment_services(
     )
     application_steps: tuple[object, ...] = build_service_stack_steps(
         compose_repository=compose_repository,
-        portainer_client=portainer_client,
-        endpoint_name=DEFAULT_PORTAINER_ENDPOINT_NAME,
+        deployment_gateway=portainer_client,
         service_profile=selected_service_profile,
         excluded_stack_names=("nexus",),
         stack_environments=stack_environment,

--- a/tests/application/services/deployment/test_ensure_nexus_stack.py
+++ b/tests/application/services/deployment/test_ensure_nexus_stack.py
@@ -1,6 +1,9 @@
 import unittest
 from unittest.mock import MagicMock
 
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+)
 from tiny_swarm_world.application.services.deployment.ensure_nexus_stack import EnsureNexusStack
 from tiny_swarm_world.domain.deployment.stack_definition import StackDefinition
 
@@ -10,32 +13,36 @@ class TestEnsureNexusStack(unittest.TestCase):
         stack_definition = StackDefinition(name="nexus", compose_content="services: {}")
         compose_repository = MagicMock()
         compose_repository.get_compose_of.return_value = stack_definition
-        portainer_client = MagicMock()
-        portainer_client.get_endpoint_id_by_name.return_value = 1
-        portainer_client.find_stack_id_by_name.return_value = None
+        deployment_gateway = _FakeDeploymentGateway()
 
-        service = EnsureNexusStack(compose_repository, portainer_client, "nexus", "local")
+        service = EnsureNexusStack(compose_repository, deployment_gateway, "nexus")
         service.run()
 
         compose_repository.get_compose_of.assert_called_once_with("nexus")
-        portainer_client.get_endpoint_id_by_name.assert_called_once_with("local")
-        portainer_client.find_stack_id_by_name.assert_called_once_with("nexus")
-        portainer_client.create_stack.assert_called_once_with(stack_definition, 1)
-        portainer_client.update_stack.assert_not_called()
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+        request = deployment_gateway.applied_requests[0]
+        self.assertEqual("nexus", request.target_stack)
+        self.assertEqual(stack_definition, request.stack_definition)
 
     def test_updates_stack_when_present(self):
         stack_definition = StackDefinition(name="nexus", compose_content="services: {}")
         compose_repository = MagicMock()
         compose_repository.get_compose_of.return_value = stack_definition
-        portainer_client = MagicMock()
-        portainer_client.get_endpoint_id_by_name.return_value = 1
-        portainer_client.find_stack_id_by_name.return_value = 7
+        deployment_gateway = _FakeDeploymentGateway()
 
-        service = EnsureNexusStack(compose_repository, portainer_client, "nexus", "local")
+        service = EnsureNexusStack(compose_repository, deployment_gateway, "nexus")
         service.run()
 
         compose_repository.get_compose_of.assert_called_once_with("nexus")
-        portainer_client.get_endpoint_id_by_name.assert_called_once_with("local")
-        portainer_client.find_stack_id_by_name.assert_called_once_with("nexus")
-        portainer_client.update_stack.assert_called_once_with(7, stack_definition, 1)
-        portainer_client.create_stack.assert_not_called()
+        self.assertEqual(stack_definition, deployment_gateway.applied_requests[0].stack_definition)
+
+
+class _FakeDeploymentGateway:
+    def __init__(self) -> None:
+        self.applied_requests: list[DeploymentStackRequest] = []
+
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        self.applied_requests.append(request)
+
+    def stack_registered(self, stack_name: str) -> bool:
+        return bool(self.applied_requests)

--- a/tests/application/services/deployment/test_ensure_portainer_stack.py
+++ b/tests/application/services/deployment/test_ensure_portainer_stack.py
@@ -1,6 +1,9 @@
 import unittest
 from unittest.mock import MagicMock
 
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+)
 from tiny_swarm_world.application.services.deployment.ensure_portainer_stack import (
     EnsurePortainerStack,
 )
@@ -12,63 +15,67 @@ class TestEnsurePortainerStack(unittest.IsolatedAsyncioTestCase):
         stack_definition = StackDefinition(name="portainer", compose_content="services: {}")
         compose_repository = MagicMock()
         compose_repository.get_compose_of.return_value = stack_definition
-        portainer_client = MagicMock()
-        portainer_client.get_endpoint_id_by_name.return_value = 7
-        portainer_client.find_stack_id_by_name.return_value = None
+        deployment_gateway = _FakeDeploymentGateway()
 
-        service = EnsurePortainerStack(compose_repository, portainer_client, "portainer", "local")
+        service = EnsurePortainerStack(compose_repository, deployment_gateway, "portainer")
         await service.run()
 
         compose_repository.get_compose_of.assert_called_once_with("portainer")
-        portainer_client.get_endpoint_id_by_name.assert_called_once_with("local")
-        portainer_client.find_stack_id_by_name.assert_called_once_with("portainer")
-        portainer_client.create_stack.assert_called_once_with(stack_definition, 7)
-        portainer_client.update_stack.assert_not_called()
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+        request = deployment_gateway.applied_requests[0]
+        self.assertEqual("portainer", request.target_stack)
+        self.assertEqual(stack_definition, request.stack_definition)
 
     async def test_updates_stack_when_portainer_stack_exists(self):
         stack_definition = StackDefinition(name="portainer", compose_content="services: {}")
         compose_repository = MagicMock()
         compose_repository.get_compose_of.return_value = stack_definition
-        portainer_client = MagicMock()
-        portainer_client.get_endpoint_id_by_name.return_value = 7
-        portainer_client.find_stack_id_by_name.return_value = 42
+        deployment_gateway = _FakeDeploymentGateway()
 
-        service = EnsurePortainerStack(compose_repository, portainer_client, "portainer", "local")
+        service = EnsurePortainerStack(compose_repository, deployment_gateway, "portainer")
         await service.run()
 
-        portainer_client.create_stack.assert_not_called()
-        portainer_client.update_stack.assert_called_once_with(42, stack_definition, 7)
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+        self.assertEqual(stack_definition, deployment_gateway.applied_requests[0].stack_definition)
 
     async def test_compose_lookup_failure_does_not_deploy_stack(self):
         compose_repository = MagicMock()
         compose_repository.get_compose_of.side_effect = FileNotFoundError("missing")
-        portainer_client = MagicMock()
+        deployment_gateway = _FakeDeploymentGateway()
 
-        service = EnsurePortainerStack(compose_repository, portainer_client, "portainer", "local")
+        service = EnsurePortainerStack(compose_repository, deployment_gateway, "portainer")
 
         with self.assertRaises(FileNotFoundError):
             await service.run()
 
-        portainer_client.get_endpoint_id_by_name.assert_not_called()
-        portainer_client.find_stack_id_by_name.assert_not_called()
-        portainer_client.create_stack.assert_not_called()
-        portainer_client.update_stack.assert_not_called()
+        self.assertEqual([], deployment_gateway.applied_requests)
 
-    async def test_endpoint_lookup_failure_does_not_create_or_update_stack(self):
+    async def test_gateway_failure_is_propagated(self):
         stack_definition = StackDefinition(name="portainer", compose_content="services: {}")
         compose_repository = MagicMock()
         compose_repository.get_compose_of.return_value = stack_definition
-        portainer_client = MagicMock()
-        portainer_client.get_endpoint_id_by_name.side_effect = RuntimeError("endpoint missing")
+        deployment_gateway = _FakeDeploymentGateway(RuntimeError("deployment gateway failed"))
 
-        service = EnsurePortainerStack(compose_repository, portainer_client, "portainer", "local")
+        service = EnsurePortainerStack(compose_repository, deployment_gateway, "portainer")
 
         with self.assertRaises(RuntimeError):
             await service.run()
 
-        portainer_client.find_stack_id_by_name.assert_not_called()
-        portainer_client.create_stack.assert_not_called()
-        portainer_client.update_stack.assert_not_called()
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+
+
+class _FakeDeploymentGateway:
+    def __init__(self, apply_exception: Exception | None = None) -> None:
+        self.apply_exception = apply_exception
+        self.applied_requests: list[DeploymentStackRequest] = []
+
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        self.applied_requests.append(request)
+        if self.apply_exception is not None:
+            raise self.apply_exception
+
+    def stack_registered(self, stack_name: str) -> bool:
+        return bool(self.applied_requests)
 
 
 if __name__ == "__main__":

--- a/tests/application/services/deployment/test_ensure_service_stack.py
+++ b/tests/application/services/deployment/test_ensure_service_stack.py
@@ -1,6 +1,9 @@
 import unittest
 from tests.support.sonar_safe_literals import sensitive_assignment
 
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+)
 from tiny_swarm_world.application.services.deployment.ensure_service_stack import EnsureServiceStack
 from tiny_swarm_world.domain.deployment import ServiceStackContract
 from tiny_swarm_world.domain.deployment.stack_definition import StackDefinition
@@ -11,106 +14,102 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
     async def test_creates_missing_default_service_stack(self):
         stack_definition = StackDefinition(name="jenkins", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[None])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[False])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("jenkins", ("jenkins",)),
-            "local",
         )
 
         await service.run()
 
         self.assertEqual(["jenkins"], compose_repository.requested_stacks)
-        self.assertEqual(["local"], portainer_client.requested_endpoints)
-        self.assertEqual([("jenkins", 7, {})], portainer_client.created_stacks)
-        self.assertEqual([], portainer_client.updated_stacks)
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+        request = deployment_gateway.applied_requests[0]
+        self.assertEqual("jenkins", request.target_stack)
+        self.assertEqual(stack_definition, request.stack_definition)
+        self.assertEqual({}, dict(request.stack_environment))
 
     async def test_updates_existing_default_service_stack(self):
         stack_definition = StackDefinition(name="rabbitmq", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[42])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[True])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("rabbitmq", ("rabbitmq",)),
-            "local",
         )
 
         await service.run()
 
-        self.assertEqual([], portainer_client.created_stacks)
-        self.assertEqual([(42, "rabbitmq", 7, {})], portainer_client.updated_stacks)
+        self.assertEqual(1, len(deployment_gateway.applied_requests))
+        self.assertEqual("rabbitmq", deployment_gateway.applied_requests[0].target_stack)
 
     async def test_passes_stack_environment_when_creating_service_access_stack(self):
         stack_definition = StackDefinition(name="service-access", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[None])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[False])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("service-access", ("service-access-dashboard",)),
-            "local",
             stack_environment={"TSW_VAULTWARDEN_ADMIN_TOKEN_SECRET": "operator_defined"},
         )
 
         await service.run()
 
         self.assertEqual(
-            [("service-access", 7, {"TSW_VAULTWARDEN_ADMIN_TOKEN_SECRET": "operator_defined"})],
-            portainer_client.created_stacks,
+            {"TSW_VAULTWARDEN_ADMIN_TOKEN_SECRET": "operator_defined"},
+            dict(deployment_gateway.applied_requests[0].stack_environment),
         )
 
     async def test_treats_create_timeout_as_success_when_stack_registration_is_visible(self):
         stack_definition = StackDefinition(name="swagger", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(
-            stack_ids=[None, 52],
-            create_exception=TimeoutError("Portainer create timed out"),
+        deployment_gateway = _FakeDeploymentGateway(
+            registered_values=[True],
+            apply_exception=TimeoutError("Deployment gateway timed out"),
         )
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
-            "local",
             verify_wait_seconds=0,
         )
 
         await service.run()
 
-        self.assertEqual([("swagger", 7, {})], portainer_client.created_stacks)
+        self.assertEqual(["swagger"], deployment_gateway.registration_checks)
 
     async def test_treats_update_timeout_as_success_when_stack_registration_is_visible(self):
         stack_definition = StackDefinition(name="swagger", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(
-            stack_ids=[52, 52],
-            update_exception=TimeoutError("Portainer update timed out"),
+        deployment_gateway = _FakeDeploymentGateway(
+            registered_values=[True],
+            apply_exception=TimeoutError("Deployment gateway timed out"),
         )
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
-            "local",
             verify_wait_seconds=0,
         )
 
         await service.run()
 
-        self.assertEqual([(52, "swagger", 7, {})], portainer_client.updated_stacks)
+        self.assertEqual(["swagger"], deployment_gateway.registration_checks)
 
     async def test_keeps_create_timeout_when_stack_registration_is_missing(self):
         stack_definition = StackDefinition(name="swagger", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(
-            stack_ids=[None, None],
-            create_exception=TimeoutError("Portainer create timed out"),
+        deployment_gateway = _FakeDeploymentGateway(
+            registered_values=[False],
+            apply_exception=TimeoutError("Deployment gateway timed out"),
         )
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
-            "local",
             verify_wait_seconds=0,
         )
 
@@ -120,19 +119,18 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
     async def test_verify_reports_registered_stack_without_claiming_readiness(self):
         stack_definition = StackDefinition(name="sonarqube", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[31])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[True])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("sonarqube", ("sonarqube", "sonar_db")),
-            "local",
         )
 
         verification = await service.verify()
 
         self.assertEqual(VerificationStatus.VERIFIED, verification.status)
         self.assertEqual("deployment:sonarqube-stack", verification.target_id)
-        self.assertEqual("portainer_stack", verification.evidence["registration_scope"])
+        self.assertEqual("deployment_gateway_stack", verification.evidence["registration_scope"])
         self.assertEqual("false", verification.evidence["readiness_observed"])
         self.assertEqual("true", verification.evidence["stack_registered"])
         self.assertIn("service readiness remains", verification.message)
@@ -140,15 +138,14 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
     async def test_verify_retries_transient_portainer_stack_lookup_failure(self):
         stack_definition = StackDefinition(name="swagger", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(
-            stack_ids=[31],
-            stack_exceptions=[RuntimeError("temporary Portainer lookup failure")],
+        deployment_gateway = _FakeDeploymentGateway(
+            registered_values=[True],
+            stack_exceptions=[RuntimeError("temporary gateway lookup failure")],
         )
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
-            "local",
             verify_wait_seconds=0,
         )
 
@@ -161,12 +158,11 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
     async def test_verify_reports_missing_stack_without_running_compose(self):
         stack_definition = StackDefinition(name="swagger", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[None])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[False])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
-            "local",
         )
 
         verification = await service.verify()
@@ -179,29 +175,29 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
     async def test_run_rejects_compose_stack_name_mismatch(self):
         stack_definition = StackDefinition(name="wrong-stack", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_ids=[None])
+        deployment_gateway = _FakeDeploymentGateway(registered_values=[False])
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("service-access", ("service-access-dashboard",)),
-            "local",
         )
 
         with self.assertRaises(ValueError):
             await service.run()
 
         self.assertEqual(["service-access"], compose_repository.requested_stacks)
-        self.assertEqual([], portainer_client.requested_endpoints)
+        self.assertEqual([], deployment_gateway.applied_requests)
 
     async def test_verify_sanitizes_portainer_client_failures(self):
         stack_definition = StackDefinition(name="nexus", compose_content="services: {}")
         compose_repository = _FakeComposeRepository(stack_definition)
-        portainer_client = _FakePortainerClient(stack_exception=RuntimeError(sensitive_assignment()))
+        deployment_gateway = _FakeDeploymentGateway(
+            stack_exception=RuntimeError(sensitive_assignment())
+        )
         service = EnsureServiceStack(
             compose_repository,
-            portainer_client,
+            deployment_gateway,
             ServiceStackContract("nexus", ("nexus",)),
-            "local",
         )
 
         verification = await service.verify()
@@ -224,54 +220,32 @@ class _FakeComposeRepository:
         return self.stack_definition
 
 
-class _FakePortainerClient:
+class _FakeDeploymentGateway:
     def __init__(
         self,
-        stack_ids: list[int | None] | None = None,
+        registered_values: list[bool] | None = None,
         stack_exception: Exception | None = None,
         stack_exceptions: list[Exception] | None = None,
-        create_exception: Exception | None = None,
-        update_exception: Exception | None = None,
+        apply_exception: Exception | None = None,
     ):
-        self.stack_ids = list(stack_ids or [])
+        self.registered_values = list(registered_values or [])
         self.stack_exception = stack_exception
         self.stack_exceptions = list(stack_exceptions or [])
-        self.create_exception = create_exception
-        self.update_exception = update_exception
-        self.requested_endpoints: list[str] = []
-        self.created_stacks: list[tuple[str, int, dict[str, str]]] = []
-        self.updated_stacks: list[tuple[int, str, int, dict[str, str]]] = []
+        self.apply_exception = apply_exception
+        self.applied_requests: list[DeploymentStackRequest] = []
+        self.registration_checks: list[str] = []
 
-    def get_endpoint_id_by_name(self, endpoint_name: str) -> int:
-        self.requested_endpoints.append(endpoint_name)
-        return 7
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        self.applied_requests.append(request)
+        if self.apply_exception is not None:
+            raise self.apply_exception
 
-    def find_stack_id_by_name(self, stack_name: str) -> int | None:
+    def stack_registered(self, stack_name: str) -> bool:
+        self.registration_checks.append(stack_name)
         if self.stack_exceptions:
             raise self.stack_exceptions.pop(0)
         if self.stack_exception:
             raise self.stack_exception
-        if self.stack_ids:
-            return self.stack_ids.pop(0)
-        return None
-
-    def create_stack(
-        self,
-        stack_definition: StackDefinition,
-        endpoint_id: int,
-        stack_environment: dict[str, str] | None = None,
-    ) -> None:
-        self.created_stacks.append((stack_definition.name, endpoint_id, dict(stack_environment or {})))
-        if self.create_exception is not None:
-            raise self.create_exception
-
-    def update_stack(
-        self,
-        stack_id: int,
-        stack_definition: StackDefinition,
-        endpoint_id: int,
-        stack_environment: dict[str, str] | None = None,
-    ) -> None:
-        self.updated_stacks.append((stack_id, stack_definition.name, endpoint_id, dict(stack_environment or {})))
-        if self.update_exception is not None:
-            raise self.update_exception
+        if self.registered_values:
+            return self.registered_values.pop(0)
+        return False

--- a/tests/application/services/deployment/test_service_stack_plan.py
+++ b/tests/application/services/deployment/test_service_stack_plan.py
@@ -1,12 +1,14 @@
 import unittest
 from typing import cast
 
-from tiny_swarm_world.application.ports.clients.port_portainer_client import PortPortainerClient
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+    PortDeploymentGateway,
+)
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import (
     PortComposeFileRepository,
 )
 from tiny_swarm_world.application.services.deployment.service_stack_plan import (
-    DEFAULT_PORTAINER_ENDPOINT_NAME,
     build_default_service_stack_steps,
     build_service_stack_steps,
 )
@@ -18,9 +20,9 @@ from tiny_swarm_world.domain.inventory import VerificationStatus
 class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
     def test_builds_default_service_stack_steps_without_concrete_adapters(self):
         compose_repository = _compose_repository_stub()
-        portainer_client = _portainer_client_stub()
+        deployment_gateway = _deployment_gateway_stub()
 
-        steps = build_default_service_stack_steps(compose_repository, portainer_client, "local")
+        steps = build_default_service_stack_steps(compose_repository, deployment_gateway)
 
         self.assertEqual(5, len(steps))
         self.assertEqual(
@@ -34,47 +36,23 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
             [step.verification_target_id for step in steps],
         )
         self.assertTrue(all(step.compose_repository is compose_repository for step in steps))
-        self.assertTrue(all(step.portainer_client is portainer_client for step in steps))
-        self.assertTrue(all(step.endpoint_name == "local" for step in steps))
+        self.assertTrue(all(step.deployment_gateway is deployment_gateway for step in steps))
 
     def test_default_service_stack_steps_do_not_include_portainer_bootstrap_cycle(self):
         steps = build_default_service_stack_steps(
             _compose_repository_stub(),
-            _portainer_client_stub(),
-            "local",
+            _deployment_gateway_stub(),
         )
 
         self.assertNotIn("portainer", [step.service_stack.stack_name for step in steps])
 
-    def test_default_service_stack_steps_use_named_portainer_endpoint_default(self):
-        steps = build_default_service_stack_steps(
-            _compose_repository_stub(),
-            _portainer_client_stub(),
-        )
-
-        self.assertEqual("local", DEFAULT_PORTAINER_ENDPOINT_NAME)
-        self.assertTrue(
-            all(step.endpoint_name == DEFAULT_PORTAINER_ENDPOINT_NAME for step in steps)
-        )
-
-    def test_service_stack_steps_use_named_portainer_endpoint_default(self):
-        steps = build_service_stack_steps(
-            _compose_repository_stub(),
-            _portainer_client_stub(),
-        )
-
-        self.assertTrue(
-            all(step.endpoint_name == DEFAULT_PORTAINER_ENDPOINT_NAME for step in steps)
-        )
-
     def test_service_access_profile_steps_include_selected_stack(self):
         compose_repository = _compose_repository_stub()
-        portainer_client = _portainer_client_stub()
+        deployment_gateway = _deployment_gateway_stub()
 
         steps = build_service_stack_steps(
             compose_repository,
-            portainer_client,
-            "local",
+            deployment_gateway,
             service_profile=ServiceStackProfile.SERVICE_ACCESS,
         )
 
@@ -84,14 +62,12 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("portainer", tuple(step.service_stack.stack_name for step in steps))
         self.assertTrue(all(step.compose_repository is compose_repository for step in steps))
-        self.assertTrue(all(step.portainer_client is portainer_client for step in steps))
-        self.assertTrue(all(step.endpoint_name == "local" for step in steps))
+        self.assertTrue(all(step.deployment_gateway is deployment_gateway for step in steps))
 
     def test_service_stack_steps_can_exclude_bootstrap_owned_stacks(self):
         steps = build_service_stack_steps(
             _compose_repository_stub(),
-            _portainer_client_stub(),
-            "local",
+            _deployment_gateway_stub(),
             service_profile=ServiceStackProfile.SERVICE_ACCESS,
             excluded_stack_names=("nexus",),
         )
@@ -104,8 +80,7 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
     def test_service_stack_steps_attach_stack_specific_environment(self):
         steps = build_service_stack_steps(
             _compose_repository_stub(),
-            _portainer_client_stub(),
-            "local",
+            _deployment_gateway_stub(),
             service_profile=ServiceStackProfile.SERVICE_ACCESS,
             stack_environments={
                 "infisical": {
@@ -127,12 +102,11 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
 
     async def test_default_service_stack_steps_verify_stack_registration_without_readiness_claim(self):
         compose_repository = _FakeComposeRepository()
-        portainer_client = _FakePortainerClient()
+        deployment_gateway = _FakeDeploymentGateway()
 
         steps = build_default_service_stack_steps(
             cast(PortComposeFileRepository, compose_repository),
-            cast(PortPortainerClient, portainer_client),
-            "local",
+            cast(PortDeploymentGateway, deployment_gateway),
         )
         verification_results = [await step.verify() for step in steps]
 
@@ -152,6 +126,12 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             all(verification.evidence["readiness_observed"] == "false" for verification in verification_results)
         )
+        self.assertTrue(
+            all(
+                verification.evidence["registration_scope"] == "deployment_gateway_stack"
+                for verification in verification_results
+            )
+        )
         self.assertEqual([], compose_repository.requested_stacks)
 
 
@@ -164,17 +144,20 @@ class _FakeComposeRepository:
         return StackDefinition(name=stack_name, compose_content="services: {}")
 
 
-class _FakePortainerClient:
-    def get_endpoint_id_by_name(self, endpoint_name: str) -> int:
-        return 7
+class _FakeDeploymentGateway:
+    def __init__(self) -> None:
+        self.applied_requests: list[DeploymentStackRequest] = []
 
-    def find_stack_id_by_name(self, stack_name: str) -> int | None:
-        return 42
+    def apply_stack(self, request: DeploymentStackRequest) -> None:
+        self.applied_requests.append(request)
+
+    def stack_registered(self, stack_name: str) -> bool:
+        return True
 
 
 def _compose_repository_stub() -> PortComposeFileRepository:
     return cast(PortComposeFileRepository, object())
 
 
-def _portainer_client_stub() -> PortPortainerClient:
-    return cast(PortPortainerClient, object())
+def _deployment_gateway_stub() -> PortDeploymentGateway:
+    return cast(PortDeploymentGateway, object())

--- a/tests/architecture/test_hexagonal_imports.py
+++ b/tests/architecture/test_hexagonal_imports.py
@@ -159,7 +159,10 @@ class TestResponsibilityBoundaryDocumentation(unittest.TestCase):
         legacy_imports = [imported for imported, _line_number in _direct_imports(legacy_service_file)]
 
         self.assertTrue(deployment_service_file.is_file())
-        self.assertIn("tiny_swarm_world.application.ports.clients.port_portainer_client", deployment_imports)
+        self.assertIn(
+            "tiny_swarm_world.application.ports.clients.port_deployment_gateway",
+            deployment_imports,
+        )
         self.assertIn(
             "tiny_swarm_world.application.ports.repositories.port_compose_file_repository",
             deployment_imports,

--- a/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
@@ -537,6 +537,59 @@ networks:
             check=False,
         )
 
+    def test_lxc_portainer_client_apply_stack_uses_gateway_and_overlay_preflight(self):
+        from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+            DeploymentStackRequest,
+        )
+        from tiny_swarm_world.infrastructure.adapters.clients.lxc_swarm_runtime import (
+            LxcPortainerHttpClient,
+        )
+
+        client = LxcPortainerHttpClient(
+            backend=ManagedLxcBackend.LXD,
+            username="admin",
+            password=operator_credential(),
+        )
+        stack = StackDefinition(
+            name="service-access",
+            compose_content="""
+networks:
+  service_access_link:
+    name: service_access_link
+    external: true
+""",
+        )
+        delegate = _FakePortainerDelegate(stack_id=None)
+
+        with patch.object(
+            client,
+            "_run_manager_shell",
+            side_effect=(
+                subprocess.CompletedProcess([], 1),
+                subprocess.CompletedProcess([], 0),
+            ),
+        ) as run_manager_shell:
+            with patch.object(client, "_client", return_value=delegate):
+                client.apply_stack(
+                    DeploymentStackRequest(
+                        target_stack="service-access",
+                        stack_definition=stack,
+                        stack_environment={"TSW_EXAMPLE": "value"},
+                    )
+                )
+
+        scripts = [call.args[0] for call in run_manager_shell.call_args_list]
+        self.assertEqual(
+            [
+                "docker network inspect -- service_access_link >/dev/null 2>&1",
+                "docker network create --driver overlay --attachable -- service_access_link >/dev/null",
+            ],
+            scripts,
+        )
+        self.assertEqual(["local"], delegate.requested_endpoints)
+        self.assertEqual(["service-access"], delegate.requested_stacks)
+        self.assertEqual([(stack, 1, {"TSW_EXAMPLE": "value"})], delegate.created_stacks)
+
     def test_lxc_portainer_client_reuses_delegate_for_workflow_lifetime(self):
         from tiny_swarm_world.infrastructure.adapters.clients.lxc_swarm_runtime import (
             LxcPortainerHttpClient,
@@ -599,9 +652,20 @@ class _FakeSession:
 
 
 class _FakePortainerDelegate:
-    def __init__(self) -> None:
+    def __init__(self, stack_id: int | None = None) -> None:
+        self.stack_id = stack_id
+        self.requested_endpoints: list[str] = []
+        self.requested_stacks: list[str] = []
         self.created_stacks: list[tuple[StackDefinition, int, dict[str, str]]] = []
         self.updated_stacks: list[tuple[int, StackDefinition, int, dict[str, str]]] = []
+
+    def get_endpoint_id_by_name(self, endpoint_name: str) -> int:
+        self.requested_endpoints.append(endpoint_name)
+        return 1
+
+    def find_stack_id_by_name(self, stack_name: str) -> int | None:
+        self.requested_stacks.append(stack_name)
+        return self.stack_id
 
     def create_stack(
         self,

--- a/tests/infrastructure/adapters/clients/test_portainer_http_client.py
+++ b/tests/infrastructure/adapters/clients/test_portainer_http_client.py
@@ -2,6 +2,9 @@ import unittest
 
 from tests.support.sonar_safe_literals import sample_text, sample_url
 
+from tiny_swarm_world.application.ports.clients.port_deployment_gateway import (
+    DeploymentStackRequest,
+)
 from tiny_swarm_world.domain.deployment.stack_definition import StackDefinition
 from tiny_swarm_world.infrastructure.adapters.clients.portainer_http_client import (
     PortainerHttpClient,
@@ -69,6 +72,92 @@ class TestPortainerHttpClient(unittest.TestCase):
             [{"name": "TSW_VAULTWARDEN_ADMIN_TOKEN_SECRET", "value": "operator_defined"}],
             session.request_calls[1]["json"]["env"],
         )
+
+    def test_apply_stack_creates_missing_stack_through_deployment_gateway(self):
+        session = _FakeSession(
+            post_responses=[_FakeResponse(200, {"jwt": "jwt-token"})],
+            request_responses=[
+                _FakeResponse(200, [{"Name": "local", "Id": 7}]),
+                _FakeResponse(200, []),
+                _swarm_info_response(),
+                _FakeResponse(200, {}),
+            ],
+        )
+        client = PortainerHttpClient(
+            "http://portainer.local",
+            "admin",
+            OPERATOR_CREDENTIAL,
+            session=session,
+        )
+
+        client.apply_stack(
+            DeploymentStackRequest(
+                target_stack="jenkins",
+                stack_definition=StackDefinition(
+                    name="jenkins",
+                    compose_content="services: {}",
+                ),
+                stack_environment={"TSW_JENKINS_IMAGE": "jenkins:latest"},
+            )
+        )
+
+        self.assertEqual("http://portainer.local/api/endpoints", session.request_calls[0]["url"])
+        self.assertEqual("http://portainer.local/api/stacks", session.request_calls[1]["url"])
+        self.assertEqual(
+            "http://portainer.local/api/endpoints/7/docker/info",
+            session.request_calls[2]["url"],
+        )
+        self.assertEqual("jenkins", session.request_calls[3]["json"]["name"])
+        self.assertEqual(
+            [{"name": "TSW_JENKINS_IMAGE", "value": "jenkins:latest"}],
+            session.request_calls[3]["json"]["env"],
+        )
+
+    def test_apply_stack_updates_existing_stack_through_deployment_gateway(self):
+        session = _FakeSession(
+            post_responses=[_FakeResponse(200, {"jwt": "jwt-token"})],
+            request_responses=[
+                _FakeResponse(200, [{"Name": "local", "Id": 7}]),
+                _FakeResponse(200, [{"Name": "swagger", "Id": 42}]),
+                _FakeResponse(200, {}),
+            ],
+        )
+        client = PortainerHttpClient(
+            "http://portainer.local",
+            "admin",
+            OPERATOR_CREDENTIAL,
+            session=session,
+        )
+
+        client.apply_stack(
+            DeploymentStackRequest(
+                target_stack="swagger",
+                stack_definition=StackDefinition(
+                    name="swagger",
+                    compose_content="services: {}",
+                ),
+            )
+        )
+
+        request = session.request_calls[2]
+        self.assertEqual("PUT", request["method"])
+        self.assertEqual("http://portainer.local/api/stacks/42?endpointId=7", request["url"])
+        self.assertEqual("services: {}", request["json"]["stackFileContent"])
+
+    def test_stack_registered_uses_portainer_stack_lookup_inside_adapter(self):
+        session = _FakeSession(
+            post_responses=[_FakeResponse(200, {"jwt": "jwt-token"})],
+            request_responses=[_FakeResponse(200, [{"Name": "nexus", "Id": 31}])],
+        )
+        client = PortainerHttpClient(
+            "http://portainer.local",
+            "admin",
+            OPERATOR_CREDENTIAL,
+            session=session,
+        )
+
+        self.assertTrue(client.stack_registered("nexus"))
+        self.assertEqual("http://portainer.local/api/stacks", session.request_calls[0]["url"])
 
     def test_create_stack_uses_extended_stack_request_timeout(self):
         session = _FakeSession(

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -695,7 +695,7 @@ class TestComposition(unittest.TestCase):
         )
         self.assertTrue(
             all(
-                step.endpoint_name == composition.DEFAULT_PORTAINER_ENDPOINT_NAME
+                step.deployment_gateway is services.workflows.bootstrap.steps[2].portainer_client
                 for step in services.workflows.apply.steps
                 if step.verification_target_id.endswith("-stack")
             )


### PR DESCRIPTION
## Summary
- Introduce `PortDeploymentGateway` so deployment orchestration expresses stack intent without Portainer endpoint or stack IDs.
- Move create/update stack mapping behind Portainer infrastructure adapters, including LXC runtime adapter support.
- Update application fakes, adapter tests, architecture checks, docs, and workflow evidence for issue #77.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_ensure_service_stack`
- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_ensure_service_stack tests.application.services.deployment.test_service_stack_plan tests.application.services.deployment.test_ensure_portainer_stack tests.application.services.deployment.test_ensure_nexus_stack tests.infrastructure.adapters.clients.test_portainer_http_client tests.infrastructure.test_composition`
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.clients.test_lxc_swarm_runtime tests.infrastructure.adapters.clients.test_portainer_http_client`
- `python3 tools/quality_gate.py quality`

Closes #77