### PR TITLE
Split oversized composition root helpers

### DIFF
--- a/.codex/evidence/slice-73-consolidation.md
+++ b/.codex/evidence/slice-73-consolidation.md
@@ -1,0 +1,73 @@
+# Slice 73 Consolidation
+
+Workflow id: `issue-73-split-composition-root-20260614`
+Slice id: `S01-S04`
+Slice title: Split oversized composition root
+
+Stream results:
+
+- architecture/runtime: accepted Dewey's facade-compatible extraction plan.
+- tests: preserved existing `composition` import surface and patch points.
+- documentation: updated arc42 and README with the new internal module map.
+
+Accepted findings:
+
+- Keep `composition.py` as the public runtime wiring facade.
+- Extract service bundle dataclasses to `composition_models.py`.
+- Extract fail-closed blocked workflow stubs to
+  `composition_blocked_workflows.py`.
+- Extract provider-selected LXC runtime wrappers and stack asset preparation to
+  `composition_lxc_runtimes.py`.
+
+Rejected findings:
+
+- Full platform/deployment/artifact builder extraction was deferred to avoid a
+  broad behavior-preserving move with higher conflict risk in this slice.
+
+Files changed per stream:
+
+- architecture/runtime: `src/tiny_swarm_world/infrastructure/composition.py`,
+  `src/tiny_swarm_world/infrastructure/composition_models.py`,
+  `src/tiny_swarm_world/infrastructure/composition_blocked_workflows.py`,
+  `src/tiny_swarm_world/infrastructure/composition_lxc_runtimes.py`
+- documentation: `documentation/arc42/05_building_blocks.adoc`,
+  `documentation/arc42/06_runtime_view.adoc`, `README.md`
+- evidence: `.codex/evidence/slice-73-distribution.md`,
+  `.codex/evidence/slice-73-consolidation.md`
+
+Conflicts found:
+
+- `tests.infrastructure.test_composition` patches `composition.LxcContainerDockerRuntime`.
+  The facade import was preserved and the runtime factory is passed into the
+  provider-selected adapter to keep that patch point effective.
+
+Conflicts resolved:
+
+- Corrected the moved runtime module import for `NodeProviderSelectionRequest`.
+- Removed stale imports from `composition.py` after helper extraction.
+
+Tests executed:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition`:
+  passed.
+- `python3 tools/quality_gate.py lint`: passed.
+- `python3 tools/quality_gate.py arch-tests`: passed.
+- `python3 tools/quality_gate.py typecheck`: passed.
+- `python3 tools/quality_gate.py quality`: passed. The full gate executed lint,
+  arch-lint, arch-tests, typecheck, and 876 unit tests with 17 skipped.
+
+SonarQube findings and fixes:
+
+- Pending remote PR lifecycle.
+
+Documentation updates:
+
+- arc42 building blocks and runtime view now describe the public facade and
+  focused internal composition modules.
+- README now points operators and contributors to the `composition_*.py`
+  module family.
+
+Final integration decision:
+
+- Accepted for full local quality gate and PR lifecycle after required checks
+  pass.

--- a/.codex/evidence/slice-73-distribution.md
+++ b/.codex/evidence/slice-73-distribution.md
@@ -1,0 +1,65 @@
+# Slice 73 Distribution
+
+Workflow id: `issue-73-split-composition-root-20260614`
+Slice id: `S01-S04`
+Slice title: Split oversized composition root
+
+Affected areas:
+
+- architecture
+- runtime
+- tests
+- documentation
+
+Chosen execution mode: sequential.
+
+Selected streams:
+
+- architecture/runtime: extract focused internal composition modules while keeping
+  `composition.py` as the public facade.
+- tests: preserve `tests.infrastructure.test_composition` behavior and facade
+  compatibility.
+- documentation: update arc42 and README navigation.
+
+Real subagents used: yes. Dewey provided read-only architecture planning.
+
+Fallback role-based review used: no.
+
+Git worktrees used: no. Parallel stream execution was rejected because the
+composition root, tests, and documentation share the same responsibility
+boundary and file locks.
+
+Expected touched files/directories:
+
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `src/tiny_swarm_world/infrastructure/composition_*.py`
+- `documentation/arc42/**`
+- `README.md`
+- `.codex/evidence/**`
+
+Conflict risks:
+
+- Existing tests patch `tiny_swarm_world.infrastructure.composition` as a stable
+  import facade.
+- Provider selection and live-consent gates must remain fail-closed.
+- Service construction must not run live LXC, Docker, Swarm, Portainer, Nexus,
+  or network commands.
+
+Quality gates to run:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py arch-tests`
+- `python3 tools/quality_gate.py quality`
+
+Consolidation plan:
+
+- Keep public builder names and compatibility aliases in `composition.py`.
+- Extract only internal helper surfaces with no behavior change.
+- Run focused tests first, then full quality before push.
+
+Parallelization decision:
+
+- Rejected. The core work changes a single public facade and its tightly coupled
+  regression test surface, so parallel edits would increase merge risk without
+  reducing implementation risk.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ nodes count as reset/destroy evidence; unrelated provider resources are never
 a supported cleanup target. Direct no-argument construction from the old
 `docker` layout is no longer supported. Use `build_application_services()` for
 the standard local wiring, or pass compatible port implementations in tests.
+The composition root remains the public facade; focused
+`src/tiny_swarm_world/infrastructure/composition_*.py` modules hold
+service-bundle models, fail-closed workflow stubs, and provider-selected LXC
+runtime wiring.
 
 The canonical setup path is the workflow-level Python command. Former direct preparation scripts and host-side compose orchestration
 scripts have been removed so service bootstrap, image publication, and stack

--- a/documentation/arc42/05_building_blocks.adoc
+++ b/documentation/arc42/05_building_blocks.adoc
@@ -22,6 +22,18 @@ application services and keeps `src/tiny_swarm_world/__main__.py` thin. Services
 are constructed with explicit ports and repositories instead of creating
 infrastructure adapters inside the application layer.
 
+`composition.py` remains the public runtime wiring facade. Focused internal
+composition modules keep the root navigable without creating new domain or
+application responsibilities:
+
+* `composition_models.py` contains the service-bundle dataclasses used by the
+  facade and entry point.
+* `composition_blocked_workflows.py` contains fail-closed workflow stubs for
+  unsupported provider selections.
+* `composition_lxc_runtimes.py` contains provider-selected LXC runtime
+  adapters that delegate to concrete Docker, Swarm, and proxy-device adapters
+  only after composed provider selection allows it.
+
 The composition root now exposes separate in-process application service
 bundles. These bundles are responsibility boundaries inside the Python
 automation process; they are not independently deployable services or

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -17,6 +17,13 @@ configuration before returning their explicit contract result. `setup run`
 builds a dedicated `SetupServices` bundle only after accepted live consent and
 delegates all sequencing to the setup application workflow.
 
+The public composition facade delegates focused internal structure to
+`composition_models.py`, `composition_blocked_workflows.py`, and
+`composition_lxc_runtimes.py`. These modules are still infrastructure wiring:
+they do not change CLI behavior, do not move adapter construction into
+application services, and do not execute live commands during service bundle
+construction.
+
 The composition root builds `ApplicationServices` as an aggregate of three
 service bundles:
 

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -5,7 +5,7 @@ import os
 import re
 import shutil
 import subprocess
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from pathlib import Path
 from typing import cast
 from uuid import uuid4
@@ -17,8 +17,6 @@ from tiny_swarm_world.application.services.artifacts import (
     ArtifactVerifyCheck,
     ArtifactVerifyWorkflow,
     ArtifactWorkflowKind,
-    ArtifactWorkflowResult,
-    ArtifactWorkflowStatus,
     EnsureContainerImage,
     EnsureNexusAdminAccess,
     EnsureNexusDockerHostedRepository,
@@ -32,8 +30,6 @@ from tiny_swarm_world.application.services.artifacts import (
 from tiny_swarm_world.application.services.deployment import (
     DeploymentApplyWorkflow,
     DeploymentWorkflowKind,
-    DeploymentWorkflowResult,
-    DeploymentWorkflowStatus,
     DeploymentVerifyWorkflow,
     EnsureInfisicalSilentInstall,
     EnsureInfisicalSecretItems,
@@ -54,14 +50,6 @@ from tiny_swarm_world.application.services.deployment.workflows import Deploymen
 from tiny_swarm_world.application.services.deployment.service_stack_plan import (
     DEFAULT_PORTAINER_ENDPOINT_NAME,
     build_service_stack_steps,
-)
-from tiny_swarm_world.application.ports.node_provider import (
-    LxcProxyDriftRepairOutcome,
-    LxcProxyDeviceState,
-    PortContainerDockerRuntime,
-    PortContainerNetworkIdentity,
-    PortContainerSwarmBootstrap,
-    PortLxcProxyDeviceRuntime,
 )
 from tiny_swarm_world.application.ports.progress import PortWorkflowProgress
 from tiny_swarm_world.application.ports.repositories.port_compose_file_repository import (
@@ -114,25 +102,15 @@ from tiny_swarm_world.domain.deployment import (
     service_stack_contracts_for_profile,
 )
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
-from tiny_swarm_world.domain.network import LxcProxyDevicePlan
 from tiny_swarm_world.domain.network.port_forwarding_plan import (
     ForwardingStrategy,
     PortForwardingPlan,
 )
 from tiny_swarm_world.domain.node_provider import (
-    ContainerDockerInstallOutcome,
-    ContainerDockerReadiness,
-    DockerEngineState,
-    DockerInstallState,
     ManagedLxcBackend,
     NodeProviderKind,
     NodeRole,
     NodeSpec,
-    SwarmManagerBootstrapOutcome,
-    SwarmManagerState,
-    SwarmWorkerJoinCredential,
-    SwarmWorkerJoinOutcome,
-    WorkerJoinState,
 )
 from tiny_swarm_world.domain.preflight import (
     LiveConsent,
@@ -145,16 +123,11 @@ from tiny_swarm_world.domain.preflight import (
 from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import CommandWorkflow
 from tiny_swarm_world.infrastructure.adapters.clients.lxc_node_provider import (
     AsyncLxcNodeCommandRunner,
-    LxcNodeCommandRunner,
     LxcNodeProvider,
 )
 from tiny_swarm_world.infrastructure.adapters.clients.lxc_container_docker_runtime import (
     DockerRegistryMirrorConfiguration,
     LxcContainerDockerRuntime,
-)
-from tiny_swarm_world.infrastructure.adapters.clients.lxc_container_swarm_bootstrap import (
-    LxcContainerNetworkIdentity,
-    LxcContainerSwarmBootstrap,
 )
 from tiny_swarm_world.infrastructure.adapters.clients.lxc_proxy_device_runtime import (
     LxcProxyDeviceRuntime,
@@ -210,6 +183,28 @@ from tiny_swarm_world.infrastructure.logging.progress_trace_logging import (
     CompositeWorkflowProgress,
     LoggingMethodTrace,
     LoggingWorkflowProgress,
+)
+from tiny_swarm_world.infrastructure.composition_blocked_workflows import (
+    BlockedArtifactWorkflow,
+    BlockedDeploymentWorkflow,
+)
+from tiny_swarm_world.infrastructure.composition_lxc_runtimes import (
+    PrepareLxcStackAssets,
+    ProviderSelectedLxcDockerRuntime,
+    ProviderSelectedLxcProxyDeviceRuntime,
+    ProviderSelectedLxcSwarmRuntime,
+    selected_lxc_backend,
+)
+from tiny_swarm_world.infrastructure.composition_models import (
+    ApplicationServices,
+    ArtifactServices,
+    ArtifactWorkflows,
+    DeploymentServices,
+    DeploymentWorkflows,
+    PlatformServices,
+    PlatformWorkflows,
+    SetupServices,
+    SetupWorkflows,
 )
 
 
@@ -271,116 +266,13 @@ LXC_RECONCILE_VERIFIED_MESSAGE = (
 )
 
 
-@dataclass(frozen=True)
-class PlatformWorkflows:
-    init: PlatformInitWorkflow
-    reconcile: PlatformReconcileWorkflow
-    expose: PlatformExposeWorkflow
-    repair_lxc_proxy_drift: PlatformRepairLxcProxyDriftWorkflow
-    reset: PlatformResetWorkflow
-    destroy: PlatformDestroyWorkflow
-    verify: PlatformVerifyWorkflow
-
-
-@dataclass(frozen=True)
-class PlatformServices:
-    command_workflow: CommandWorkflow
-    lxc_docker_install: LxcDockerInstallService
-    lxc_proxy_drift_repair: LxcProxyDriftRepairService
-    lxc_service_exposure: LxcServiceExposureService
-    lxc_swarm_bootstrap: LxcSwarmBootstrapService
-    preflight: PreflightService
-    lxc_node_provider: LxcNodeProvider
-    node_provider_selection: NodeProviderSelectionService
-    socat_manager: SocatManager
-    workflows: PlatformWorkflows
-
-
-@dataclass(frozen=True)
-class ArtifactWorkflows:
-    prepare: ArtifactPrepareWorkflow
-    verify: ArtifactVerifyWorkflow
-
-
-@dataclass(frozen=True)
-class ArtifactServices:
-    workflows: ArtifactWorkflows
-
-
-@dataclass(frozen=True)
-class DeploymentWorkflows:
-    bootstrap: DeploymentApplyWorkflow
-    apply: DeploymentApplyWorkflow
-    verify: DeploymentVerifyWorkflow
-
-
-@dataclass(frozen=True)
-class DeploymentServices:
-    workflows: DeploymentWorkflows
-
-
-@dataclass(frozen=True)
-class SetupWorkflows:
-    run: SetupWorkflow
-
-
-@dataclass(frozen=True)
-class SetupServices:
-    workflows: SetupWorkflows
-
-
-@dataclass(frozen=True)
-class ApplicationServices:
-    platform: PlatformServices
-    artifacts: ArtifactServices
-    deployment: DeploymentServices
-
-    @property
-    def preflight(self) -> PreflightService:
-        return self.platform.preflight
-
-    @property
-    def socat_manager(self) -> SocatManager:
-        return self.platform.socat_manager
-
-
-class _BlockedArtifactWorkflow:
-    def __init__(self, kind: ArtifactWorkflowKind, reason: str):
-        self.kind = kind
-        self.reason = reason
-        self.steps = ()
-        self.checks = ()
-
-    async def run(self) -> ArtifactWorkflowResult:
-        await asyncio.sleep(0)
-        return ArtifactWorkflowResult(
-            kind=self.kind,
-            status=ArtifactWorkflowStatus.BLOCKED,
-            message=(
-                f"artifacts {self.kind.value} is blocked for the selected node provider."
-            ),
-            reason=self.reason,
-        )
-
-
-class _BlockedDeploymentWorkflow:
-    def __init__(self, kind: DeploymentWorkflowKind, reason: str):
-        self.kind = kind
-        self.reason = reason
-        self.steps = ()
-        self.pre_apply_checks = ()
-        self.checks = ()
-
-    async def run(self) -> DeploymentWorkflowResult:
-        await asyncio.sleep(0)
-        return DeploymentWorkflowResult(
-            kind=self.kind,
-            status=DeploymentWorkflowStatus.BLOCKED,
-            message=(
-                f"deployment {self.kind.value} is blocked for the selected node provider."
-            ),
-            reason=self.reason,
-        )
+_BlockedArtifactWorkflow = BlockedArtifactWorkflow
+_BlockedDeploymentWorkflow = BlockedDeploymentWorkflow
+_ProviderSelectedLxcDockerRuntime = ProviderSelectedLxcDockerRuntime
+_ProviderSelectedLxcSwarmRuntime = ProviderSelectedLxcSwarmRuntime
+_PrepareLxcStackAssets = PrepareLxcStackAssets
+_ProviderSelectedLxcProxyDeviceRuntime = ProviderSelectedLxcProxyDeviceRuntime
+_selected_lxc_backend = selected_lxc_backend
 
 
 class _BlockedPlatformProviderStep:
@@ -535,303 +427,6 @@ class _WslSocatExposeStep:
                 "failed_count": str(failed_count),
             },
         )
-
-
-class _ProviderSelectedLxcDockerRuntime(PortContainerDockerRuntime):
-    def __init__(
-        self,
-        *,
-        provider_selection: NodeProviderSelectionService,
-        provider_request: NodeProviderSelectionRequest,
-        runner: LxcNodeCommandRunner,
-        allow_live_mutation: bool,
-        allow_live_inspection: bool = False,
-    ) -> None:
-        self.provider_selection = provider_selection
-        self.provider_request = provider_request
-        self.runner = runner
-        self.allow_live_mutation = allow_live_mutation
-        self.allow_live_inspection = allow_live_inspection
-
-    async def inspect_docker(self, node: NodeSpec) -> ContainerDockerReadiness:
-        if not self.allow_live_mutation and not self.allow_live_inspection:
-            return ContainerDockerReadiness(
-                node=node,
-                observed=False,
-                engine_state=DockerEngineState.UNKNOWN,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return ContainerDockerReadiness(
-                node=node,
-                observed=False,
-                engine_state=DockerEngineState.UNKNOWN,
-            )
-        return await delegate.inspect_docker(node)
-
-    async def install_docker(self, node: NodeSpec) -> ContainerDockerInstallOutcome:
-        if not self.allow_live_mutation:
-            return ContainerDockerInstallOutcome(
-                node=node,
-                state=DockerInstallState.FAILED,
-                verified=False,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return ContainerDockerInstallOutcome(
-                node=node,
-                state=DockerInstallState.FAILED,
-                verified=False,
-            )
-        return await delegate.install_docker(node)
-
-    async def verify_docker(self, node: NodeSpec) -> ContainerDockerReadiness:
-        if not self.allow_live_mutation and not self.allow_live_inspection:
-            return ContainerDockerReadiness(
-                node=node,
-                observed=False,
-                engine_state=DockerEngineState.UNKNOWN,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return ContainerDockerReadiness(
-                node=node,
-                observed=False,
-                engine_state=DockerEngineState.UNKNOWN,
-            )
-        return await delegate.verify_docker(node)
-
-    async def _delegate(self) -> LxcContainerDockerRuntime | None:
-        backend = await _selected_lxc_backend(
-            self.provider_selection,
-            self.provider_request,
-        )
-        if backend is None:
-            return None
-        return LxcContainerDockerRuntime(
-            backend=backend,
-            runner=self.runner,
-            allow_live_mutation=self.allow_live_mutation,
-            registry_mirror=_lxc_docker_registry_mirror_configuration(),
-        )
-
-
-class _ProviderSelectedLxcSwarmRuntime(
-    PortContainerNetworkIdentity,
-    PortContainerSwarmBootstrap,
-):
-    def __init__(
-        self,
-        *,
-        provider_selection: NodeProviderSelectionService,
-        provider_request: NodeProviderSelectionRequest,
-        runner: LxcNodeCommandRunner,
-        allow_live_mutation: bool,
-        allow_live_inspection: bool = False,
-    ) -> None:
-        self.provider_selection = provider_selection
-        self.provider_request = provider_request
-        self.runner = runner
-        self.allow_live_mutation = allow_live_mutation
-        self.allow_live_inspection = allow_live_inspection
-
-    async def manager_advertise_address(self, node: NodeSpec) -> str:
-        if not self.allow_live_mutation:
-            return ""
-        backend = await _selected_lxc_backend(
-            self.provider_selection,
-            self.provider_request,
-        )
-        if backend is None:
-            return ""
-        return await LxcContainerNetworkIdentity(
-            backend=backend,
-            runner=self.runner,
-        ).manager_advertise_address(node)
-
-    async def inspect_manager(self, node: NodeSpec) -> SwarmManagerBootstrapOutcome:
-        if not self.allow_live_mutation and not self.allow_live_inspection:
-            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.UNKNOWN)
-        delegate = await self._delegate()
-        if delegate is None:
-            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.UNKNOWN)
-        return await delegate.inspect_manager(node)
-
-    async def initialize_manager(
-        self,
-        node: NodeSpec,
-        advertise_address: str,
-    ) -> SwarmManagerBootstrapOutcome:
-        if not self.allow_live_mutation:
-            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.ERROR)
-        delegate = await self._delegate()
-        if delegate is None:
-            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.ERROR)
-        return await delegate.initialize_manager(node, advertise_address)
-
-    async def worker_join_credential(self, node: NodeSpec) -> SwarmWorkerJoinCredential:
-        if not self.allow_live_mutation:
-            return SwarmWorkerJoinCredential("<unavailable>")
-        delegate = await self._delegate()
-        if delegate is None:
-            return SwarmWorkerJoinCredential("<unavailable>")
-        return await delegate.worker_join_credential(node)
-
-    async def inspect_worker(self, node: NodeSpec) -> SwarmWorkerJoinOutcome:
-        if not self.allow_live_mutation and not self.allow_live_inspection:
-            return SwarmWorkerJoinOutcome(
-                node=node,
-                state=WorkerJoinState.UNKNOWN,
-                verified=False,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return SwarmWorkerJoinOutcome(
-                node=node,
-                state=WorkerJoinState.UNKNOWN,
-                verified=False,
-            )
-        return await delegate.inspect_worker(node)
-
-    async def join_worker(
-        self,
-        node: NodeSpec,
-        manager_address: str,
-        credential: SwarmWorkerJoinCredential,
-    ) -> SwarmWorkerJoinOutcome:
-        if not self.allow_live_mutation:
-            return SwarmWorkerJoinOutcome(
-                node=node,
-                state=WorkerJoinState.FAILED,
-                verified=False,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return SwarmWorkerJoinOutcome(
-                node=node,
-                state=WorkerJoinState.FAILED,
-                verified=False,
-            )
-        return await delegate.join_worker(node, manager_address, credential)
-
-    async def _delegate(self) -> LxcContainerSwarmBootstrap | None:
-        backend = await _selected_lxc_backend(
-            self.provider_selection,
-            self.provider_request,
-        )
-        if backend is None:
-            return None
-        return LxcContainerSwarmBootstrap(
-            backend=backend,
-            runner=self.runner,
-            allow_live_mutation=self.allow_live_mutation,
-        )
-
-
-class _PrepareLxcStackAssets:
-    def __init__(self, swarm_runtime: LxcSwarmRuntime, stack_name: str) -> None:
-        self.swarm_runtime = swarm_runtime
-        self.stack_name = stack_name
-        self.deployment_target_id = f"deployment:{stack_name}-stack-assets"
-
-    def run(self) -> None:
-        self.swarm_runtime.prepare_stack_assets(self.stack_name)
-
-
-class _ProviderSelectedLxcProxyDeviceRuntime(PortLxcProxyDeviceRuntime):
-    def __init__(
-        self,
-        *,
-        provider_selection: NodeProviderSelectionService,
-        provider_request: NodeProviderSelectionRequest,
-        runner: LxcNodeCommandRunner,
-        allow_live_mutation: bool,
-        allow_live_inspection: bool = False,
-    ) -> None:
-        self.provider_selection = provider_selection
-        self.provider_request = provider_request
-        self.runner = runner
-        self.allow_live_mutation = allow_live_mutation
-        self.allow_live_inspection = allow_live_inspection
-
-    async def inspect_proxy_device(
-        self,
-        profile_name: str,
-        plan: LxcProxyDevicePlan,
-    ) -> LxcProxyDeviceState:
-        if not self.allow_live_mutation and not self.allow_live_inspection:
-            return LxcProxyDeviceState.UNKNOWN
-        delegate = await self._delegate()
-        if delegate is None:
-            return LxcProxyDeviceState.UNKNOWN
-        return await delegate.inspect_proxy_device(profile_name, plan)
-
-    async def create_proxy_device(
-        self,
-        profile_name: str,
-        plan: LxcProxyDevicePlan,
-    ) -> bool:
-        delegate = await self._delegate()
-        if delegate is None:
-            return False
-        return await delegate.create_proxy_device(profile_name, plan)
-
-    async def update_proxy_device(
-        self,
-        profile_name: str,
-        plan: LxcProxyDevicePlan,
-    ) -> bool:
-        delegate = await self._delegate()
-        if delegate is None:
-            return False
-        return await delegate.update_proxy_device(profile_name, plan)
-
-    async def repair_stale_proxy_devices(
-        self,
-        profile_name: str,
-        gateway_node: NodeSpec,
-        plans: tuple[LxcProxyDevicePlan, ...],
-    ) -> LxcProxyDriftRepairOutcome:
-        if not self.allow_live_mutation:
-            return LxcProxyDriftRepairOutcome(
-                expected_profile_device_count=len(plans),
-                mutation_allowed=False,
-            )
-        delegate = await self._delegate()
-        if delegate is None:
-            return LxcProxyDriftRepairOutcome(
-                expected_profile_device_count=len(plans),
-                lookup_failure_count=len(plans),
-                failed_devices=tuple(plan.device_name for plan in plans),
-            )
-        return await delegate.repair_stale_proxy_devices(
-            profile_name,
-            gateway_node,
-            plans,
-        )
-
-    async def _delegate(self) -> LxcProxyDeviceRuntime | None:
-        backend = await _selected_lxc_backend(
-            self.provider_selection,
-            self.provider_request,
-        )
-        if backend is None:
-            return None
-        return LxcProxyDeviceRuntime(
-            backend=backend,
-            runner=self.runner,
-            allow_live_mutation=self.allow_live_mutation,
-        )
-
-
-async def _selected_lxc_backend(
-    provider_selection: NodeProviderSelectionService,
-    provider_request: NodeProviderSelectionRequest,
-) -> ManagedLxcBackend | None:
-    selection = await provider_selection.select_provider(provider_request)
-    if selection.blocks_mutation or selection.backend_selection is None:
-        return None
-    return selection.backend_selection.backend
 
 
 def configure_infrastructure_container() -> None:
@@ -999,6 +594,8 @@ def build_platform_services(
         provider_request=provider_request,
         runner=lxc_runner,
         allow_live_mutation=False if live_consent is None else live_consent.accepted,
+        registry_mirror_configuration=_lxc_docker_registry_mirror_configuration,
+        docker_runtime_factory=LxcContainerDockerRuntime,
     )
     lxc_docker_install = LxcDockerInstallService(lxc_docker_runtime)
     lxc_docker_verify = LxcDockerInstallService(
@@ -1008,6 +605,8 @@ def build_platform_services(
             runner=lxc_runner,
             allow_live_mutation=False,
             allow_live_inspection=True,
+            registry_mirror_configuration=_lxc_docker_registry_mirror_configuration,
+            docker_runtime_factory=LxcContainerDockerRuntime,
         )
     )
     lxc_swarm_runtime = _ProviderSelectedLxcSwarmRuntime(
@@ -1015,6 +614,7 @@ def build_platform_services(
         provider_request=provider_request,
         runner=lxc_runner,
         allow_live_mutation=False if live_consent is None else live_consent.accepted,
+        proxy_runtime_factory=LxcProxyDeviceRuntime,
     )
     lxc_swarm_bootstrap = LxcSwarmBootstrapService(
         lxc_swarm_runtime,
@@ -1027,6 +627,7 @@ def build_platform_services(
             runner=lxc_runner,
             allow_live_mutation=False,
             allow_live_inspection=True,
+            proxy_runtime_factory=LxcProxyDeviceRuntime,
         ),
         lxc_swarm_runtime,
     )

--- a/src/tiny_swarm_world/infrastructure/composition_blocked_workflows.py
+++ b/src/tiny_swarm_world/infrastructure/composition_blocked_workflows.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import asyncio
+
+from tiny_swarm_world.application.services.artifacts import (
+    ArtifactWorkflowKind,
+    ArtifactWorkflowResult,
+    ArtifactWorkflowStatus,
+)
+from tiny_swarm_world.application.services.deployment import (
+    DeploymentWorkflowKind,
+    DeploymentWorkflowResult,
+    DeploymentWorkflowStatus,
+)
+
+
+class BlockedArtifactWorkflow:
+    def __init__(self, kind: ArtifactWorkflowKind, reason: str):
+        self.kind = kind
+        self.reason = reason
+        self.steps = ()
+        self.checks = ()
+
+    async def run(self) -> ArtifactWorkflowResult:
+        await asyncio.sleep(0)
+        return ArtifactWorkflowResult(
+            kind=self.kind,
+            status=ArtifactWorkflowStatus.BLOCKED,
+            message=(
+                f"artifacts {self.kind.value} is blocked for the selected node provider."
+            ),
+            reason=self.reason,
+        )
+
+
+class BlockedDeploymentWorkflow:
+    def __init__(self, kind: DeploymentWorkflowKind, reason: str):
+        self.kind = kind
+        self.reason = reason
+        self.steps = ()
+        self.pre_apply_checks = ()
+        self.checks = ()
+
+    async def run(self) -> DeploymentWorkflowResult:
+        await asyncio.sleep(0)
+        return DeploymentWorkflowResult(
+            kind=self.kind,
+            status=DeploymentWorkflowStatus.BLOCKED,
+            message=(
+                f"deployment {self.kind.value} is blocked for the selected node provider."
+            ),
+            reason=self.reason,
+        )

--- a/src/tiny_swarm_world/infrastructure/composition_lxc_runtimes.py
+++ b/src/tiny_swarm_world/infrastructure/composition_lxc_runtimes.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tiny_swarm_world.application.ports.node_provider import (
+    LxcProxyDriftRepairOutcome,
+    LxcProxyDeviceState,
+    PortContainerDockerRuntime,
+    PortContainerNetworkIdentity,
+    PortContainerSwarmBootstrap,
+    PortLxcProxyDeviceRuntime,
+)
+from tiny_swarm_world.application.services.platform import (
+    NodeProviderSelectionRequest,
+    NodeProviderSelectionService,
+)
+from tiny_swarm_world.domain.network import LxcProxyDevicePlan
+from tiny_swarm_world.domain.node_provider import (
+    ContainerDockerInstallOutcome,
+    ContainerDockerReadiness,
+    DockerEngineState,
+    DockerInstallState,
+    ManagedLxcBackend,
+    NodeSpec,
+    SwarmManagerBootstrapOutcome,
+    SwarmManagerState,
+    SwarmWorkerJoinCredential,
+    SwarmWorkerJoinOutcome,
+    WorkerJoinState,
+)
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_container_docker_runtime import (
+    DockerRegistryMirrorConfiguration,
+    LxcContainerDockerRuntime,
+)
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_container_swarm_bootstrap import (
+    LxcContainerNetworkIdentity,
+    LxcContainerSwarmBootstrap,
+)
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_node_provider import LxcNodeCommandRunner
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_proxy_device_runtime import (
+    LxcProxyDeviceRuntime,
+)
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_swarm_runtime import LxcSwarmRuntime
+
+
+class ProviderSelectedLxcDockerRuntime(PortContainerDockerRuntime):
+    def __init__(
+        self,
+        *,
+        provider_selection: NodeProviderSelectionService,
+        provider_request: NodeProviderSelectionRequest,
+        runner: LxcNodeCommandRunner,
+        allow_live_mutation: bool,
+        allow_live_inspection: bool = False,
+        registry_mirror_configuration: Callable[
+            [],
+            DockerRegistryMirrorConfiguration | None,
+        ]
+        | None = None,
+        docker_runtime_factory: type[LxcContainerDockerRuntime] = LxcContainerDockerRuntime,
+    ) -> None:
+        self.provider_selection = provider_selection
+        self.provider_request = provider_request
+        self.runner = runner
+        self.allow_live_mutation = allow_live_mutation
+        self.allow_live_inspection = allow_live_inspection
+        self.registry_mirror_configuration = registry_mirror_configuration
+        self.docker_runtime_factory = docker_runtime_factory
+
+    async def inspect_docker(self, node: NodeSpec) -> ContainerDockerReadiness:
+        if not self.allow_live_mutation and not self.allow_live_inspection:
+            return ContainerDockerReadiness(
+                node=node,
+                observed=False,
+                engine_state=DockerEngineState.UNKNOWN,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return ContainerDockerReadiness(
+                node=node,
+                observed=False,
+                engine_state=DockerEngineState.UNKNOWN,
+            )
+        return await delegate.inspect_docker(node)
+
+    async def install_docker(self, node: NodeSpec) -> ContainerDockerInstallOutcome:
+        if not self.allow_live_mutation:
+            return ContainerDockerInstallOutcome(
+                node=node,
+                state=DockerInstallState.FAILED,
+                verified=False,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return ContainerDockerInstallOutcome(
+                node=node,
+                state=DockerInstallState.FAILED,
+                verified=False,
+            )
+        return await delegate.install_docker(node)
+
+    async def verify_docker(self, node: NodeSpec) -> ContainerDockerReadiness:
+        if not self.allow_live_mutation and not self.allow_live_inspection:
+            return ContainerDockerReadiness(
+                node=node,
+                observed=False,
+                engine_state=DockerEngineState.UNKNOWN,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return ContainerDockerReadiness(
+                node=node,
+                observed=False,
+                engine_state=DockerEngineState.UNKNOWN,
+            )
+        return await delegate.verify_docker(node)
+
+    async def _delegate(self) -> LxcContainerDockerRuntime | None:
+        backend = await selected_lxc_backend(
+            self.provider_selection,
+            self.provider_request,
+        )
+        if backend is None:
+            return None
+        registry_mirror = (
+            self.registry_mirror_configuration()
+            if self.registry_mirror_configuration is not None
+            else None
+        )
+        return self.docker_runtime_factory(
+            backend=backend,
+            runner=self.runner,
+            allow_live_mutation=self.allow_live_mutation,
+            registry_mirror=registry_mirror,
+        )
+
+
+class ProviderSelectedLxcSwarmRuntime(
+    PortContainerNetworkIdentity,
+    PortContainerSwarmBootstrap,
+):
+    def __init__(
+        self,
+        *,
+        provider_selection: NodeProviderSelectionService,
+        provider_request: NodeProviderSelectionRequest,
+        runner: LxcNodeCommandRunner,
+        allow_live_mutation: bool,
+        allow_live_inspection: bool = False,
+        proxy_runtime_factory: type[LxcProxyDeviceRuntime] = LxcProxyDeviceRuntime,
+    ) -> None:
+        self.provider_selection = provider_selection
+        self.provider_request = provider_request
+        self.runner = runner
+        self.allow_live_mutation = allow_live_mutation
+        self.allow_live_inspection = allow_live_inspection
+        self.proxy_runtime_factory = proxy_runtime_factory
+
+    async def manager_advertise_address(self, node: NodeSpec) -> str:
+        if not self.allow_live_mutation:
+            return ""
+        backend = await selected_lxc_backend(
+            self.provider_selection,
+            self.provider_request,
+        )
+        if backend is None:
+            return ""
+        return await LxcContainerNetworkIdentity(
+            backend=backend,
+            runner=self.runner,
+        ).manager_advertise_address(node)
+
+    async def inspect_manager(self, node: NodeSpec) -> SwarmManagerBootstrapOutcome:
+        if not self.allow_live_mutation and not self.allow_live_inspection:
+            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.UNKNOWN)
+        delegate = await self._delegate()
+        if delegate is None:
+            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.UNKNOWN)
+        return await delegate.inspect_manager(node)
+
+    async def initialize_manager(
+        self,
+        node: NodeSpec,
+        advertise_address: str,
+    ) -> SwarmManagerBootstrapOutcome:
+        if not self.allow_live_mutation:
+            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.ERROR)
+        delegate = await self._delegate()
+        if delegate is None:
+            return SwarmManagerBootstrapOutcome(node=node, state=SwarmManagerState.ERROR)
+        return await delegate.initialize_manager(node, advertise_address)
+
+    async def worker_join_credential(self, node: NodeSpec) -> SwarmWorkerJoinCredential:
+        if not self.allow_live_mutation:
+            return SwarmWorkerJoinCredential("<unavailable>")
+        delegate = await self._delegate()
+        if delegate is None:
+            return SwarmWorkerJoinCredential("<unavailable>")
+        return await delegate.worker_join_credential(node)
+
+    async def inspect_worker(self, node: NodeSpec) -> SwarmWorkerJoinOutcome:
+        if not self.allow_live_mutation and not self.allow_live_inspection:
+            return SwarmWorkerJoinOutcome(
+                node=node,
+                state=WorkerJoinState.UNKNOWN,
+                verified=False,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return SwarmWorkerJoinOutcome(
+                node=node,
+                state=WorkerJoinState.UNKNOWN,
+                verified=False,
+            )
+        return await delegate.inspect_worker(node)
+
+    async def join_worker(
+        self,
+        node: NodeSpec,
+        manager_address: str,
+        credential: SwarmWorkerJoinCredential,
+    ) -> SwarmWorkerJoinOutcome:
+        if not self.allow_live_mutation:
+            return SwarmWorkerJoinOutcome(
+                node=node,
+                state=WorkerJoinState.FAILED,
+                verified=False,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return SwarmWorkerJoinOutcome(
+                node=node,
+                state=WorkerJoinState.FAILED,
+                verified=False,
+            )
+        return await delegate.join_worker(node, manager_address, credential)
+
+    async def _delegate(self) -> LxcContainerSwarmBootstrap | None:
+        backend = await selected_lxc_backend(
+            self.provider_selection,
+            self.provider_request,
+        )
+        if backend is None:
+            return None
+        return LxcContainerSwarmBootstrap(
+            backend=backend,
+            runner=self.runner,
+            allow_live_mutation=self.allow_live_mutation,
+        )
+
+
+class PrepareLxcStackAssets:
+    def __init__(self, swarm_runtime: LxcSwarmRuntime, stack_name: str) -> None:
+        self.swarm_runtime = swarm_runtime
+        self.stack_name = stack_name
+        self.deployment_target_id = f"deployment:{stack_name}-stack-assets"
+
+    def run(self) -> None:
+        self.swarm_runtime.prepare_stack_assets(self.stack_name)
+
+
+class ProviderSelectedLxcProxyDeviceRuntime(PortLxcProxyDeviceRuntime):
+    def __init__(
+        self,
+        *,
+        provider_selection: NodeProviderSelectionService,
+        provider_request: NodeProviderSelectionRequest,
+        runner: LxcNodeCommandRunner,
+        allow_live_mutation: bool,
+        allow_live_inspection: bool = False,
+        proxy_runtime_factory: type[LxcProxyDeviceRuntime] = LxcProxyDeviceRuntime,
+    ) -> None:
+        self.provider_selection = provider_selection
+        self.provider_request = provider_request
+        self.runner = runner
+        self.allow_live_mutation = allow_live_mutation
+        self.allow_live_inspection = allow_live_inspection
+        self.proxy_runtime_factory = proxy_runtime_factory
+
+    async def inspect_proxy_device(
+        self,
+        profile_name: str,
+        plan: LxcProxyDevicePlan,
+    ) -> LxcProxyDeviceState:
+        if not self.allow_live_mutation and not self.allow_live_inspection:
+            return LxcProxyDeviceState.UNKNOWN
+        delegate = await self._delegate()
+        if delegate is None:
+            return LxcProxyDeviceState.UNKNOWN
+        return await delegate.inspect_proxy_device(profile_name, plan)
+
+    async def create_proxy_device(
+        self,
+        profile_name: str,
+        plan: LxcProxyDevicePlan,
+    ) -> bool:
+        delegate = await self._delegate()
+        if delegate is None:
+            return False
+        return await delegate.create_proxy_device(profile_name, plan)
+
+    async def update_proxy_device(
+        self,
+        profile_name: str,
+        plan: LxcProxyDevicePlan,
+    ) -> bool:
+        delegate = await self._delegate()
+        if delegate is None:
+            return False
+        return await delegate.update_proxy_device(profile_name, plan)
+
+    async def repair_stale_proxy_devices(
+        self,
+        profile_name: str,
+        gateway_node: NodeSpec,
+        plans: tuple[LxcProxyDevicePlan, ...],
+    ) -> LxcProxyDriftRepairOutcome:
+        if not self.allow_live_mutation:
+            return LxcProxyDriftRepairOutcome(
+                expected_profile_device_count=len(plans),
+                mutation_allowed=False,
+            )
+        delegate = await self._delegate()
+        if delegate is None:
+            return LxcProxyDriftRepairOutcome(
+                expected_profile_device_count=len(plans),
+                lookup_failure_count=len(plans),
+                failed_devices=tuple(plan.device_name for plan in plans),
+            )
+        return await delegate.repair_stale_proxy_devices(
+            profile_name,
+            gateway_node,
+            plans,
+        )
+
+    async def _delegate(self) -> LxcProxyDeviceRuntime | None:
+        backend = await selected_lxc_backend(
+            self.provider_selection,
+            self.provider_request,
+        )
+        if backend is None:
+            return None
+        return self.proxy_runtime_factory(
+            backend=backend,
+            runner=self.runner,
+            allow_live_mutation=self.allow_live_mutation,
+        )
+
+
+async def selected_lxc_backend(
+    provider_selection: NodeProviderSelectionService,
+    provider_request: NodeProviderSelectionRequest,
+) -> ManagedLxcBackend | None:
+    selection = await provider_selection.select_provider(provider_request)
+    if selection.blocks_mutation or selection.backend_selection is None:
+        return None
+    return selection.backend_selection.backend

--- a/src/tiny_swarm_world/infrastructure/composition_models.py
+++ b/src/tiny_swarm_world/infrastructure/composition_models.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tiny_swarm_world.application.services.artifacts import (
+    ArtifactPrepareWorkflow,
+    ArtifactVerifyWorkflow,
+)
+from tiny_swarm_world.application.services.deployment import (
+    DeploymentApplyWorkflow,
+    DeploymentVerifyWorkflow,
+)
+from tiny_swarm_world.application.services.platform import (
+    LxcDockerInstallService,
+    LxcProxyDriftRepairService,
+    LxcServiceExposureService,
+    LxcSwarmBootstrapService,
+    PlatformDestroyWorkflow,
+    PlatformExposeWorkflow,
+    PlatformInitWorkflow,
+    PlatformReconcileWorkflow,
+    PlatformRepairLxcProxyDriftWorkflow,
+    PlatformResetWorkflow,
+    PlatformVerifyWorkflow,
+    PreflightService,
+    SocatManager,
+)
+from tiny_swarm_world.application.services.setup import SetupWorkflow
+from tiny_swarm_world.infrastructure.adapters.clients.lxc_node_provider import LxcNodeProvider
+from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import CommandWorkflow
+from tiny_swarm_world.application.services.platform import NodeProviderSelectionService
+
+
+@dataclass(frozen=True)
+class PlatformWorkflows:
+    init: PlatformInitWorkflow
+    reconcile: PlatformReconcileWorkflow
+    expose: PlatformExposeWorkflow
+    repair_lxc_proxy_drift: PlatformRepairLxcProxyDriftWorkflow
+    reset: PlatformResetWorkflow
+    destroy: PlatformDestroyWorkflow
+    verify: PlatformVerifyWorkflow
+
+
+@dataclass(frozen=True)
+class PlatformServices:
+    command_workflow: CommandWorkflow
+    lxc_docker_install: LxcDockerInstallService
+    lxc_proxy_drift_repair: LxcProxyDriftRepairService
+    lxc_service_exposure: LxcServiceExposureService
+    lxc_swarm_bootstrap: LxcSwarmBootstrapService
+    preflight: PreflightService
+    lxc_node_provider: LxcNodeProvider
+    node_provider_selection: NodeProviderSelectionService
+    socat_manager: SocatManager
+    workflows: PlatformWorkflows
+
+
+@dataclass(frozen=True)
+class ArtifactWorkflows:
+    prepare: ArtifactPrepareWorkflow
+    verify: ArtifactVerifyWorkflow
+
+
+@dataclass(frozen=True)
+class ArtifactServices:
+    workflows: ArtifactWorkflows
+
+
+@dataclass(frozen=True)
+class DeploymentWorkflows:
+    bootstrap: DeploymentApplyWorkflow
+    apply: DeploymentApplyWorkflow
+    verify: DeploymentVerifyWorkflow
+
+
+@dataclass(frozen=True)
+class DeploymentServices:
+    workflows: DeploymentWorkflows
+
+
+@dataclass(frozen=True)
+class SetupWorkflows:
+    run: SetupWorkflow
+
+
+@dataclass(frozen=True)
+class SetupServices:
+    workflows: SetupWorkflows
+
+
+@dataclass(frozen=True)
+class ApplicationServices:
+    platform: PlatformServices
+    artifacts: ArtifactServices
+    deployment: DeploymentServices
+
+    @property
+    def preflight(self) -> PreflightService:
+        return self.platform.preflight
+
+    @property
+    def socat_manager(self) -> SocatManager:
+        return self.platform.socat_manager


### PR DESCRIPTION
## Summary
- Keep `composition.py` as the public runtime wiring facade while extracting focused internal helpers.
- Move service bundle dataclasses, blocked workflow stubs, and provider-selected LXC runtime wrappers into `composition_*.py` modules.
- Preserve facade patch points used by existing composition tests and document the new module map.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.test_composition`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py arch-tests`
- `python3 tools/quality_gate.py typecheck`
- `python3 tools/quality_gate.py quality`

Closes #73