### PR TITLE
Define console status evidence contract

### DIFF
--- a/.codex/evidence/slice-83-consolidation.md
+++ b/.codex/evidence/slice-83-consolidation.md
@@ -1,0 +1,69 @@
+# Slice 83 Consolidation
+
+Workflow id: `issue-83-ui-status-evidence-contract-20260614`
+Slice id: `S01-S04`
+Slice title: Define the status and evidence contract consumed by the console UI
+
+Stream results:
+
+- application contract: added `ConsoleStatusEvent` and `PortUI.update_status_event`.
+- workflow progress: added optional safe `evidence_path`, `correlation_id`,
+  and `trace_id` fields and mapped progress events into console status events.
+- console UI: Linux terminal rendering now reads supplied recovery, evidence,
+  and correlation fields from UI status state.
+- tests: added Linux UI tests for event ingestion and event-only rendering.
+- documentation: updated runtime view and README.
+
+Accepted findings:
+
+- The existing application UI port is the minimal contract location.
+- The event must be additive so existing command-runner status updates remain
+  compatible.
+- `TerminalWorkflowProgress` should translate `WorkflowProgressEvent` into
+  `ConsoleStatusEvent` so console adapters consume status/evidence state rather
+  than workflow internals.
+
+Rejected findings:
+
+- No new browser, React, or standalone UI layer is needed.
+
+Files changed per stream:
+
+- application contract: `src/tiny_swarm_world/application/ports/ui/port_ui.py`,
+  `src/tiny_swarm_world/application/ports/progress/port_workflow_progress.py`
+- console UI: `src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py`,
+  `src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py`
+- tests: `tests/application/ports/test_workflow_progress.py`,
+  `tests/infrastructure/adapters/ui/test_progress_trace_ui.py`,
+  `tests/infrastructure/adapters/ui/test_linux_ui.py`
+- documentation: `documentation/arc42/06_runtime_view.adoc`, `README.md`
+- evidence: `.codex/evidence/slice-83-distribution.md`,
+  `.codex/evidence/slice-83-consolidation.md`
+
+Conflicts found:
+
+- None.
+
+Tests executed:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`:
+  passed.
+- `PYTHONPATH=src python3 -m unittest tests.application.ports.test_workflow_progress tests.infrastructure.adapters.ui.test_progress_trace_ui tests.infrastructure.adapters.ui.test_linux_ui`:
+  passed.
+- `python3 tools/quality_gate.py lint`: passed.
+- `python3 tools/quality_gate.py quality`: passed. The full gate executed lint,
+  arch-lint, arch-tests, typecheck, and 878 unit tests with 17 skipped.
+
+SonarQube findings and fixes:
+
+- Pending remote PR lifecycle.
+
+Documentation updates:
+
+- arc42 runtime view now describes `ConsoleStatusEvent` as the presentation
+  boundary.
+- README now identifies the UI event contract for status/evidence rendering.
+
+Final integration decision:
+
+- Accepted for PR lifecycle after required remote checks pass.

--- a/.codex/evidence/slice-83-distribution.md
+++ b/.codex/evidence/slice-83-distribution.md
@@ -1,0 +1,53 @@
+# Slice 83 Distribution
+
+Workflow id: `issue-83-ui-status-evidence-contract-20260614`
+Slice id: `S01-S04`
+Slice title: Define the status and evidence contract consumed by the console UI
+
+Affected areas:
+
+- application UI port
+- terminal console adapter
+- UI adapter tests
+- architecture documentation
+
+Chosen execution mode: sequential.
+
+Selected streams:
+
+- application contract: introduce a status/evidence event on the UI port.
+- console UI: render supplied evidence and trace fields from the event state.
+- tests: prove rendering from the supplied event only.
+- documentation: record the presentation-only boundary.
+
+Real subagents used: yes. Avicenna provided read-only planning.
+
+Fallback role-based review used: no.
+
+Git worktrees used: no. The changed files are tightly coupled and share one UI
+port contract.
+
+Conflict risks:
+
+- Existing `update_status` callers must remain backward compatible.
+- Console UI must not own workflow lifecycle decisions.
+- Evidence and correlation fields must be optional so existing command-runner
+  flows keep working.
+
+Quality gates to run:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py quality`
+
+Consolidation plan:
+
+- Keep the existing `PortUI.update_status` API stable.
+- Add an event-based method that maps to the same UI state plus optional
+  recovery, evidence, and trace metadata.
+- Run targeted UI tests first, then full quality before PR.
+
+Parallelization decision:
+
+- Rejected because the UI port, renderer, and tests define one small contract
+  and should change together.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ The composition root remains the public facade; focused
 `src/tiny_swarm_world/infrastructure/composition_*.py` modules hold
 service-bundle models, fail-closed workflow stubs, and provider-selected LXC
 runtime wiring.
+Console/status rendering consumes the application-level `ConsoleStatusEvent`
+contract from `tiny_swarm_world.application.ports.ui.port_ui`. The event carries
+workflow command, result status, recovery hint, evidence path, and correlation
+or trace IDs when available, keeping terminal adapters presentation-only.
 
 The canonical setup path is the workflow-level Python command. Former direct preparation scripts and host-side compose orchestration
 scripts have been removed so service bootstrap, image publication, and stack

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -133,6 +133,13 @@ renderers. Command runners report per-instance terminal results with the same
 `Success`, `Error`, and `Failed` semantics that the Linux console adapter uses
 to decide when all visible instances have reached a terminal state.
 
+The presentation boundary is the `ConsoleStatusEvent` contract exposed by the
+application UI port. Workflow and command paths can publish the workflow
+command, result status, recovery hint, evidence path, correlation ID, and trace
+ID through that event. Console adapters consume the supplied event state and
+render it; they do not inspect command-runner internals or decide workflow
+lifecycle outcomes.
+
 Aggregate updates use the reserved `all` instance and are stored separately
 from per-VM state. The terminal renderer derives completion summaries from
 both aggregate and per-instance status, so failed command runs display

--- a/src/tiny_swarm_world/application/ports/progress/port_workflow_progress.py
+++ b/src/tiny_swarm_world/application/ports/progress/port_workflow_progress.py
@@ -32,6 +32,9 @@ class WorkflowProgressEvent:
     result: str
     safe_message: str
     recovery_hint: str | None = None
+    evidence_path: str | None = None
+    correlation_id: str | None = None
+    trace_id: str | None = None
 
     def __post_init__(self) -> None:
         for field_name, value in self.to_dict().items():

--- a/src/tiny_swarm_world/application/ports/ui/port_ui.py
+++ b/src/tiny_swarm_world/application/ports/ui/port_ui.py
@@ -2,6 +2,7 @@ import asyncio
 import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 
 AGGREGATE_INSTANCE = "all"
 STATUS_PENDING = "Pending"
@@ -42,6 +43,18 @@ FAILURE_RESULTS = frozenset(
 TERMINAL_RESULTS = SUCCESS_RESULTS | FAILURE_RESULTS
 
 
+@dataclass(frozen=True, kw_only=True)
+class ConsoleStatusEvent:
+    instance: str
+    workflow_command: str
+    step: str
+    result_status: str
+    recovery_hint: str | None = None
+    evidence_path: str | None = None
+    correlation_id: str | None = None
+    trace_id: str | None = None
+
+
 class PortUI(ABC):
     def __init__(self, instances, test_mode=False):
         self.instances = instances
@@ -70,6 +83,22 @@ class PortUI(ABC):
                 target_status["current_step"] = step
                 if result is not None:
                     target_status["result"] = self._safe_result_update(instance, result)
+
+    def update_status_event(self, event: ConsoleStatusEvent) -> None:
+        self.update_status(
+            event.instance,
+            task=event.workflow_command,
+            step=event.step,
+            result=event.result_status,
+        )
+        with self.lock:
+            target_status = self._status_for_instance(event.instance)
+            if target_status is None:
+                return
+            target_status["recovery_hint"] = event.recovery_hint or ""
+            target_status["evidence_path"] = event.evidence_path or ""
+            target_status["correlation_id"] = event.correlation_id or ""
+            target_status["trace_id"] = event.trace_id or ""
 
     def _status_for_instance(self, instance):
         if instance == AGGREGATE_INSTANCE:
@@ -107,6 +136,12 @@ class PortUI(ABC):
 
     def recovery_action(self, result):
         return SETUP_RECOVERY_ACTIONS.get(_normalize_result(result), "")
+
+    def status_recovery_action(self, status):
+        recovery_hint = status.get("recovery_hint", "")
+        if recovery_hint:
+            return recovery_hint
+        return self.recovery_action(status["result"])
 
     def _safe_result_update(self, instance, result):
         if not self.is_success_result(result):

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py
@@ -99,18 +99,27 @@ class LinuxUI(PortUI):
         stdscr.addstr(2, column, f"Task: {current_task[:col_width - 7]}")
         stdscr.addstr(3, column, f"Step: {current_step[:col_width - 7]}")
         stdscr.addstr(4, column, f"Status: {current_result[:col_width - 7]}")
-        recovery_action = self.recovery_action(current_result)
+        recovery_action = self.status_recovery_action(current_status)
         if recovery_action:
             stdscr.addstr(5, column, f"Action: {recovery_action[:col_width - 8]}")
+        evidence_path = current_status.get("evidence_path", "")
+        if evidence_path:
+            stdscr.addstr(6, column, f"Evidence: {evidence_path[:col_width - 10]}")
+        correlation_id = current_status.get("correlation_id", "")
+        if correlation_id:
+            stdscr.addstr(7, column, f"Trace: {correlation_id[:col_width - 7]}")
 
     def _draw_aggregate_status(self, stdscr, width):
         aggregate_result = self.aggregate_status["result"]
         if not self.is_terminal_result(aggregate_result):
             return
         stdscr.addstr(6, 0, f"Overall: {aggregate_result}"[:width], curses.A_BOLD)
-        aggregate_recovery = self.recovery_action(aggregate_result)
+        aggregate_recovery = self.status_recovery_action(self.aggregate_status)
         if aggregate_recovery:
             stdscr.addstr(7, 0, f"Action: {aggregate_recovery}"[:width])
+        evidence_path = self.aggregate_status.get("evidence_path", "")
+        if evidence_path:
+            stdscr.addstr(8, 0, f"Evidence: {evidence_path}"[:width])
 
     def _draw_completion_if_terminal(self, stdscr, height, width):
         if not self.all_instances_terminal():

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py
@@ -8,7 +8,11 @@ from tiny_swarm_world.application.ports.progress import (
     PortWorkflowProgress,
     WorkflowProgressEvent,
 )
-from tiny_swarm_world.application.ports.ui.port_ui import AGGREGATE_INSTANCE, PortUI
+from tiny_swarm_world.application.ports.ui.port_ui import (
+    AGGREGATE_INSTANCE,
+    ConsoleStatusEvent,
+    PortUI,
+)
 
 
 class TerminalWorkflowProgress(PortWorkflowProgress):
@@ -16,11 +20,17 @@ class TerminalWorkflowProgress(PortWorkflowProgress):
         self.ui = ui
 
     def report(self, event: WorkflowProgressEvent) -> None:
-        self.ui.update_status(
-            instance=AGGREGATE_INSTANCE,
-            task=event.task,
-            step=f"{event.phase}:{event.step}",
-            result=event.result,
+        self.ui.update_status_event(
+            ConsoleStatusEvent(
+                instance=AGGREGATE_INSTANCE,
+                workflow_command=event.workflow,
+                step=f"{event.phase}:{event.step}",
+                result_status=event.result,
+                recovery_hint=event.recovery_hint,
+                evidence_path=event.evidence_path,
+                correlation_id=event.correlation_id,
+                trace_id=event.trace_id,
+            )
         )
 
 

--- a/tests/application/ports/test_workflow_progress.py
+++ b/tests/application/ports/test_workflow_progress.py
@@ -18,6 +18,9 @@ class TestWorkflowProgressEvent(unittest.TestCase):
             result="pending",
             safe_message="Checking host prerequisites.",
             recovery_hint="Resolve reported blockers and rerun setup.",
+            evidence_path=".tiny-swarm-world/evidence/preflight.json",
+            correlation_id="setup-123",
+            trace_id="trace-456",
         )
 
         self.assertEqual(
@@ -31,6 +34,9 @@ class TestWorkflowProgressEvent(unittest.TestCase):
                 "result": "pending",
                 "safe_message": "Checking host prerequisites.",
                 "recovery_hint": "Resolve reported blockers and rerun setup.",
+                "evidence_path": ".tiny-swarm-world/evidence/preflight.json",
+                "correlation_id": "setup-123",
+                "trace_id": "trace-456",
             },
             event.to_dict(),
         )

--- a/tests/infrastructure/adapters/ui/test_linux_ui.py
+++ b/tests/infrastructure/adapters/ui/test_linux_ui.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, MagicMock
 
 from tiny_swarm_world.application.ports.ui.port_ui import (
     AGGREGATE_INSTANCE,
+    ConsoleStatusEvent,
     SETUP_RECOVERY_ACTIONS,
     STATUS_BLOCKED,
     STATUS_FAILED,
@@ -78,6 +79,57 @@ class TestLinuxUI(unittest.TestCase):
             },
             self.ui.aggregate_status,
         )
+
+    def test_update_status_event_records_console_status_contract(self):
+        self.ui.update_status_event(
+            ConsoleStatusEvent(
+                instance="Instance1",
+                workflow_command="setup run",
+                step="deployment verify",
+                result_status=STATUS_FAILED_TO_VERIFY,
+                recovery_hint="Inspect deployment verification evidence.",
+                evidence_path=".tiny-swarm-world/evidence/deployment.json",
+                correlation_id="setup-123",
+                trace_id="trace-456",
+            )
+        )
+
+        self.assertEqual(
+            {
+                "current_task": "setup run",
+                "current_step": "deployment verify",
+                "result": STATUS_FAILED_TO_VERIFY,
+                "recovery_hint": "Inspect deployment verification evidence.",
+                "evidence_path": ".tiny-swarm-world/evidence/deployment.json",
+                "correlation_id": "setup-123",
+                "trace_id": "trace-456",
+            },
+            self.ui.status["Instance1"],
+        )
+
+    def test_draw_instance_status_renders_supplied_evidence_event_only(self):
+        self.ui.update_status_event(
+            ConsoleStatusEvent(
+                instance="Instance1",
+                workflow_command="deployment apply",
+                step="nexus stack",
+                result_status=STATUS_FAILED_TO_APPLY,
+                recovery_hint="Repair deployment apply failure.",
+                evidence_path=".tiny-swarm-world/evidence/nexus.json",
+                correlation_id="deployment-789",
+            )
+        )
+        stdscr = MagicMock()
+
+        self.ui._draw_instance_status(stdscr, 0, 80, self.ui.status["Instance1"])
+
+        rendered = [call.args[2] for call in stdscr.addstr.call_args_list]
+        self.assertIn("Task: deployment apply", rendered)
+        self.assertIn("Step: nexus stack", rendered)
+        self.assertIn(f"Status: {STATUS_FAILED_TO_APPLY}", rendered)
+        self.assertIn("Action: Repair deployment apply failure.", rendered)
+        self.assertIn("Evidence: .tiny-swarm-world/evidence/nexus.json", rendered)
+        self.assertIn("Trace: deployment-789", rendered)
 
     def test_terminal_status_contract_accepts_runner_and_executer_values(self):
         terminal_results = (

--- a/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
+++ b/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
@@ -28,13 +28,27 @@ class TestProgressTraceUi(unittest.TestCase):
                 status="started",
                 result="pending",
                 safe_message="Platform init started.",
+                recovery_hint="Wait for platform init evidence.",
+                evidence_path=".tiny-swarm-world/evidence/platform-init.json",
+                correlation_id="setup-123",
+                trace_id="trace-456",
             )
         )
 
         self.assertEqual(
-            [(AGGREGATE_INSTANCE, "Run platform init", "platform init:apply", "pending")],
+            [(AGGREGATE_INSTANCE, "setup run", "platform init:apply", "pending")],
             ui.updates,
         )
+        self.assertEqual(
+            "Wait for platform init evidence.",
+            ui.aggregate_status["recovery_hint"],
+        )
+        self.assertEqual(
+            ".tiny-swarm-world/evidence/platform-init.json",
+            ui.aggregate_status["evidence_path"],
+        )
+        self.assertEqual("setup-123", ui.aggregate_status["correlation_id"])
+        self.assertEqual("trace-456", ui.aggregate_status["trace_id"])
 
     def test_raised_method_trace_updates_aggregate_failure_state(self):
         ui = RecordingUI()


### PR DESCRIPTION
## Summary
- Add `ConsoleStatusEvent` to the application UI port and keep `update_status` backward compatible.
- Extend workflow progress events with optional safe evidence and trace metadata, then map progress events into console status events.
- Render supplied recovery, evidence path, and correlation data in the Linux terminal UI without inspecting execution internals.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`
- `PYTHONPATH=src python3 -m unittest tests.application.ports.test_workflow_progress tests.infrastructure.adapters.ui.test_progress_trace_ui tests.infrastructure.adapters.ui.test_linux_ui`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py quality`

Closes #83