### PR TITLE
Guard console UI presentation boundary

### DIFF
--- a/.codex/evidence/slice-82-consolidation.md
+++ b/.codex/evidence/slice-82-consolidation.md
@@ -1,0 +1,61 @@
+# Slice 82 Consolidation
+
+Workflow id: `issue-82-ui-presentation-arch-tests-20260614`
+Slice id: `S01-S04`
+Slice title: Add architecture tests that keep the console UI presentation-only
+
+Stream results:
+
+- architecture: added a presentation-only import guardrail for console UI
+  adapters.
+- implementation: command UI adapters now receive a command executor factory
+  instead of importing and constructing `CommandExecuter` directly.
+- tests: updated async and sync command UI tests to inject the executor.
+- documentation: updated arc42 runtime view.
+
+Accepted findings:
+
+- Existing async/sync command UI adapters directly imported command execution
+  services and needed repair before the guardrail could pass.
+- `CommandWorkflow` is the correct infrastructure orchestration place to wire
+  the concrete executor for command-runner UI flows.
+
+Rejected findings:
+
+- No browser/frontend or new UI layer changes are needed.
+
+Files changed per stream:
+
+- architecture: `tests/architecture/test_hexagonal_imports.py`
+- implementation: `src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py`,
+  `src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py`,
+  `src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py`
+- tests: `tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py`
+- documentation: `documentation/arc42/06_runtime_view.adoc`
+- evidence: `.codex/evidence/slice-82-distribution.md`,
+  `.codex/evidence/slice-82-consolidation.md`
+
+Conflicts found:
+
+- None.
+
+Tests executed:
+
+- `PYTHONPATH=src python3 -m unittest tests.architecture.test_hexagonal_imports tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics`:
+  passed.
+- `python3 tools/quality_gate.py lint`: passed.
+- `python3 tools/quality_gate.py quality`: passed. The full gate executed lint,
+  arch-lint, arch-tests, typecheck, and 879 unit tests with 17 skipped.
+
+SonarQube findings and fixes:
+
+- Pending remote PR lifecycle.
+
+Documentation updates:
+
+- arc42 runtime view now names the architecture test guardrail that keeps UI
+  adapters presentation-only.
+
+Final integration decision:
+
+- Accepted for PR lifecycle after required remote checks pass.

--- a/.codex/evidence/slice-82-distribution.md
+++ b/.codex/evidence/slice-82-distribution.md
@@ -1,0 +1,54 @@
+# Slice 82 Distribution
+
+Workflow id: `issue-82-ui-presentation-arch-tests-20260614`
+Slice id: `S01-S04`
+Slice title: Add architecture tests that keep the console UI presentation-only
+
+Affected areas:
+
+- architecture tests
+- console UI adapters
+- command workflow wiring
+- documentation
+
+Chosen execution mode: sequential.
+
+Selected streams:
+
+- architecture: add deterministic UI presentation-only import guardrail.
+- implementation: remove direct `CommandExecuter` construction from UI
+  adapters by injecting an executor factory.
+- tests: preserve async/sync command UI failure semantics.
+- documentation: record the guardrail.
+
+Real subagents used: no. Agent spawning was blocked by the active thread limit.
+
+Fallback role-based review used: yes. The main thread performed Senior System
+Architect and Senior Tester review against the current UI adapter imports.
+
+Git worktrees used: no. The slice touches tightly coupled UI adapters and
+architecture tests.
+
+Conflict risks:
+
+- Existing command UI failure tests expect `runner_ui.command_execute`.
+- The guardrail must allow UI/progress/status ports while forbidding execution
+  and live infrastructure concerns.
+
+Quality gates to run:
+
+- `PYTHONPATH=src python3 -m unittest tests.architecture.test_hexagonal_imports tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py quality`
+
+Consolidation plan:
+
+- Add the failing architecture guardrail.
+- Move concrete command executor construction out of UI adapters into
+  `CommandWorkflow`.
+- Preserve UI status semantics through targeted tests.
+
+Parallelization decision:
+
+- Rejected because the guardrail and UI adapter repair must be integrated
+  together.

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -139,6 +139,11 @@ command, result status, recovery hint, evidence path, correlation ID, and trace
 ID through that event. Console adapters consume the supplied event state and
 render it; they do not inspect command-runner internals or decide workflow
 lifecycle outcomes.
+Architecture tests enforce this boundary for all console UI adapter modules:
+UI adapters may import rendering ports and progress/status contracts, but must
+not import command execution services, setup/deployment/platform orchestration,
+node-provider clients, Docker/Swarm clients, command-runner adapters, or the
+composition root.
 
 Aggregate updates use the reserved `all` instance and are stored separately
 from per-VM state. The terminal renderer derives completion summaries from

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
@@ -5,7 +5,9 @@ from tiny_swarm_world.application.ports.commands.port_command_workflow import Po
 from tiny_swarm_world.application.ports.commands.port_command_runner_factory import PortCommandRunnerFactory
 from tiny_swarm_world.application.ports.repositories.port_command_repository import PortCommandRepository
 from tiny_swarm_world.application.ports.repositories.port_vm_repository import PortVmRepository
+from tiny_swarm_world.application.ports.ui.port_ui import PortUI
 from tiny_swarm_world.application.services.commands.command_builder.vm_parameter.command_builder import CommandBuilder
+from tiny_swarm_world.application.services.commands.command_executer.command_executer import CommandExecuter
 from tiny_swarm_world.application.ports.commands.parameter_type import ParameterType
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
 from tiny_swarm_world.domain.command.command_entity import CommandCatalogValidationError
@@ -19,6 +21,12 @@ from tiny_swarm_world.infrastructure.adapters.repositories.command_repository_ya
 )
 from tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui import AsyncCommandRunnerUI
 from tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui import SyncCommandRunnerUI
+from tiny_swarm_world.infrastructure.adapters.ui.progress_trace_ui import TerminalMethodTrace
+from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
+from tiny_swarm_world.infrastructure.logging.progress_trace_logging import (
+    CompositeMethodTrace,
+    LoggingMethodTrace,
+)
 
 
 CommandRepositoryFactory = Callable[[str], PortCommandRepository]
@@ -69,7 +77,8 @@ class CommandWorkflow(PortCommandWorkflow):
         workflow_id: str,
     ) -> Any:
         return await AsyncCommandRunnerUI(
-            self.build_command_list(config_file, parameter, workflow_id=workflow_id)
+            self.build_command_list(config_file, parameter, workflow_id=workflow_id),
+            command_executor_factory=_build_command_executor,
         ).run()
 
     async def run_sync(
@@ -80,7 +89,8 @@ class CommandWorkflow(PortCommandWorkflow):
         workflow_id: str,
     ) -> Any:
         return await SyncCommandRunnerUI(
-            self.build_command_list(config_file, parameter, workflow_id=workflow_id)
+            self.build_command_list(config_file, parameter, workflow_id=workflow_id),
+            command_executor_factory=_build_command_executor,
         ).run()
 
     def verify_config_contract(
@@ -204,6 +214,19 @@ def _verification_classification(
     if is_probe_allowed_for_workflow(probe_id, workflow_id):
         return "command_backed"
     return "unknown_probe"
+
+
+def _build_command_executor(ui: PortUI) -> CommandExecuter:
+    return CommandExecuter(
+        ui=ui,
+        method_trace=CompositeMethodTrace(
+            (
+                LoggingMethodTrace(LoggerFactory.get_logger("MethodTrace")),
+                TerminalMethodTrace(ui),
+            )
+        ),
+        trace_correlation_id="trace-command-execution",
+    )
 
 
 VM_REPOSITORY_NOT_CONFIGURED = "VM repository is not configured"

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py
@@ -1,8 +1,8 @@
 import asyncio
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from typing import Protocol
 from typing import Dict
 
-from tiny_swarm_world.application.services.commands.command_executer.command_executer import CommandExecuter
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
 from tiny_swarm_world.application.ports.ui.port_ui import (
     AGGREGATE_INSTANCE,
@@ -11,20 +11,28 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     PortUI,
 )
 from tiny_swarm_world.infrastructure.adapters.ui.command_runner_ui import CommandRunnerUi
-from tiny_swarm_world.infrastructure.adapters.ui.progress_trace_ui import TerminalMethodTrace
 from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
-from tiny_swarm_world.infrastructure.logging.progress_trace_logging import (
-    CompositeMethodTrace,
-    LoggingMethodTrace,
-)
 from tiny_swarm_world.infrastructure.adapters.ui.factory_ui import FactoryUI
+
+
+class _CommandExecutor(Protocol):
+    async def execute(self, commands: Dict[int, ExecutableCommandEntity]) -> object:
+        ...
+
+
+CommandExecutorFactory = Callable[[PortUI], _CommandExecutor]
+
 
 class AsyncCommandRunnerUI(CommandRunnerUi):
     """
     Handles the UI initialization and asynchronous execution of commands.
     """
 
-    def __init__(self, command_list: Dict[str, Dict[int, ExecutableCommandEntity]]):
+    def __init__(
+        self,
+        command_list: Dict[str, Dict[int, ExecutableCommandEntity]],
+        command_executor_factory: CommandExecutorFactory,
+    ):
         """
         Initializes the UI and command execution logic.
 
@@ -34,11 +42,7 @@ class AsyncCommandRunnerUI(CommandRunnerUi):
         self.command_list = command_list
         self.instances = list(command_list.keys())
         self.ui = FactoryUI().get_ui(instances=self.instances, test_mode=False)
-        self.command_execute = CommandExecuter(
-            ui=self.ui,
-            method_trace=_build_command_method_trace(self.ui),
-            trace_correlation_id="trace-command-execution",
-        )
+        self.command_execute = command_executor_factory(self.ui)
         self.logger = LoggerFactory.get_logger(self.__class__)
         self.logger.info(f"CommandRunnerUI initialized {self.instances} instances")
 
@@ -92,12 +96,3 @@ class AsyncCommandRunnerUI(CommandRunnerUi):
             raise failures[0]
 
         return results
-
-
-def _build_command_method_trace(ui: PortUI) -> CompositeMethodTrace:
-    return CompositeMethodTrace(
-        (
-            LoggingMethodTrace(LoggerFactory.get_logger("MethodTrace")),
-            TerminalMethodTrace(ui),
-        )
-    )

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py
@@ -1,6 +1,7 @@
+from collections.abc import Callable
+from typing import Protocol
 from typing import Dict
 
-from tiny_swarm_world.application.services.commands.command_executer.command_executer import CommandExecuter
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
 from tiny_swarm_world.application.ports.ui.port_ui import (
     AGGREGATE_INSTANCE,
@@ -9,20 +10,28 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     PortUI,
 )
 from tiny_swarm_world.infrastructure.adapters.ui.command_runner_ui import CommandRunnerUi
-from tiny_swarm_world.infrastructure.adapters.ui.progress_trace_ui import TerminalMethodTrace
 from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
-from tiny_swarm_world.infrastructure.logging.progress_trace_logging import (
-    CompositeMethodTrace,
-    LoggingMethodTrace,
-)
 from tiny_swarm_world.infrastructure.adapters.ui.factory_ui import FactoryUI
+
+
+class _CommandExecutor(Protocol):
+    async def execute(self, commands: Dict[int, ExecutableCommandEntity]) -> object:
+        ...
+
+
+CommandExecutorFactory = Callable[[PortUI], _CommandExecutor]
+
 
 class SyncCommandRunnerUI(CommandRunnerUi):
     """
     Handles the UI initialization and asynchronous execution of commands.
     """
 
-    def __init__(self, command_list: Dict[str, Dict[int, ExecutableCommandEntity]]):
+    def __init__(
+        self,
+        command_list: Dict[str, Dict[int, ExecutableCommandEntity]],
+        command_executor_factory: CommandExecutorFactory,
+    ):
         """
         Initializes the UI and command execution logic.
 
@@ -32,11 +41,7 @@ class SyncCommandRunnerUI(CommandRunnerUi):
         self.command_list = command_list
         self.instances = list(command_list.keys())
         self.ui = FactoryUI().get_ui(instances=self.instances, test_mode=False)
-        self.command_execute = CommandExecuter(
-            ui=self.ui,
-            method_trace=_build_command_method_trace(self.ui),
-            trace_correlation_id="trace-command-execution",
-        )
+        self.command_execute = command_executor_factory(self.ui)
         self.logger = LoggerFactory.get_logger(self.__class__)
         self.logger.info(f"CommandRunnerUI initialized {self.instances} instances")
 
@@ -85,12 +90,3 @@ class SyncCommandRunnerUI(CommandRunnerUi):
             raise failure
 
         return results
-
-
-def _build_command_method_trace(ui: PortUI) -> CompositeMethodTrace:
-    return CompositeMethodTrace(
-        (
-            LoggingMethodTrace(LoggerFactory.get_logger("MethodTrace")),
-            TerminalMethodTrace(ui),
-        )
-    )

--- a/tests/architecture/test_hexagonal_imports.py
+++ b/tests/architecture/test_hexagonal_imports.py
@@ -257,6 +257,29 @@ class TestResponsibilityBoundaryDocumentation(unittest.TestCase):
 
         self.assertEqual([], violations)
 
+    def test_console_ui_adapters_remain_presentation_only(self):
+        forbidden_prefixes = (
+            "tiny_swarm_world.application.services.artifacts",
+            "tiny_swarm_world.application.services.commands",
+            "tiny_swarm_world.application.services.deployment",
+            "tiny_swarm_world.application.services.nexus",
+            "tiny_swarm_world.application.services.platform",
+            "tiny_swarm_world.application.services.setup",
+            "tiny_swarm_world.infrastructure.adapters.clients",
+            "tiny_swarm_world.infrastructure.adapters.command_runner",
+            "tiny_swarm_world.infrastructure.composition",
+        )
+        violations = [
+            violation
+            for forbidden_prefix in forbidden_prefixes
+            for violation in _find_forbidden_imports(
+                root=CONSOLE_UI_INFRASTRUCTURE_ROOT,
+                forbidden_prefix=forbidden_prefix,
+            )
+        ]
+
+        self.assertEqual([], violations)
+
     def test_nexus_artifact_repository_contracts_do_not_import_deployment_or_infrastructure(self):
         repository_contract_file = APPLICATION_SERVICES_ROOT / "nexus" / "ensure_nexus_repository.py"
         forbidden_prefixes = (

--- a/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
+++ b/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
@@ -13,6 +13,7 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     PortUI,
 )
 from tiny_swarm_world.application.services.commands.command_executer.command_executer import (
+    CommandExecuter,
     CommandExecutionFailed,
 )
 from tiny_swarm_world.application.ports.commands.executable_command import (
@@ -33,7 +34,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(_command_list(FailingRunner()))
+            runner_ui = AsyncCommandRunnerUI(
+                _command_list(FailingRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -52,7 +56,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(_command_list(FailingRunner()))
+            runner_ui = SyncCommandRunnerUI(
+                _command_list(FailingRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -71,7 +78,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(_command_list(SensitiveRuntimeFailureRunner()))
+            runner_ui = AsyncCommandRunnerUI(
+                _command_list(SensitiveRuntimeFailureRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -88,7 +98,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(_command_list(SensitiveRuntimeFailureRunner()))
+            runner_ui = SyncCommandRunnerUI(
+                _command_list(SensitiveRuntimeFailureRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -109,7 +122,8 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
                 {
                     "swarm-manager": _commands_for("swarm-manager", FailingRunner()),
                     "swarm-worker": _commands_for("swarm-worker", SuccessfulRunner()),
-                }
+                },
+                command_executor_factory=_command_executor_factory,
             )
 
         with patch(
@@ -129,7 +143,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(_command_list(SuccessfulRunner()))
+            runner_ui = AsyncCommandRunnerUI(
+                _command_list(SuccessfulRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -148,7 +165,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(_command_list(SuccessfulRunner()))
+            runner_ui = SyncCommandRunnerUI(
+                _command_list(SuccessfulRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -167,7 +187,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(_command_list(StatusOnlyFailureRunner()))
+            runner_ui = AsyncCommandRunnerUI(
+                _command_list(StatusOnlyFailureRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -186,7 +209,10 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(_command_list(StatusOnlyFailureRunner()))
+            runner_ui = SyncCommandRunnerUI(
+                _command_list(StatusOnlyFailureRunner()),
+                command_executor_factory=_command_executor_factory,
+            )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
@@ -203,6 +229,10 @@ def _command_list(runner: PortCommandRunner):
     return {
         "swarm-manager": _commands_for("swarm-manager", runner)
     }
+
+
+def _command_executor_factory(ui: PortUI) -> CommandExecuter:
+    return CommandExecuter(ui=ui)
 
 
 def _commands_for(vm_instance_name: str, runner: PortCommandRunner):


### PR DESCRIPTION
## Summary
- Add an architecture test that keeps console UI adapters presentation-only.
- Move concrete command executor construction out of async/sync UI adapters into `CommandWorkflow` via an injected executor factory.
- Preserve async/sync command UI failure semantics and document the guardrail.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.architecture.test_hexagonal_imports tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py quality`

Closes #82