### PR TITLE
Move command execution out of UI adapters

### DIFF
--- a/.codex/evidence/slice-80-consolidation.md
+++ b/.codex/evidence/slice-80-consolidation.md
@@ -1,0 +1,59 @@
+# Slice 80 Consolidation
+
+Workflow id: `issue-80-ui-execution-decoupling-20260614`
+Slice id: `S01-S04`
+Slice title: Decouple command execution from the console UI adapter
+
+Stream results:
+
+- runtime: `CommandWorkflow` now owns async and sync command execution loops.
+- UI: `AsyncCommandRunnerUI` and `SyncCommandRunnerUI` only start the UI,
+  expose status helpers, finish aggregate status, and wait for closure.
+- tests: existing command-runner UI behavior tests now exercise the workflow
+  orchestration path.
+- documentation: arc42 runtime view documents the session-adapter boundary.
+
+Accepted findings:
+
+- UI adapters must not instantiate or invoke command execution services.
+- `CommandWorkflow` is the existing workflow/reconciler surface for command
+  execution orchestration.
+
+Rejected findings:
+
+- No new UI layer or browser frontend is required.
+
+Files changed per stream:
+
+- runtime: `src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py`
+- UI: `src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py`,
+  `src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py`
+- tests: `tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py`
+- documentation: `documentation/arc42/06_runtime_view.adoc`
+- evidence: `.codex/evidence/slice-80-distribution.md`,
+  `.codex/evidence/slice-80-consolidation.md`
+
+Conflicts found:
+
+- None.
+
+Tests executed:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics tests.architecture.test_hexagonal_imports`:
+  passed.
+- `python3 tools/quality_gate.py lint`: passed.
+- `python3 tools/quality_gate.py quality`: passed. The full gate executed lint,
+  arch-lint, arch-tests, typecheck, and 879 unit tests with 17 skipped.
+
+SonarQube findings and fixes:
+
+- Pending remote PR lifecycle.
+
+Documentation updates:
+
+- arc42 runtime view now states that command-runner UI adapters are UI sessions
+  while `CommandWorkflow` owns command execution.
+
+Final integration decision:
+
+- Accepted for PR lifecycle after required remote checks pass.

--- a/.codex/evidence/slice-80-distribution.md
+++ b/.codex/evidence/slice-80-distribution.md
@@ -1,0 +1,51 @@
+# Slice 80 Distribution
+
+Workflow id: `issue-80-ui-execution-decoupling-20260614`
+Slice id: `S01-S04`
+Slice title: Decouple command execution from the console UI adapter
+
+Affected areas:
+
+- command workflow orchestration
+- console UI adapters
+- command-runner UI tests
+- documentation
+
+Chosen execution mode: sequential.
+
+Selected streams:
+
+- architecture/runtime: move command execution loops into `CommandWorkflow`.
+- UI: keep async/sync command UI adapters as presentation-only sessions.
+- tests: preserve command-runner failure and aggregate status semantics.
+- documentation: update runtime boundary.
+
+Real subagents used: no. Previous #82/#83 subagents informed the dependency
+chain; this slice used main-thread role-based execution.
+
+Fallback role-based review used: yes.
+
+Git worktrees used: no. The same command/UI behavior is being split across
+tightly coupled files.
+
+Conflict risks:
+
+- Existing tests assert command-runner aggregate status and redaction behavior.
+- UI adapters must not call command execution services after the split.
+
+Quality gates to run:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics tests.architecture.test_hexagonal_imports`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py quality`
+
+Consolidation plan:
+
+- Convert UI adapters to UI session helpers.
+- Move async and sync command execution loops into `CommandWorkflow`.
+- Keep redaction and aggregate terminal-state tests green.
+
+Parallelization decision:
+
+- Rejected because execution orchestration and UI status semantics must remain
+  behaviorally identical.

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -144,6 +144,10 @@ UI adapters may import rendering ports and progress/status contracts, but must
 not import command execution services, setup/deployment/platform orchestration,
 node-provider clients, Docker/Swarm clients, command-runner adapters, or the
 composition root.
+Legacy async and sync command-runner UI adapters are now UI session adapters:
+they create/start the terminal UI, expose status update helpers, and wait for
+the UI thread. `CommandWorkflow` owns command execution orchestration and
+passes decided status results into those UI sessions.
 
 Aggregate updates use the reserved `all` instance and are stored separately
 from per-VM state. The terminal renderer derives completion summaries from

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -76,10 +77,31 @@ class CommandWorkflow(PortCommandWorkflow):
         *,
         workflow_id: str,
     ) -> Any:
-        return await AsyncCommandRunnerUI(
-            self.build_command_list(config_file, parameter, workflow_id=workflow_id),
-            command_executor_factory=_build_command_executor,
-        ).run()
+        command_list = self.build_command_list(config_file, parameter, workflow_id=workflow_id)
+        runner_ui = AsyncCommandRunnerUI(command_list)
+        runner_ui.start()
+        command_executor = _build_command_executor(runner_ui.ui)
+        results: tuple[object, ...] = ()
+        failures: list[BaseException] = []
+        try:
+            tasks = {
+                vm: asyncio.create_task(command_executor.execute(command_list[vm]))
+                for vm in runner_ui.instances
+            }
+            results = tuple(await asyncio.gather(*tasks.values(), return_exceptions=True))
+            for vm, result in zip(runner_ui.instances, results):
+                if isinstance(result, BaseException):
+                    failures.append(result)
+                    runner_ui.mark_instance_failed(vm, result)
+                else:
+                    runner_ui.mark_instance_completed(vm)
+        finally:
+            runner_ui.finish(failed=bool(failures))
+            await runner_ui.wait_until_closed()
+
+        if failures:
+            raise failures[0]
+        return results
 
     async def run_sync(
         self,
@@ -88,10 +110,30 @@ class CommandWorkflow(PortCommandWorkflow):
         *,
         workflow_id: str,
     ) -> Any:
-        return await SyncCommandRunnerUI(
-            self.build_command_list(config_file, parameter, workflow_id=workflow_id),
-            command_executor_factory=_build_command_executor,
-        ).run()
+        command_list = self.build_command_list(config_file, parameter, workflow_id=workflow_id)
+        runner_ui = SyncCommandRunnerUI(command_list)
+        runner_ui.start()
+        command_executor = _build_command_executor(runner_ui.ui)
+        failure: BaseException | None = None
+        results = []
+        try:
+            for vm in runner_ui.instances:
+                try:
+                    result = await command_executor.execute(command_list[vm])
+                except Exception as exc:
+                    failure = exc
+                    runner_ui.mark_instance_failed(vm, exc)
+                    break
+                else:
+                    results.append(result)
+                    runner_ui.mark_instance_completed(vm)
+        finally:
+            runner_ui.finish(failed=failure is not None)
+            await runner_ui.wait_until_closed()
+
+        if failure is not None:
+            raise failure
+        return results
 
     def verify_config_contract(
         self,

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/command_async_runner_ui.py
@@ -1,6 +1,3 @@
-import asyncio
-from collections.abc import Callable, Sequence
-from typing import Protocol
 from typing import Dict
 
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
@@ -8,19 +5,10 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     AGGREGATE_INSTANCE,
     STATUS_ERROR,
     STATUS_SUCCESS,
-    PortUI,
 )
 from tiny_swarm_world.infrastructure.adapters.ui.command_runner_ui import CommandRunnerUi
 from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
 from tiny_swarm_world.infrastructure.adapters.ui.factory_ui import FactoryUI
-
-
-class _CommandExecutor(Protocol):
-    async def execute(self, commands: Dict[int, ExecutableCommandEntity]) -> object:
-        ...
-
-
-CommandExecutorFactory = Callable[[PortUI], _CommandExecutor]
 
 
 class AsyncCommandRunnerUI(CommandRunnerUi):
@@ -31,7 +19,6 @@ class AsyncCommandRunnerUI(CommandRunnerUi):
     def __init__(
         self,
         command_list: Dict[str, Dict[int, ExecutableCommandEntity]],
-        command_executor_factory: CommandExecutorFactory,
     ):
         """
         Initializes the UI and command execution logic.
@@ -42,57 +29,39 @@ class AsyncCommandRunnerUI(CommandRunnerUi):
         self.command_list = command_list
         self.instances = list(command_list.keys())
         self.ui = FactoryUI().get_ui(instances=self.instances, test_mode=False)
-        self.command_execute = command_executor_factory(self.ui)
         self.logger = LoggerFactory.get_logger(self.__class__)
         self.logger.info(f"CommandRunnerUI initialized {self.instances} instances")
 
     async def run(self):
         """
-        Runs the UI and executes commands asynchronously.
+        Starts the UI session without owning command execution.
         """
-        # Start the UI in a separate thread
+        self.start()
+        await self.wait_until_closed()
+
+    def start(self) -> None:
         self.logger.info("start ui")
         self.ui.start_in_thread()
-        results: Sequence[object] = ()
-        failures: list[BaseException] = []
 
-        try:
-            # Execute commands for each VM concurrently.
-            tasks = {
-                vm: asyncio.create_task(self.command_execute.execute(self.command_list[vm]))
-                for vm in self.instances
-            }
+    def mark_instance_failed(self, vm: str, result: BaseException) -> None:
+        self.logger.error(f"Execution failed for {vm}: {result}")
+        self.ui.update_status(task="failed", step="execution", result=STATUS_ERROR, instance=vm)
 
-            # Collect results after all VM executions finish.
-            results = await asyncio.gather(*tasks.values(), return_exceptions=True)
+    def mark_instance_completed(self, vm: str) -> None:
+        self.logger.info(f"Execution successful for {vm}")
+        self.ui.update_status(task="completed", step="execution", result=STATUS_SUCCESS, instance=vm)
 
-            # Handle each VM result independently.
-            for vm, result in zip(self.instances, results):
-                if isinstance(result, Exception):
-                    failures.append(result)
-                    self.logger.error(f"Execution failed for {vm}: {result}")
-                    self.ui.update_status(task="failed", step="execution", result=STATUS_ERROR, instance=vm)
-                else:
-                    self.logger.info(f"Execution successful for {vm}")
-                    self.ui.update_status(task="completed", step="execution", result=STATUS_SUCCESS, instance=vm)
+    def finish(self, *, failed: bool) -> None:
+        final_result = STATUS_ERROR if failed else STATUS_SUCCESS
+        self.ui.update_status(
+            task="finished",
+            step="execution",
+            result=final_result,
+            instance=AGGREGATE_INSTANCE,
+        )
 
-        finally:
-            # Update the UI with the final aggregate status.
-            final_result = STATUS_ERROR if failures else STATUS_SUCCESS
-            self.ui.update_status(
-                task="finished",
-                step="execution",
-                result=final_result,
-                instance=AGGREGATE_INSTANCE,
-            )
-
-            # Wait for the UI thread to finish.
+    async def wait_until_closed(self) -> None:
+        if self.ui.ui_thread is not None:
             self.logger.info("Waiting for UI thread to close...")
             await self.ui.ui_thread
-
-            self.logger.info("Execution complete.")
-
-        if failures:
-            raise failures[0]
-
-        return results
+        self.logger.info("Execution complete.")

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/command_sync_runner_ui.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-from typing import Protocol
 from typing import Dict
 
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
@@ -7,19 +5,10 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     AGGREGATE_INSTANCE,
     STATUS_ERROR,
     STATUS_SUCCESS,
-    PortUI,
 )
 from tiny_swarm_world.infrastructure.adapters.ui.command_runner_ui import CommandRunnerUi
 from tiny_swarm_world.infrastructure.logging.logger_factory import LoggerFactory
 from tiny_swarm_world.infrastructure.adapters.ui.factory_ui import FactoryUI
-
-
-class _CommandExecutor(Protocol):
-    async def execute(self, commands: Dict[int, ExecutableCommandEntity]) -> object:
-        ...
-
-
-CommandExecutorFactory = Callable[[PortUI], _CommandExecutor]
 
 
 class SyncCommandRunnerUI(CommandRunnerUi):
@@ -30,7 +19,6 @@ class SyncCommandRunnerUI(CommandRunnerUi):
     def __init__(
         self,
         command_list: Dict[str, Dict[int, ExecutableCommandEntity]],
-        command_executor_factory: CommandExecutorFactory,
     ):
         """
         Initializes the UI and command execution logic.
@@ -41,52 +29,39 @@ class SyncCommandRunnerUI(CommandRunnerUi):
         self.command_list = command_list
         self.instances = list(command_list.keys())
         self.ui = FactoryUI().get_ui(instances=self.instances, test_mode=False)
-        self.command_execute = command_executor_factory(self.ui)
         self.logger = LoggerFactory.get_logger(self.__class__)
         self.logger.info(f"CommandRunnerUI initialized {self.instances} instances")
 
     async def run(self):
         """
-        Runs the UI and executes commands asynchronously.
+        Starts the UI session without owning command execution.
         """
-        # Start the UI in a separate thread
+        self.start()
+        await self.wait_until_closed()
+
+    def start(self) -> None:
         self.logger.info("start ui")
         self.ui.start_in_thread()
-        failure: BaseException | None = None
-        results = []
 
-        try:
-            # Execute the commands for each VM.
-            for vm in self.instances:
-                try:
-                    result = await self.command_execute.execute(self.command_list[vm])
-                except Exception as exc:
-                    failure = exc
-                    self.logger.error(f"Execution failed for {vm}: {exc}")
-                    self.ui.update_status(task="failed", step="execution", result=STATUS_ERROR, instance=vm)
-                    break
-                else:
-                    results.append(result)
-                    self.logger.info(f"Execution successful for {vm}")
-                    self.ui.update_status(task="completed", step="execution", result=STATUS_SUCCESS, instance=vm)
+    def mark_instance_failed(self, vm: str, result: BaseException) -> None:
+        self.logger.error(f"Execution failed for {vm}: {result}")
+        self.ui.update_status(task="failed", step="execution", result=STATUS_ERROR, instance=vm)
 
-        finally:
-            # Update the UI with the final aggregate status.
-            final_result = STATUS_ERROR if failure else STATUS_SUCCESS
-            self.ui.update_status(
-                task="finished",
-                step="execution",
-                result=final_result,
-                instance=AGGREGATE_INSTANCE,
-            )
+    def mark_instance_completed(self, vm: str) -> None:
+        self.logger.info(f"Execution successful for {vm}")
+        self.ui.update_status(task="completed", step="execution", result=STATUS_SUCCESS, instance=vm)
 
-            # Wait for the UI thread to finish.
+    def finish(self, *, failed: bool) -> None:
+        final_result = STATUS_ERROR if failed else STATUS_SUCCESS
+        self.ui.update_status(
+            task="finished",
+            step="execution",
+            result=final_result,
+            instance=AGGREGATE_INSTANCE,
+        )
+
+    async def wait_until_closed(self) -> None:
+        if self.ui.ui_thread is not None:
             self.logger.info("Waiting for UI thread to close...")
             await self.ui.ui_thread
-
-            self.logger.info("Execution complete.")
-
-        if failure:
-            raise failure
-
-        return results
+        self.logger.info("Execution complete.")

--- a/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
+++ b/tests/infrastructure/adapters/ui/test_command_runner_ui_failure_semantics.py
@@ -12,15 +12,11 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     STATUS_SUCCESS,
     PortUI,
 )
-from tiny_swarm_world.application.services.commands.command_executer.command_executer import (
-    CommandExecuter,
-    CommandExecutionFailed,
-)
+from tiny_swarm_world.application.services.commands.command_executer.command_executer import CommandExecutionFailed
 from tiny_swarm_world.application.ports.commands.executable_command import (
     ExecutableCommandEntity,
 )
-from tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui import AsyncCommandRunnerUI
-from tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui import SyncCommandRunnerUI
+from tiny_swarm_world.infrastructure.adapters.command_runner.command_workflow import CommandWorkflow
 from tiny_swarm_world.infrastructure.adapters.exceptions.exception_command_execution import (
     CommandExecutionError,
 )
@@ -34,16 +30,15 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(
-                _command_list(FailingRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(FailingRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await _assert_redacted_runner_ui_failure(runner_ui)
+            await _assert_redacted_runner_ui_failure(
+                lambda: _run_async_with_ui(workflow, ui)
+            )
 
         self.assertIn(("swarm-manager", "failed", "execution", STATUS_ERROR), ui.updates)
         self.assertIn((AGGREGATE_INSTANCE, "finished", "execution", STATUS_ERROR), ui.updates)
@@ -56,16 +51,15 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(
-                _command_list(FailingRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(FailingRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await _assert_redacted_runner_ui_failure(runner_ui)
+            await _assert_redacted_runner_ui_failure(
+                lambda: _run_sync_with_ui(workflow, ui)
+            )
 
         self.assertIn(("swarm-manager", "failed", "execution", STATUS_ERROR), ui.updates)
         self.assertIn((AGGREGATE_INSTANCE, "finished", "execution", STATUS_ERROR), ui.updates)
@@ -78,16 +72,16 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(
-                _command_list(SensitiveRuntimeFailureRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(SensitiveRuntimeFailureRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await _assert_arbitrary_runner_ui_failure_redacted(runner_ui)
+            await _assert_arbitrary_runner_ui_failure_redacted(
+                lambda: _run_async_with_ui(workflow, ui),
+                ui,
+            )
 
         self.assertEqual(STATUS_ERROR, ui.aggregate_status["result"])
 
@@ -98,16 +92,16 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(
-                _command_list(SensitiveRuntimeFailureRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(SensitiveRuntimeFailureRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await _assert_arbitrary_runner_ui_failure_redacted(runner_ui)
+            await _assert_arbitrary_runner_ui_failure_redacted(
+                lambda: _run_sync_with_ui(workflow, ui),
+                ui,
+            )
 
         self.assertEqual(STATUS_ERROR, ui.aggregate_status["result"])
 
@@ -118,19 +112,20 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(
+            workflow = _workflow_for(
                 {
                     "swarm-manager": _commands_for("swarm-manager", FailingRunner()),
                     "swarm-worker": _commands_for("swarm-worker", SuccessfulRunner()),
-                },
-                command_executor_factory=_command_executor_factory,
+                }
             )
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await _assert_redacted_runner_ui_failure(runner_ui)
+            await _assert_redacted_runner_ui_failure(
+                lambda: _run_sync_with_ui(workflow, ui)
+            )
 
         self.assertEqual("Pending", ui.status["swarm-worker"]["result"])
         self.assertEqual(STATUS_ERROR, ui.aggregate_status["result"])
@@ -143,16 +138,13 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(
-                _command_list(SuccessfulRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(SuccessfulRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await runner_ui.run()
+            await _run_async_with_ui(workflow, ui)
 
         self.assertIn(("swarm-manager", "completed", "execution", STATUS_SUCCESS), ui.updates)
         self.assertIn((AGGREGATE_INSTANCE, "finished", "execution", STATUS_SUCCESS), ui.updates)
@@ -165,16 +157,13 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(
-                _command_list(SuccessfulRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(SuccessfulRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await runner_ui.run()
+            await _run_sync_with_ui(workflow, ui)
 
         self.assertIn(("swarm-manager", "completed", "execution", STATUS_SUCCESS), ui.updates)
         self.assertIn((AGGREGATE_INSTANCE, "finished", "execution", STATUS_SUCCESS), ui.updates)
@@ -187,16 +176,13 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = AsyncCommandRunnerUI(
-                _command_list(StatusOnlyFailureRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(StatusOnlyFailureRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await runner_ui.run()
+            await _run_async_with_ui(workflow, ui)
 
         self.assertEqual(STATUS_FAILED_TO_VERIFY, ui.status["swarm-manager"]["result"])
         self.assertEqual(STATUS_ERROR, ui.aggregate_status["result"])
@@ -209,16 +195,13 @@ class TestCommandRunnerUiFailureSemantics(unittest.IsolatedAsyncioTestCase):
             "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
         ) as factory:
             factory.return_value.get_ui.return_value = ui
-            runner_ui = SyncCommandRunnerUI(
-                _command_list(StatusOnlyFailureRunner()),
-                command_executor_factory=_command_executor_factory,
-            )
+            workflow = _workflow_for(_command_list(StatusOnlyFailureRunner()))
 
         with patch(
             "tiny_swarm_world.application.services.commands.command_executer.command_executer.asyncio.sleep",
             new=AsyncMock(),
         ):
-            await runner_ui.run()
+            await _run_sync_with_ui(workflow, ui)
 
         self.assertEqual(STATUS_FAILED_TO_VERIFY, ui.status["swarm-manager"]["result"])
         self.assertEqual(STATUS_ERROR, ui.aggregate_status["result"])
@@ -231,8 +214,26 @@ def _command_list(runner: PortCommandRunner):
     }
 
 
-def _command_executor_factory(ui: PortUI) -> CommandExecuter:
-    return CommandExecuter(ui=ui)
+def _workflow_for(command_list):
+    workflow = CommandWorkflow()
+    workflow.build_command_list = lambda *_args, **_kwargs: command_list
+    return workflow
+
+
+async def _run_async_with_ui(workflow, ui):
+    with patch(
+        "tiny_swarm_world.infrastructure.adapters.ui.command_async_runner_ui.FactoryUI"
+    ) as factory:
+        factory.return_value.get_ui.return_value = ui
+        return await workflow.run_async("commands.yaml", workflow_id="test")
+
+
+async def _run_sync_with_ui(workflow, ui):
+    with patch(
+        "tiny_swarm_world.infrastructure.adapters.ui.command_sync_runner_ui.FactoryUI"
+    ) as factory:
+        factory.return_value.get_ui.return_value = ui
+        return await workflow.run_sync("commands.yaml", workflow_id="test")
 
 
 def _commands_for(vm_instance_name: str, runner: PortCommandRunner):
@@ -309,36 +310,26 @@ class RecordingUI(PortUI):
         pass
 
 
-async def _assert_redacted_runner_ui_failure(runner_ui):
-    with patch.object(runner_ui.command_execute.logger, "error") as command_error:
-        with patch.object(runner_ui.logger, "error") as ui_error:
-            with unittest.TestCase().assertRaises(CommandExecutionFailed) as context:
-                await runner_ui.run()
+async def _assert_redacted_runner_ui_failure(run_workflow):
+    with unittest.TestCase().assertRaises(CommandExecutionFailed) as context:
+        await run_workflow()
 
-    text = " ".join(
-        str(call.args)
-        for call in (*command_error.call_args_list, *ui_error.call_args_list)
-    )
-    text = f"{text} {context.exception}"
+    text = str(context.exception)
     unittest.TestCase().assertIn("return code 2", text)
     unittest.TestCase().assertNotIn("cannot connect to the provider socket", text)
     unittest.TestCase().assertNotIn("raw vm output", text)
     unittest.TestCase().assertNotIn("incus info", text)
 
 
-async def _assert_arbitrary_runner_ui_failure_redacted(runner_ui):
-    with patch.object(runner_ui.command_execute.logger, "error") as command_error:
-        with patch.object(runner_ui.logger, "error") as ui_error:
-            with unittest.TestCase().assertRaises(CommandExecutionFailed) as context:
-                await runner_ui.run()
+async def _assert_arbitrary_runner_ui_failure_redacted(run_workflow, ui):
+    with unittest.TestCase().assertRaises(CommandExecutionFailed) as context:
+        await run_workflow()
 
     text = " ".join(
         str(value)
         for value in (
-            command_error.call_args_list,
-            ui_error.call_args_list,
             context.exception,
-            runner_ui.ui.updates,
+            ui.updates,
         )
     )
     unittest.TestCase().assertIn("RuntimeError", text)


### PR DESCRIPTION
## Summary
- Convert async/sync command-runner UI adapters into presentation-only UI session adapters.
- Move async and sync command execution orchestration into `CommandWorkflow`.
- Preserve command-runner status, aggregate error/success, and redaction behavior through tests.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_command_runner_ui_failure_semantics tests.architecture.test_hexagonal_imports`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py quality`

Closes #80