### PR TITLE
Clarify console status completion semantics

### DIFF
--- a/.codex/evidence/slice-75-consolidation.md
+++ b/.codex/evidence/slice-75-consolidation.md
@@ -1,0 +1,55 @@
+# Slice 75 Consolidation
+
+Workflow id: `issue-75-status-display-purpose-20260614`
+Slice id: `S01-S04`
+Slice title: Clarify status display purpose
+
+Stream results:
+
+- UI semantics: empty instance collections no longer complete unless aggregate
+  status is terminal.
+- tests: Linux UI tests now cover empty-instance pending and aggregate terminal
+  completion.
+- documentation: arc42 runtime view states console/status UI is advisory.
+
+Accepted findings:
+
+- Setup-style UI can use zero concrete instances, but workflow completion must
+  be published through explicit aggregate status.
+
+Rejected findings:
+
+- No new required operator UI target list is needed for setup.
+
+Files changed per stream:
+
+- UI semantics: `src/tiny_swarm_world/application/ports/ui/port_ui.py`
+- tests: `tests/infrastructure/adapters/ui/test_linux_ui.py`
+- documentation: `documentation/arc42/06_runtime_view.adoc`
+- evidence: `.codex/evidence/slice-75-distribution.md`,
+  `.codex/evidence/slice-75-consolidation.md`
+
+Conflicts found:
+
+- None.
+
+Tests executed:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`:
+  passed.
+- `python3 tools/quality_gate.py lint`: passed.
+- `python3 tools/quality_gate.py quality`: passed. The full gate executed lint,
+  arch-lint, arch-tests, typecheck, and 881 unit tests with 17 skipped.
+
+SonarQube findings and fixes:
+
+- Pending remote PR lifecycle.
+
+Documentation updates:
+
+- arc42 runtime view documents advisory status display and explicit aggregate
+  completion for empty instance collections.
+
+Final integration decision:
+
+- Accepted for PR lifecycle after required remote checks pass.

--- a/.codex/evidence/slice-75-distribution.md
+++ b/.codex/evidence/slice-75-distribution.md
@@ -1,0 +1,48 @@
+# Slice 75 Distribution
+
+Workflow id: `issue-75-status-display-purpose-20260614`
+Slice id: `S01-S04`
+Slice title: Clarify status display purpose
+
+Affected areas:
+
+- application UI port
+- Linux terminal UI tests
+- architecture documentation
+
+Chosen execution mode: sequential.
+
+Selected streams:
+
+- UI semantics: make empty instance handling deliberate.
+- tests: cover empty instance completion and aggregate completion.
+- documentation: record console/status UI as advisory status display.
+
+Real subagents used: no. This slice is small and follows directly from #83 and
+#82.
+
+Fallback role-based review used: yes.
+
+Git worktrees used: no.
+
+Conflict risks:
+
+- Setup UI intentionally uses `instances=()` and must remain valid.
+- Completion must come from aggregate workflow state, not accidental
+  `all([])` truthiness.
+
+Quality gates to run:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`
+- `python3 tools/quality_gate.py lint`
+- `python3 tools/quality_gate.py quality`
+
+Consolidation plan:
+
+- Change `PortUI.all_instances_terminal()`.
+- Add focused UI tests.
+- Update runtime documentation.
+
+Parallelization decision:
+
+- Rejected because one small semantic change spans one port and its tests.

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -165,6 +165,13 @@ known recovery path exists. Successful setup-style terminal values such as
 `completed`, `passed`, and `verified` remain terminal success states and do
 not render recovery guidance.
 
+Console/status UI output is advisory status display, not the authoritative
+source of workflow completion. Setup and command workflows decide completion
+from application results, then publish aggregate status to the UI. Empty UI
+instance collections are valid for setup-style aggregate status, but they do
+not complete by default; completion requires an explicit terminal aggregate
+status event.
+
 When an aggregate setup state is terminal while individual rows are still
 pending, the Linux terminal renderer shows the aggregate status and recovery
 guidance explicitly. This avoids relying on color and prevents refused,

--- a/src/tiny_swarm_world/application/ports/ui/port_ui.py
+++ b/src/tiny_swarm_world/application/ports/ui/port_ui.py
@@ -108,6 +108,8 @@ class PortUI(ABC):
     def all_instances_terminal(self):
         if self.is_terminal_result(self.aggregate_status["result"]):
             return True
+        if not self.instances:
+            return False
         return all(
             self.is_terminal_result(self.status[instance]["result"])
             for instance in self.instances

--- a/tests/infrastructure/adapters/ui/test_linux_ui.py
+++ b/tests/infrastructure/adapters/ui/test_linux_ui.py
@@ -234,6 +234,24 @@ class TestLinuxUI(unittest.TestCase):
         self.assertTrue(self.ui.all_instances_terminal())
         self.assertEqual("All instances completed with errors", self.ui.completion_summary())
 
+    def test_empty_instance_status_is_not_complete_without_terminal_aggregate(self):
+        ui = LinuxUI(())
+
+        self.assertFalse(ui.all_instances_terminal())
+
+    def test_empty_instance_status_completes_from_terminal_aggregate_only(self):
+        ui = LinuxUI(())
+
+        ui.update_status(
+            AGGREGATE_INSTANCE,
+            task="setup",
+            step="complete",
+            result=STATUS_SUCCESS,
+        )
+
+        self.assertTrue(ui.all_instances_terminal())
+        self.assertEqual("All instances completed", ui.completion_summary())
+
     @patch("asyncio.get_running_loop", return_value=asyncio.new_event_loop())
     @patch("threading.Thread")
     def test_run_in_thread(self, mock_thread, mock_loop):


### PR DESCRIPTION
## Summary
- Treat console/status UI output as advisory status display, not authoritative workflow completion.
- Make empty UI instance collections deliberately pending until an explicit terminal aggregate status is published.
- Add focused Linux UI tests for empty-instance completion semantics.

## Verification
- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.ui.test_linux_ui`
- `python3 tools/quality_gate.py lint`
- `python3 tools/quality_gate.py quality`

Closes #75