### PR TITLE
fix(quality): resolve sonar leak findings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,8 @@ case "${1:-}" in
     usage
     exit 0
     ;;
+  *)
+    ;;
 esac
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/pylock.toml
+++ b/pylock.toml
@@ -1,0 +1,81 @@
+lock-version = "1.0"
+environments = ["sys_platform == 'linux'"]
+requires-python = ">=3.12"
+created-by = "tiny-swarm-world"
+
+[[packages]]
+name = "annotated-types"
+version = "0.7.0"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "certifi"
+version = "2024.7.4"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "charset-normalizer"
+version = "3.4.1"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "idna"
+version = "3.10"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "pydantic"
+version = "2.10.6"
+index = "https://pypi.org/simple/"
+dependencies = [
+  {name = "annotated-types"},
+  {name = "pydantic-core"},
+  {name = "typing-extensions"},
+]
+
+[[packages]]
+name = "pydantic-core"
+version = "2.27.2"
+index = "https://pypi.org/simple/"
+dependencies = [
+  {name = "typing-extensions"},
+]
+
+[[packages]]
+name = "PyYAML"
+version = "6.0.1"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "requests"
+version = "2.32.0"
+index = "https://pypi.org/simple/"
+dependencies = [
+  {name = "certifi"},
+  {name = "charset-normalizer"},
+  {name = "idna"},
+  {name = "urllib3"},
+]
+
+[[packages]]
+name = "ruamel.yaml"
+version = "0.17.21"
+index = "https://pypi.org/simple/"
+dependencies = [
+  {name = "ruamel.yaml.clib"},
+]
+
+[[packages]]
+name = "ruamel.yaml.clib"
+version = "0.2.8"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "typing-extensions"
+version = "4.15.0"
+index = "https://pypi.org/simple/"
+
+[[packages]]
+name = "urllib3"
+version = "2.0.7"
+index = "https://pypi.org/simple/"

--- a/src/tiny_swarm_world/__main__.py
+++ b/src/tiny_swarm_world/__main__.py
@@ -413,13 +413,12 @@ def _blocked_workflow_result(workflow: CliWorkflow) -> dict[str, object]:
 
 def _live_consent_from_args(args: Namespace) -> LiveConsent:
     confirmed = bool(args.approve_live)
-    if args.live:
-        if not confirmed:
-            try:
-                answer = input(f"{LIVE_CONSENT_PROMPT} ")
-                confirmed = answer.strip().lower() in LIVE_CONSENT_YES_VALUES
-            except EOFError:
-                confirmed = False
+    if args.live and not confirmed:
+        try:
+            answer = input(f"{LIVE_CONSENT_PROMPT} ")
+            confirmed = answer.strip().lower() in LIVE_CONSENT_YES_VALUES
+        except EOFError:
+            confirmed = False
     return LiveConsent(live_flag=args.live, confirmed=confirmed)
 
 

--- a/src/tiny_swarm_world/application/services/platform/node_provider_selection.py
+++ b/src/tiny_swarm_world/application/services/platform/node_provider_selection.py
@@ -390,7 +390,7 @@ def _selection_evidence(
             candidate.value for candidate in backend_selection.candidates
         )
     for key, value in backend_selection.evidence.items():
-        if key.startswith("selected_") or key.startswith("skipped_"):
+        if key.startswith(("selected_", "skipped_")):
             evidence[key] = value
     return evidence
 

--- a/src/tiny_swarm_world/application/services/platform/portainer_verify.py
+++ b/src/tiny_swarm_world/application/services/platform/portainer_verify.py
@@ -7,7 +7,7 @@ from tiny_swarm_world.domain.inventory import VerificationResult
 
 class PortainerVerificationService(Protocol):
     async def verify(self) -> VerificationResult:
-        pass
+        ...
 
 
 class PortainerEndpointVerifyStep:

--- a/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py
@@ -11,7 +11,6 @@ from tiny_swarm_world.application.services.commands.command_builder.vm_parameter
 from tiny_swarm_world.application.services.commands.command_executer.command_executer import CommandExecuter
 from tiny_swarm_world.application.ports.commands.parameter_type import ParameterType
 from tiny_swarm_world.application.ports.commands.executable_command import ExecutableCommandEntity
-from tiny_swarm_world.domain.command.command_entity import CommandCatalogValidationError
 from tiny_swarm_world.domain.command.vm_entity import VmEntity
 from tiny_swarm_world.domain.command.vm_type import VmType
 from tiny_swarm_world.domain.command.verification_probe import is_probe_allowed_for_workflow
@@ -149,7 +148,7 @@ class CommandWorkflow(PortCommandWorkflow):
                 parameter,
                 workflow_id=workflow_id,
             )
-        except (CommandCatalogValidationError, TypeError, ValueError):
+        except (TypeError, ValueError):
             return VerificationResult(
                 target_id=target_id,
                 status=VerificationStatus.BLOCKED,

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -389,21 +389,34 @@ def _load_export_file(path: Path) -> dict[str, str]:
         return {}
     values: dict[str, str] = {}
     for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
+        assignment = _export_assignment_from_line(raw_line)
+        if assignment is None:
             continue
-        if line.startswith("export "):
-            line = line.removeprefix("export ").strip()
-        if "=" not in line:
-            continue
-        name, raw_value = line.split("=", 1)
-        if name.isidentifier():
-            try:
-                parsed = shlex.split(raw_value, posix=True)
-            except ValueError:
-                parsed = [raw_value]
-            values[name] = parsed[0] if parsed else ""
+        name, raw_value = assignment
+        values[name] = _parse_export_value(raw_value)
     return values
+
+
+def _export_assignment_from_line(raw_line: str) -> tuple[str, str] | None:
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("export "):
+        line = line.removeprefix("export ").strip()
+    if "=" not in line:
+        return None
+    name, raw_value = line.split("=", 1)
+    if not name.isidentifier():
+        return None
+    return name, raw_value
+
+
+def _parse_export_value(raw_value: str) -> str:
+    try:
+        parsed = shlex.split(raw_value, posix=True)
+    except ValueError:
+        parsed = [raw_value]
+    return parsed[0] if parsed else ""
 
 
 def _generated_secret_values(entries: Sequence[InstallerSecretEntry]) -> dict[str, str]:

--- a/tests/application/services/deployment/test_ensure_portainer_stack.py
+++ b/tests/application/services/deployment/test_ensure_portainer_stack.py
@@ -21,8 +21,7 @@ class TestEnsurePortainerStack(unittest.IsolatedAsyncioTestCase):
         await service.run()
 
         compose_repository.get_compose_of.assert_called_once_with("portainer")
-        self.assertEqual(1, len(deployment_gateway.applied_requests))
-        request = deployment_gateway.applied_requests[0]
+        request = _single_applied_request(deployment_gateway)
         self.assertEqual("portainer", request.target_stack)
         self.assertEqual(stack_definition, request.stack_definition)
 
@@ -35,8 +34,8 @@ class TestEnsurePortainerStack(unittest.IsolatedAsyncioTestCase):
         service = EnsurePortainerStack(compose_repository, deployment_gateway, "portainer")
         await service.run()
 
-        self.assertEqual(1, len(deployment_gateway.applied_requests))
-        self.assertEqual(stack_definition, deployment_gateway.applied_requests[0].stack_definition)
+        request = _single_applied_request(deployment_gateway)
+        self.assertEqual(stack_definition, request.stack_definition)
 
     async def test_compose_lookup_failure_does_not_deploy_stack(self):
         compose_repository = MagicMock()
@@ -76,6 +75,13 @@ class _FakeDeploymentGateway:
 
     def stack_registered(self, stack_name: str) -> bool:
         return bool(self.applied_requests)
+
+
+def _single_applied_request(
+    deployment_gateway: _FakeDeploymentGateway,
+) -> DeploymentStackRequest:
+    (request,) = deployment_gateway.applied_requests
+    return request
 
 
 if __name__ == "__main__":

--- a/tests/application/services/deployment/test_ensure_service_stack.py
+++ b/tests/application/services/deployment/test_ensure_service_stack.py
@@ -24,8 +24,7 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
         await service.run()
 
         self.assertEqual(["jenkins"], compose_repository.requested_stacks)
-        self.assertEqual(1, len(deployment_gateway.applied_requests))
-        request = deployment_gateway.applied_requests[0]
+        request = _single_applied_request(deployment_gateway)
         self.assertEqual("jenkins", request.target_stack)
         self.assertEqual(stack_definition, request.stack_definition)
         self.assertEqual({}, dict(request.stack_environment))
@@ -42,8 +41,8 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
 
         await service.run()
 
-        self.assertEqual(1, len(deployment_gateway.applied_requests))
-        self.assertEqual("rabbitmq", deployment_gateway.applied_requests[0].target_stack)
+        request = _single_applied_request(deployment_gateway)
+        self.assertEqual("rabbitmq", request.target_stack)
 
     async def test_passes_stack_environment_when_creating_service_access_stack(self):
         stack_definition = StackDefinition(name="service-access", compose_content="services: {}")
@@ -60,7 +59,7 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             {"TSW_VAULTWARDEN_ADMIN_TOKEN_SECRET": "operator_defined"},
-            dict(deployment_gateway.applied_requests[0].stack_environment),
+            dict(_single_applied_request(deployment_gateway).stack_environment),
         )
 
     async def test_treats_create_timeout_as_success_when_stack_registration_is_visible(self):
@@ -74,11 +73,17 @@ class TestEnsureServiceStack(unittest.IsolatedAsyncioTestCase):
             compose_repository,
             deployment_gateway,
             ServiceStackContract("swagger", ("swagger-ui",)),
+            stack_environment={"TSW_SWAGGER_PUBLIC_URL": "https://swagger.example.test"},
             verify_wait_seconds=0,
         )
 
         await service.run()
 
+        request = _single_applied_request(deployment_gateway)
+        self.assertEqual(
+            {"TSW_SWAGGER_PUBLIC_URL": "https://swagger.example.test"},
+            dict(request.stack_environment),
+        )
         self.assertEqual(["swagger"], deployment_gateway.registration_checks)
 
     async def test_treats_update_timeout_as_success_when_stack_registration_is_visible(self):
@@ -249,3 +254,10 @@ class _FakeDeploymentGateway:
         if self.registered_values:
             return self.registered_values.pop(0)
         return False
+
+
+def _single_applied_request(
+    deployment_gateway: _FakeDeploymentGateway,
+) -> DeploymentStackRequest:
+    (request,) = deployment_gateway.applied_requests
+    return request

--- a/tools/live/nexus-docker-cache.sh
+++ b/tools/live/nexus-docker-cache.sh
@@ -16,9 +16,11 @@ NEXUS_ADMIN_PASSWORD="${NEXUS_ADMIN_PASSWORD:-}"
 NEXUS_REPOSITORY_NAME="${NEXUS_REPOSITORY_NAME:-docker-hub-proxy}"
 JSON_CONTENT_TYPE_HEADER="Content-Type: application/json"
 
-# For normal local Docker use: 127.0.0.1
+# For normal local Docker use: localhost.
 # For LXC nodes, set this to an IP/hostname reachable from inside the nodes.
-NEXUS_REGISTRY_HOST="${NEXUS_REGISTRY_HOST:-127.0.0.1}"
+NEXUS_LOCAL_API_HOST="${NEXUS_LOCAL_API_HOST:-localhost}"
+NEXUS_REGISTRY_HOST="${NEXUS_REGISTRY_HOST:-localhost}"
+NEXUS_LOCAL_API_BASE_URL="http://${NEXUS_LOCAL_API_HOST}:${NEXUS_WEB_PORT}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE_LIST_FILE="${IMAGE_LIST_FILE:-${SCRIPT_DIR}/images-to-cache.txt}"
@@ -50,7 +52,7 @@ wait_for_nexus() {
   log "Waiting for Nexus to become reachable..."
 
   for _ in $(seq 1 120); do
-    if curl -fsS "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/status" >/dev/null 2>&1; then
+    if curl -fsS "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/status" >/dev/null 2>&1; then
       log "Nexus is reachable."
       return 0
     fi
@@ -80,7 +82,7 @@ set_admin_password_if_needed() {
     -X PUT \
     -H "Content-Type: text/plain" \
     --data "${NEXUS_ADMIN_PASSWORD}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/security/users/admin/change-password" >/dev/null
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/security/users/admin/change-password" >/dev/null
 }
 
 enable_docker_bearer_token_realm() {
@@ -88,7 +90,7 @@ enable_docker_bearer_token_realm() {
 
   local active_realms
   active_realms="$(curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/security/realms/active")"
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/security/realms/active")"
 
   if printf '%s' "${active_realms}" | grep -q '"DockerToken"'; then
     log "Docker Bearer Token Realm is already active."
@@ -102,7 +104,7 @@ enable_docker_bearer_token_realm() {
     -X PUT \
     -H "$JSON_CONTENT_TYPE_HEADER" \
     --data "${updated_realms}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/security/realms/active" >/dev/null
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/security/realms/active" >/dev/null
 }
 
 accept_community_eula() {
@@ -110,7 +112,7 @@ accept_community_eula() {
 
   local eula_status
   eula_status="$(curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/system/eula" || true)"
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/system/eula" || true)"
 
   if printf '%s' "${eula_status}" | grep -q '"accepted"[[:space:]]*:[[:space:]]*true'; then
     log "Nexus Community EULA is already accepted."
@@ -126,7 +128,7 @@ accept_community_eula() {
     -X POST \
     -H "$JSON_CONTENT_TYPE_HEADER" \
     --data "${accepted_payload}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/system/eula" >/dev/null
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/system/eula" >/dev/null
 }
 
 enable_anonymous_access() {
@@ -140,12 +142,12 @@ enable_anonymous_access() {
       "userId": "anonymous",
       "realmName": "NexusAuthorizingRealm"
     }' \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/security/anonymous" >/dev/null
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/security/anonymous" >/dev/null
 }
 
 repository_exists() {
   curl -fsS -u "admin:${NEXUS_ADMIN_PASSWORD}" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/repositories/${NEXUS_REPOSITORY_NAME}" >/dev/null 2>&1
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/repositories/${NEXUS_REPOSITORY_NAME}" >/dev/null 2>&1
 }
 
 create_docker_proxy_repository() {
@@ -190,7 +192,7 @@ create_docker_proxy_repository() {
         \"foreignLayerUrlWhitelist\": []
       }
     }" \
-    "http://127.0.0.1:${NEXUS_WEB_PORT}/service/rest/v1/repositories/docker/proxy" >/dev/null
+    "${NEXUS_LOCAL_API_BASE_URL}/service/rest/v1/repositories/docker/proxy" >/dev/null
 }
 
 start_nexus() {
@@ -290,7 +292,7 @@ main() {
   cache_images
 
   log "Done."
-  log "Nexus UI:      http://127.0.0.1:${NEXUS_WEB_PORT}"
+  log "Nexus UI:      ${NEXUS_LOCAL_API_BASE_URL}"
   log "Docker cache: http://${NEXUS_REGISTRY_HOST}:${NEXUS_DOCKER_PROXY_PORT}"
 }
 


### PR DESCRIPTION
## Summary

- Resolve SonarCloud leak-period findings across Python, shell, and tests.
- Centralize the Nexus Docker cache local API host while keeping live Nexus/Docker execution out of verification.
- Add a Linux-scoped Python lock file for dependency evidence.

## Changed files / areas

- `tools/live/nexus-docker-cache.sh`: configurable local API host and shell cleanup.
- `install.sh`: shell-case cleanup.
- `src/tiny_swarm_world/__main__.py`: simplify live-consent flow.
- `src/tiny_swarm_world/application/services/platform/*`: Python quality cleanup.
- `src/tiny_swarm_world/infrastructure/adapters/command_runner/command_workflow.py`: remove unreachable exception handling.
- `src/tiny_swarm_world/installer.py`: split export parsing helpers.
- `tests/application/services/deployment/*`: replace duplicated list indexing with helpers and cover stack environment preservation.
- `pylock.toml`: Linux/Python 3.12 dependency lock evidence.

## Verification

- PASS: `python3 tools/quality_gate.py quality`
- PASS: `bash -n install.sh && bash -n tools/live/nexus-docker-cache.sh`
- PASS: `git diff --check origin/main...HEAD`

## Impact

- Quality, tests, installer parsing, CLI consent flow, command workflow validation, and optional Nexus cache helper only.
- No breaking changes expected.

## Risks and limitations

- Live Nexus/Docker behavior was not executed by design under project safety rules.

## Push auto lifecycle

This PR is being handled by `push auto`: wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run local cleanup after merge verification.