### PR TITLE
docs(documentation): consolidate operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,9 @@ until a `LICENSE` file or explicit license statement is added.
 
 ## Links
 
+- Documentation root: `documentation/README.adoc`
+- System architecture: `documentation/arc42.adoc`
+- User handbook: `documentation/user-handbook.adoc`
 - Portainer: https://www.portainer.io/
 - LXD: https://documentation.ubuntu.com/lxd/
 - Incus: https://linuxcontainers.org/incus/

--- a/documentation/README.adoc
+++ b/documentation/README.adoc
@@ -1,0 +1,46 @@
+= Tiny Swarm World Documentation
+:toc:
+:sectnums:
+
+This directory is the documentation root for Tiny Swarm World. The canonical
+reader entry points are:
+
+* xref:arc42.adoc[System Architecture, arc42] for the complete system model,
+  architecture constraints, runtime behavior, deployment topology, risks, and
+  decision references.
+* xref:user-handbook.adoc[User Handbook] for operator-facing installation,
+  operation, credential access, verification, and troubleshooting steps.
+* xref:configuration/operator-configuration-contract.md[Operator Configuration
+  Contract] for supported environment variables and secret lifecycle rules.
+* xref:system/live-operation-surfaces.adoc[Live Operation Surfaces] for commands
+  and assets that can mutate local infrastructure.
+
+== Documentation Structure
+
+[options="header"]
+|===
+| Path | Role
+| `arc42.adoc` | Canonical architecture book assembled from `documentation/arc42`.
+| `arc42/` | Maintained arc42 section sources.
+| `user-handbook.adoc` | Canonical operator handbook with step-by-step use cases.
+| `user_guide/` | Detailed user-guide source pages used by the handbook.
+| `system/` | Runtime, LXC-native, networking, and live-operation reference pages.
+| `deployment/` | Deployment and Infisical setup reference pages.
+| `configuration/` | Operator configuration and secret contract references.
+| `architecture/` | ADRs and architecture analysis records. ADRs are historical decision records and are not rewritten during documentation consolidation.
+| `epics/` | Requirement and epic context.
+| `process/` | Repository process, workflow, and skill/agent documentation.
+| `workflow/` | Active and issue-scoped workflow records. These are execution artifacts, not the primary user handbook.
+| `skill-audit/` | Skill registry and ownership audit artifacts.
+|===
+
+== Consolidation Rules
+
+Use `arc42.adoc` and `user-handbook.adoc` as the two primary readable books.
+Keep detailed reference pages in their existing folders when they carry
+specialized operational, ADR, or workflow evidence. Do not copy password values,
+tokens, host-specific IP addresses, or generated local evidence into committed
+documentation.
+
+When behavior changes, update the nearest source page and then update the
+canonical book that exposes the behavior to readers.

--- a/documentation/arc42.adoc
+++ b/documentation/arc42.adoc
@@ -1,0 +1,184 @@
+= Tiny Swarm World Architecture
+:doctype: book
+:toc:
+:toc-title: Contents
+:sectnums:
+:sectnumlevels: 5
+:chapter-label:
+:icons: font
+
+This is the canonical arc42 system documentation for Tiny Swarm World. It
+assembles the maintained section files under `documentation/arc42` and adds
+reader-oriented diagrams that describe the verified architecture without
+promoting workflow records or ADR history into duplicate source material.
+
+== System Overview Diagrams
+
+=== Context Diagram
+
+[plantuml,tiny-swarm-world-context,svg]
+----
+@startuml
+!pragma layout smetana
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+actor Operator
+rectangle "Linux or WSL shell" as Shell
+component "Tiny Swarm World\nPython CLI" as CLI
+component "Configuration\ninfra/config" as Config
+database "Ignored local state\n.tiny-swarm-world\n.tiny-swarm" as LocalState
+cloud "LXD or Incus" as Provider
+node "Managed LXC nodes" as Nodes {
+  component "Docker Engine" as Docker
+  component "Docker Swarm" as Swarm
+}
+component "Portainer" as Portainer
+component "Service stacks\nNexus, Jenkins, RabbitMQ,\nSonarQube, Swagger/NGINX,\nInfisical, Service Access,\nTraefik" as Stacks
+
+Operator --> Shell
+Shell --> CLI
+CLI --> Config
+CLI --> LocalState
+CLI --> Provider
+Provider --> Nodes
+Docker --> Swarm
+Swarm --> Portainer
+Portainer --> Stacks
+CLI --> Portainer : deployment gateway
+CLI --> Stacks : readiness and evidence checks
+@enduml
+----
+
+=== Hexagonal Building Blocks
+
+[plantuml,tiny-swarm-world-hexagonal,svg]
+----
+@startuml
+!pragma layout smetana
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+package "Domain" {
+  component "Command, provider,\nnetwork, deployment,\nsecret, ingress,\npreflight models" as Domain
+}
+package "Application" {
+  component "Use cases and\nworkflow services" as AppServices
+  interface "Ports" as Ports
+}
+package "Infrastructure" {
+  component "Composition root" as Composition
+  component "Command runners" as Commands
+  component "YAML and file adapters" as Files
+  component "HTTP/CLI clients" as Clients
+  component "Console/status UI" as UI
+}
+component "CLI entry point" as Entrypoint
+
+Entrypoint --> Composition
+Composition --> AppServices
+AppServices --> Domain
+AppServices --> Ports
+Commands ..|> Ports
+Files ..|> Ports
+Clients ..|> Ports
+UI ..|> Ports
+Composition --> Commands
+Composition --> Files
+Composition --> Clients
+Composition --> UI
+@enduml
+----
+
+=== Guided Setup Runtime Flow
+
+[plantuml,tiny-swarm-world-setup-flow,svg]
+----
+@startuml
+skinparam shadowing false
+actor Operator
+participant "install.sh" as Install
+participant "tiny-swarm-world CLI" as CLI
+participant "Preflight" as Preflight
+participant "Platform" as Platform
+participant "Artifacts" as Artifacts
+participant "Deployment" as Deployment
+participant "Verification" as Verify
+database "Sanitized evidence" as Evidence
+
+Operator -> Install : ./install.sh
+Install -> CLI : platform reset --live --confirm ...
+CLI -> Preflight : validate host, config, ports, consent
+CLI -> Platform : reset managed TSW state
+CLI -> Evidence : write reset log and exit code
+Install -> CLI : setup run --live --service-profile service-access
+CLI -> Preflight : fail closed if prerequisites are missing
+CLI -> Platform : provider nodes, Docker, Swarm, exposure
+CLI -> Artifacts : registry, Nexus, image contracts
+CLI -> Deployment : Portainer bootstrap and stack contracts
+CLI -> Verify : observed-state checks
+CLI -> Evidence : write setup log and exit code
+@enduml
+----
+
+=== Deployment Topology
+
+[plantuml,tiny-swarm-world-deployment,svg]
+----
+@startuml
+!pragma layout smetana
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+node "Linux/WSL host" {
+  component "Operator shell" as Shell
+  component "Tiny Swarm World CLI" as CLI
+  database "local env and evidence\nignored by Git" as Evidence
+}
+
+cloud "LXD or Incus" {
+  node "swarm-manager" {
+    component "Docker Engine" as MgrDocker
+    component "Swarm manager" as Manager
+    component "Traefik ingress\n80/443" as Traefik
+    component "Portainer" as Portainer
+    component "Service stacks" as ServiceStacks
+  }
+  node "swarm-worker-1" as Worker1
+  node "swarm-worker-2" as Worker2
+}
+
+Shell --> CLI
+CLI --> Evidence
+CLI --> MgrDocker
+Manager --> Worker1
+Manager --> Worker2
+Traefik --> ServiceStacks
+Portainer --> ServiceStacks
+CLI --> Portainer
+@enduml
+----
+
+include::arc42/01_introduction.adoc[leveloffset=+1]
+
+include::arc42/02_constraints.adoc[leveloffset=+1]
+
+include::arc42/04_context_and_scope.adoc[leveloffset=+1]
+
+include::arc42/03_solution_strategy.adoc[leveloffset=+1]
+
+include::arc42/05_building_blocks.adoc[leveloffset=+1]
+
+include::arc42/06_runtime_view.adoc[leveloffset=+1]
+
+include::arc42/07_deployment_view.adoc[leveloffset=+1]
+
+include::arc42/08_concepts.adoc[leveloffset=+1]
+
+include::arc42/09_architecture_decisions.adoc[leveloffset=+1]
+
+include::arc42/10_quality_requirements.adoc[leveloffset=+1]
+
+include::arc42/11_risks_and_debt.adoc[leveloffset=+1]
+
+include::arc42/12_glossary.adoc[leveloffset=+1]

--- a/documentation/document.adoc
+++ b/documentation/document.adoc
@@ -11,7 +11,8 @@
 
 **Your tiny Docker swarm for big ideas.**
 
-include::system/system.adoc[]
+include::README.adoc[leveloffset=+1]
 
-= HowTo
-include::Howto.adoc[]
+include::arc42.adoc[leveloffset=+1]
+
+include::user-handbook.adoc[leveloffset=+1]

--- a/documentation/user-handbook.adoc
+++ b/documentation/user-handbook.adoc
@@ -1,0 +1,387 @@
+= Tiny Swarm World User Handbook
+:doctype: book
+:toc:
+:toc-title: Contents
+:sectnums:
+:sectnumlevels: 4
+:chapter-label:
+:icons: font
+
+This handbook explains how to operate Tiny Swarm World from a Linux or WSL
+shell without reading source code or generated local files as the normal
+navigation method. It references local ignored files only where an operator
+must intentionally provide or recover local secrets.
+
+== Operating Model
+
+Tiny Swarm World prepares a local Docker Swarm target environment on managed
+LXC nodes through LXD or Incus. The supported operator surface is the
+`tiny-swarm-world` CLI and the Linux/WSL `install.sh` wrapper. Multipass and
+Windows-native execution are not supported node-provider paths.
+
+[plantuml,user-handbook-operator-map,svg]
+----
+@startuml
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+actor Operator
+component "Linux/WSL shell" as Shell
+component "install.sh" as Installer
+component "tiny-swarm-world CLI" as CLI
+component "LXD or Incus" as Provider
+node "Managed Docker Swarm" as Swarm
+component "Service Access\nlanding page" as Access
+component "Infisical" as Infisical
+database "Ignored local env\nand evidence" as Local
+
+Operator --> Shell
+Shell --> Installer
+Shell --> CLI
+Installer --> CLI
+CLI --> Provider
+Provider --> Swarm
+Swarm --> Access
+Swarm --> Infisical
+Installer --> Local
+CLI --> Local
+Access --> Infisical : credential references
+@enduml
+----
+
+== Before You Start
+
+Use a Linux or WSL2 shell from the repository root. Prepare:
+
+* Python 3.12;
+* Git;
+* LXD or Incus initialized and usable from the same shell;
+* Docker CLI access for diagnostics;
+* `socat` when WSL localhost forwarding is required.
+
+Install the Python package in editable mode:
+
+[source,bash]
+----
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
+----
+
+Verify development readiness without live infrastructure mutation:
+
+[source,bash]
+----
+python3 tools/quality_gate.py quality
+tiny-swarm-world --list-workflows
+tiny-swarm-world --preflight
+----
+
+If the package is not installed yet, use the source checkout fallback:
+
+[source,bash]
+----
+PYTHONPATH=src python3 -m tiny_swarm_world --list-workflows
+PYTHONPATH=src python3 -m tiny_swarm_world --preflight
+----
+
+== Prepare Operator Configuration
+
+The tracked template is `.env.example`. Copy the keys you want to provide into
+the ignored local runtime file:
+
+[source,bash]
+----
+mkdir -p .tiny-swarm-world/local
+cp .env.example .tiny-swarm-world/local/live-installation.env
+chmod 600 .tiny-swarm-world/local/live-installation.env
+----
+
+Edit `.tiny-swarm-world/local/live-installation.env` and replace placeholder
+values. Process environment values override this file. If `./install.sh` runs
+with secret generation enabled, missing generated local secrets are created and
+kept in ignored local files instead of being printed.
+
+The required values are defined by
+`infra/config/secrets/infisical-secrets.yaml` and summarized in
+`documentation/configuration/operator-configuration-contract.md`. The important
+operator groups are:
+
+* service administrator passwords for Portainer, Nexus, Jenkins, RabbitMQ, and
+  SonarQube;
+* shared PostgreSQL and SonarQube PostgreSQL passwords;
+* Infisical bootstrap values;
+* Traefik TLS Docker secret names for certificate and key material.
+
+Do not commit `.tiny-swarm-world/local/live-installation.env`,
+`.tiny-swarm/secrets/bootstrap.local.env`,
+`.tiny-swarm/secrets/generated.local.env`, or evidence files.
+
+== Run The Guided Installation
+
+For a full fresh local install with evidence capture:
+
+[source,bash]
+----
+./install.sh
+----
+
+The wrapper first asks for the reset phrase `RESET_TINY_SWARM_PLATFORM`, then
+runs the governed platform reset, then starts `setup run --live` with the
+default `service-access` profile. The CLI live prompt is separate:
+
+[source,text]
+----
+Live setup can change local infrastructure. Continue? [y/N]:
+----
+
+Answer `y` only when changing local LXD/Incus/LXC state, Docker Swarm,
+networking, Portainer, Nexus, service stacks, images, and credentials is
+intentional.
+
+For deliberate repeatable test-system automation:
+
+[source,bash]
+----
+./install.sh --confirm-reset
+./install.sh --confirm-reset --non-interactive-live-approval
+----
+
+For headless systems:
+
+[source,bash]
+----
+./install.sh --headless
+TSW_INSTALL_HEADLESS=1 ./install.sh
+----
+
+The wrapper writes run context, reset logs, setup logs, and exit codes below:
+
+[source,text]
+----
+.tiny-swarm-world/evidence/installation-tests/<host-runtime>/<UTC timestamp>/
+----
+
+`<host-runtime>` is `wsl2` for WSL2 and `native_linux` for native Linux.
+
+== Use The CLI Directly
+
+List supported workflows:
+
+[source,bash]
+----
+tiny-swarm-world --list-workflows
+----
+
+Run a non-mutating preflight:
+
+[source,bash]
+----
+tiny-swarm-world --preflight
+tiny-swarm-world --lxc-backend lxd --preflight
+tiny-swarm-world --lxc-backend incus --preflight
+----
+
+Run the canonical live setup directly:
+
+[source,bash]
+----
+tiny-swarm-world setup run --live
+tiny-swarm-world --lxc-backend lxd setup run --live
+tiny-swarm-world --lxc-backend incus setup run --live
+----
+
+Run read-only post-install verification:
+
+[source,bash]
+----
+tiny-swarm-world platform verify
+----
+
+Reset or destroy require exact confirmation and live consent:
+
+[source,bash]
+----
+tiny-swarm-world platform reset --confirm RESET_TINY_SWARM_PLATFORM --live
+tiny-swarm-world platform destroy --confirm DESTROY_TINY_SWARM_PLATFORM --live
+----
+
+== Open The Services
+
+The default full setup uses the `service-access` profile. After a verified
+deployment, use the Service Access landing page as the operator start page:
+
+[source,text]
+----
+http://localhost
+----
+
+Common local service routes and ports are:
+
+[options="header"]
+|===
+| Service | Default route or port | Notes
+| Service Access | `http://localhost` and compatibility route `http://localhost:8086` | Static management table with service links and Infisical item references.
+| Infisical | `/infisical` through local ingress or `http://localhost:8086` | Secret-management UI for authorized operators.
+| Portainer | `/portainer` or `http://localhost:9000` | Deployment gateway after bootstrap.
+| Nexus | `/nexus` or `http://localhost:8081` | Repository service and Docker proxy behavior.
+| Jenkins | `/jenkins` or `http://localhost:8080` | CI service.
+| RabbitMQ | `/rabbitmq` or `http://localhost:15672` | Management UI.
+| SonarQube | `/sonarqube` or `http://localhost:9001` | Static analysis service.
+| Swagger/NGINX | `/swagger` or `http://localhost:8084` | API documentation surface.
+| Traefik | ports `80` and `443` | Ingress owner for the service-access setup profile.
+|===
+
+Localhost reachability depends on the selected provider, LXC profile proxy
+state, WSL forwarding, and verified stack deployment. Treat route defaults as
+operator targets, not proof that a service is healthy.
+
+== Get Infisical Credentials
+
+Infisical has two distinct credential concerns:
+
+* bootstrap login credentials for the Infisical UI;
+* service credential entries synchronized into or referenced from Infisical.
+
+The bootstrap login email and initial admin password are resolved during
+installation from the process environment or from:
+
+[source,text]
+----
+.tiny-swarm-world/local/live-installation.env
+----
+
+Check that the expected keys are present without printing password values into
+logs or tickets:
+
+[source,bash]
+----
+grep -q '^TSW_INFISICAL_LOGIN_EMAIL=' .tiny-swarm-world/local/live-installation.env
+grep -q '^TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD=' .tiny-swarm-world/local/live-installation.env
+----
+
+Open the ignored local file in a private terminal or editor to read the
+bootstrap email and password, then use those values to sign in to Infisical at
+the configured Infisical route. The default external URL is:
+
+[source,text]
+----
+http://localhost:8086
+----
+
+The installer also writes Infisical runtime bootstrap material to:
+
+[source,text]
+----
+.tiny-swarm/secrets/bootstrap.local.env
+----
+
+That file is for the self-hosted Infisical stack and recovery workflows, not
+for routine browsing. Keep its mode at `0600`.
+
+After signing in, use the Infisical UI to reveal or copy service secret values.
+The Service Access dashboard intentionally shows only users and Infisical item
+references; it does not display password values. If Infisical item
+synchronization has not been enabled or completed, service values remain in
+the ignored local environment files and the dashboard references are only
+navigation hints.
+
+To intentionally enable optional legacy Infisical item seeding for a local
+run, set:
+
+[source,bash]
+----
+export TSW_SEED_INFISICAL_ITEMS=1
+./install.sh --confirm-reset
+----
+
+The default installer value is `TSW_SEED_INFISICAL_ITEMS=0`, so do not assume
+that every generated service credential has already been copied into Infisical
+unless the setup evidence confirms it.
+
+== Verify A Finished Installation
+
+Use the non-mutating workflow first:
+
+[source,bash]
+----
+tiny-swarm-world platform verify
+----
+
+Then inspect the newest install evidence:
+
+[source,bash]
+----
+find .tiny-swarm-world/evidence/installation-tests -maxdepth 3 -type f \
+  \( -name 'context.txt' -o -name 'reset-run.exit' -o -name 'setup-run.exit' \) \
+  -print
+----
+
+Useful provider checks, using the backend selected for the run:
+
+[source,bash]
+----
+incus list
+incus exec swarm-manager -- docker node ls
+incus exec swarm-manager -- docker stack ls
+incus exec swarm-manager -- docker service ls
+----
+
+For LXD, replace `incus` with `lxc`.
+
+== Troubleshooting Checklist
+
+If `setup run` prints `REFUSED_LIVE_CONSENT_MISSING`, rerun with `--live` and
+answer the confirmation prompt only when mutation is intentional.
+
+If the LXC backend is not ready, verify from the same shell:
+
+[source,bash]
+----
+incus version
+incus info
+lxc version
+lxc info
+----
+
+If a service port is occupied, the preflight accepts it only when the listener
+matches the expected Tiny Swarm World service. Unknown listeners must be
+stopped or remapped before live setup.
+
+If Portainer initialization returns HTTP 409, check whether the configured
+Portainer username and password authenticate. A rejected initialization is
+accepted only when those same requested credentials work immediately
+afterward.
+
+If Service Access is not reachable through `http://localhost`, verify that the
+service-access profile was deployed, Traefik ports `80` and `443` are exposed,
+and WSL localhost forwarding is current. The Swarm node IP can be used for
+diagnosis, but documentation should not commit host-specific IPs.
+
+For deeper troubleshooting, use:
+
+[source,bash]
+----
+python3 tools/install_debugger.py
+python3 tools/install_debugger.py --live
+----
+
+The debugger reports checkout, host-runtime, service-definition, permission,
+and evidence-log findings. Use `--fix-permissions` only for the narrow
+installer execute-bit and local secret-file mode repair.
+
+== Reference Pages
+
+Detailed reference material remains in:
+
+* `documentation/user_guide/installation.adoc`;
+* `documentation/user_guide/usage.adoc`;
+* `documentation/user_guide/troubleshooting.adoc`;
+* `documentation/deployment/infisical-silent-setup.adoc`;
+* `documentation/deployment/system.adoc`;
+* `documentation/system/lxc-native-setup.adoc`;
+* `documentation/system/network.adoc`;
+* `documentation/system/live-operation-surfaces.adoc`;
+* `documentation/configuration/operator-configuration-contract.md`.


### PR DESCRIPTION
## Summary
- Add a documentation root index for canonical reader entry points.
- Add an assembled arc42 architecture book with system overview diagrams.
- Add an operator user handbook for installation, service access, Infisical credentials, verification, and troubleshooting.
- Link the new canonical documents from README and `documentation/document.adoc`.

## Changed files
- `README.md`
- `documentation/README.adoc`
- `documentation/arc42.adoc`
- `documentation/document.adoc`
- `documentation/user-handbook.adoc`

## Verification
- PASS: `python3 tools/quality_gate.py quality`
- PASS: `git diff --cached --check`
- PASS: static referenced-path check for primary documentation files
- NOT EXECUTED: AsciiDoc render, because `asciidoctor` is not installed in this shell

## Impact
- Documentation navigation and operator guidance only.
- No product code, configuration behavior, or live infrastructure changes.

## Risks and limitations
- Rendered HTML/PDF output was not locally verified due to missing `asciidoctor`.

## push auto
This workflow will wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.