### PR TITLE
docs(documentation): fix AsciiDoc and PlantUML rendering

### DIFF
--- a/documentation/arc42.adoc
+++ b/documentation/arc42.adoc
@@ -56,6 +56,7 @@ CLI --> Stacks : readiness and evidence checks
 ----
 @startuml
 !pragma layout smetana
+allowmixing
 skinparam componentStyle rectangle
 skinparam shadowing false
 

--- a/documentation/document.adoc
+++ b/documentation/document.adoc
@@ -1,3 +1,4 @@
+= Tiny Swarm World
 :doctype: book
 :toc-title: table of contents
 :toc: macro
@@ -7,7 +8,7 @@
 :lang: en
 :chapter-label:
 
-= Tiny Swarm World
+toc::[]
 
 **Your tiny Docker swarm for big ideas.**
 


### PR DESCRIPTION
## Summary

- Fix `documentation/document.adoc` so the AsciiDoc document title is part of the document header.
- Add the explicit `toc::[]` placement required by `:toc: macro`.
- Enable `allowmixing` for the arc42 hexagonal PlantUML diagram that mixes `component` and `interface` elements.

## Changed files

- `documentation/document.adoc`
- `documentation/arc42.adoc`

## Verification

- `git -c core.autocrlf=false diff --check`: passed
- `python3 tools/quality_gate.py quality`: passed

## Impact

- Documentation rendering only.
- No Python runtime, API, deployment, or configuration behavior changes.

## Risks and limitations

- PlantUML CLI was not available locally, so the diagram fix is based on the reported PlantUML preprocessing error and staged diff review.

## Push auto lifecycle

This PR is intended for `push auto`: wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.