### PR TITLE
docs(workflow): add installation phase and port registry workflow

### DIFF
--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-consolidation.md
@@ -1,0 +1,71 @@
+# Slice 01 Consolidation
+
+Workflow: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
+Slice: `01`
+Title: `Architecture And Port Model Decision`
+
+## Stream Results
+
+Architecture stream:
+
+- Senior System Architect subagent reviewed the active workflow, arc42 deployment/concepts/ADR index, and Traefik ADR.
+- Decision: no architecture source edits are required for Slice 01.
+- Existing architecture documentation already records Traefik `80/443` as the public ingress baseline.
+- High-numbered ports are not a public ingress replacement. Later slices may classify them as direct, diagnostic, rollback, compatibility, or preflight/conflict-detection mappings.
+
+Documentation stream:
+
+- No arc42 or ADR edits were needed.
+- Later implementation slices must keep the port registry aligned with the existing deployment view.
+
+## Accepted Findings
+
+- Port registry should classify both public ingress-owned ports and direct/diagnostic/compatibility mappings.
+- Replacing Traefik `80/443` public ingress with high-numbered public gateway ports requires a new ADR.
+- Existing compose-published ports still require explicit registry classification in later slices.
+
+## Rejected Findings
+
+- None.
+
+## Files Changed
+
+- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-distribution.md`
+- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-consolidation.md`
+
+No product source, configuration, arc42, ADR, or runtime files were changed by Slice 01.
+
+## Evidence Path Guard
+
+- Workflow-specific evidence targets were absent before write.
+- Generic evidence files were not overwritten, modified, truncated, renamed, or deleted.
+- Existing generic evidence remains owned by `workflow-replace-rabbitmq-with-apache-pulsar`.
+
+## Conflicts
+
+- Conflicts found: generic evidence names were already occupied by an unrelated workflow.
+- Conflicts resolved: the active workflow was updated to use `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+
+## Tests Executed
+
+- `git diff --check`: passed.
+- `python3 -m json.tool documentation/workflow/context-pack.json`: passed.
+- `git diff --exit-code -- .codex/evidence/slice-01-distribution.md .codex/evidence/slice-01-consolidation.md`: passed; generic evidence files remain unchanged.
+- `python3 tools/quality_gate.py quality`: passed. The gate ran lint, arch-lint, arch-tests, typecheck, and unit test discovery; 902 tests passed with 18 skipped.
+
+## SonarQube
+
+- Not applicable. Slice 01 is architecture decision evidence and workflow governance only.
+
+## Documentation Updates
+
+- `documentation/workflow/workflow.md` updated to define workflow-specific evidence governance.
+- `documentation/workflow/context-pack.md` updated with the evidence root and collision guard.
+- `documentation/workflow/context-pack.json` updated with the evidence root and collision guard.
+- arc42 update status: checked, no update needed.
+- ADR update status: checked, no update needed.
+
+## Final Integration Decision
+
+Accepted. Slice 01 is complete as an architecture decision checkpoint with workflow-specific evidence paths.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-distribution.md
@@ -1,0 +1,61 @@
+# Slice 01 Distribution
+
+Workflow: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
+Slice: `01`
+Title: `Architecture And Port Model Decision`
+
+## Affected Areas
+
+- architecture
+- documentation
+- security impact check for public ingress and exposed ports
+
+## Execution Mode
+
+Sequential.
+
+## Selected Streams
+
+- architecture: Senior System Architect review of Traefik ingress and direct port model.
+- documentation: arc42/ADR consistency check.
+
+## Subagents
+
+- Real subagent used: yes.
+- Subagent: Senior System Architect read-only review.
+- Fallback role-based review used: no.
+- Git worktrees used: no.
+
+## Evidence Path Guard
+
+- Required evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic evidence paths are forbidden for this workflow.
+- Preflight result: workflow-specific Slice 01 evidence targets were absent before write.
+- Existing generic evidence files for `workflow-replace-rabbitmq-with-apache-pulsar` were checked and not modified.
+
+## Expected Touched Files
+
+- `documentation/arc42/07_deployment_view.adoc`
+- `documentation/arc42/08_concepts.adoc`
+- `documentation/arc42/09_architecture_decisions.adoc`
+- `documentation/architecture/adr-traefik-https-ingress-existing-ca.adoc`
+
+## Conflict Risks
+
+- Replacing Traefik `80/443` public ingress with high-numbered gateway ports would contradict the accepted ADR without a new ADR.
+- Documentation must not claim live Traefik, TLS, route, or service health evidence.
+- The port registry must distinguish public ingress, direct published ports, compatibility routes, and diagnostic mappings.
+
+## Quality Gates
+
+- Targeted: `git diff --check`
+- Required by workflow before release: `python3 tools/quality_gate.py quality`
+
+## Consolidation Plan
+
+Use the subagent's read-only architecture decision to decide whether Slice 01 needs doc edits. If the existing docs are sufficient, record a no-source-change consolidation result and keep later implementation slices aligned with the documented port model.
+
+## Parallelization Decision
+
+Parallelization rejected for Slice 01 because all write candidates are shared architecture documentation and the slice is a decision checkpoint. Read-only subagent review is safe and does not require an isolated worktree.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-consolidation.md
@@ -1,0 +1,77 @@
+# Slice 02 Consolidation
+
+Workflow: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
+Slice: `02`
+Title: `Central Port Registry Contract`
+
+## Stream Results
+
+Backend stream:
+
+- Added parser-independent port registry domain concepts in `tiny_swarm_world.domain.network`.
+- Added central desired-state registry at `infra/config/ports.yaml`.
+- Kept YAML loading out of domain code; YAML repository work remains deferred to Slice 03.
+
+Tests stream:
+
+- Senior Tester subagent provided focused test recommendations for registry construction, duplicate ports, invalid ranges, invalid service IDs, unsafe metadata, and internal/external semantics.
+- Added focused unit tests in `tests/domain/network/test_port_forwarding_plan.py`.
+- No setup manifest bridge was added in Slice 02, so preflight manifest tests remain unchanged.
+
+Architecture/security stream:
+
+- Senior System Architect/security subagent gave conditional GO.
+- No ADR is required because the registry preserves Traefik `80/443` as the only public ingress baseline.
+- High-numbered ports are classified as diagnostic/direct/compatibility allocations, not public ingress replacement.
+
+## Accepted Findings
+
+- `PortRegistry`, `PortRange`, `ServicePortMapping`, and `PortExposureClass` are the Slice 02 domain shape.
+- Public ingress mappings must be Traefik-owned ports `80` and `443`.
+- Duplicate external ports are rejected.
+- Unsafe metadata keys/values for addresses, secrets, tokens, and credential-bearing URLs are rejected.
+- Internal container ports remain independent from external host/diagnostic mappings.
+
+## Rejected Findings
+
+- YAML repository tests were rejected for Slice 02 and deferred to Slice 03.
+- Setup manifest derivation from the registry was rejected for Slice 02 because the workflow assigns repository/preflight integration to Slice 03.
+
+## Files Changed
+
+- `infra/config/ports.yaml`
+- `src/tiny_swarm_world/domain/network/port_forwarding_plan.py`
+- `src/tiny_swarm_world/domain/network/__init__.py`
+- `tests/domain/network/test_port_forwarding_plan.py`
+- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-distribution.md`
+- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-consolidation.md`
+
+## Evidence Path Guard
+
+- Workflow-specific evidence targets were absent before write.
+- Generic evidence files were not overwritten, modified, truncated, renamed, or deleted.
+
+## Conflicts
+
+- Conflicts found: none.
+- Conflicts resolved: none.
+
+## Tests Executed
+
+- `PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result`: passed, 30 tests.
+- Parsed `infra/config/ports.yaml` with `ruamel.yaml` and constructed `PortRegistry`: passed, 11 ranges and 21 mappings.
+- `python3 tools/quality_gate.py quality`: passed. The gate ran lint, arch-lint, arch-tests, typecheck, and unit test discovery; 913 tests passed with 18 skipped.
+
+## SonarQube
+
+- Not applicable locally.
+
+## Documentation Updates
+
+- No arc42 update required in Slice 02 because the accepted Traefik ingress baseline is unchanged.
+- ADR update status: checked, no update needed.
+
+## Final Integration Decision
+
+Accepted. Slice 02 implements the central port registry contract without YAML parsing in domain code.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-02-distribution.md
@@ -1,0 +1,68 @@
+# Slice 02 Distribution
+
+Workflow: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
+Slice: `02`
+Title: `Central Port Registry Contract`
+
+## Affected Areas
+
+- backend
+- tests
+- architecture
+- security
+
+## Execution Mode
+
+Sequential integration with parallel read-only subagent review.
+
+## Selected Streams
+
+- backend: domain model and central registry config.
+- tests: domain/preflight and network unit tests.
+- architecture: hexagonal boundary and parser-independent domain review.
+- security: exposure classification, no host-specific addresses, no secrets, no credential URLs.
+
+## Subagents
+
+- Real subagent used: yes.
+- Subagents:
+  - Senior Tester read-only review.
+  - Senior System Architect/security read-only review.
+- Fallback role-based review used: no.
+- Git worktrees used: no.
+
+## Evidence Path Guard
+
+- Required evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Preflight result: workflow-specific Slice 02 evidence targets were absent before write.
+- Generic evidence files are not write targets and must remain unchanged.
+
+## Expected Touched Files
+
+- `infra/config/ports.yaml`
+- `src/tiny_swarm_world/domain/network/port_forwarding_plan.py`
+- `tests/domain/network/test_port_forwarding_plan.py`
+- `tests/domain/preflight/test_preflight_result.py`
+
+`src/tiny_swarm_world/domain/preflight/setup_manifest.py` is in scope but should remain unchanged unless the implementation needs a direct typed link to the registry.
+
+## Conflict Risks
+
+- Domain code must remain parser-independent and must not parse YAML.
+- The registry must not replace Traefik `80/443` public ingress with high-numbered gateway ports.
+- The registry must reject host-specific addresses, secrets, and credential-bearing URLs.
+- Duplicate externally published ports must fail closed unless they are classified as the same ingress-owned shared port by design.
+
+## Quality Gates
+
+- Targeted: `PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result`
+- Required by workflow before release: `python3 tools/quality_gate.py quality`
+
+## Consolidation Plan
+
+Implement a parser-independent port registry model in the domain network module, add a committed `infra/config/ports.yaml` desired-state registry, and add unit tests proving duplicate rejection and safety invariants. Use subagent findings to adjust invariants before checkpointing.
+
+## Parallelization Decision
+
+Parallel implementation rejected because Slice 02 has overlapping domain and test locks. Read-only subagent review is safe in parallel with local implementation.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-03-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-03-consolidation.md
@@ -1,0 +1,40 @@
+# Slice 03 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 03
+Purpose: Port registry repository and preflight integration.
+
+## Implemented Changes
+
+- Added an application repository port for loading the committed port registry.
+- Added a YAML-backed infrastructure adapter for `infra/config/ports.yaml`.
+- Wired `build_preflight_service()` to load the registry through infrastructure composition.
+- Extended `PreflightService` so host-port checks can come from registry mappings marked `required_for_preflight`.
+- Kept post-install preflight behavior unchanged by leaving registry injection out of that path.
+- Added repository, preflight, and composition regression tests.
+
+## Evidence Path Guard
+
+- Evidence written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic `.codex/evidence/slice-*` files were not used for this slice.
+- Prior evidence for `workflow-replace-rabbitmq-with-apache-pulsar` remains out of scope and must stay unchanged.
+
+## Verification
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository tests.application.services.platform.test_preflight_service tests.infrastructure.test_composition`
+  - Result: passed, 111 tests.
+- `git diff --check`
+  - Result: passed.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 402 source files.
+  - Unit tests: passed, 921 tests, 18 skipped.
+
+## Architecture And ADR Status
+
+- Hexagonal boundary preserved: application depends on a repository port and the YAML implementation remains in infrastructure.
+- No live infrastructure commands were executed.
+- No ADR required for this slice because it implements the approved workflow-local port registry integration without changing the public ingress architecture decision.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-03-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-03-distribution.md
@@ -1,0 +1,25 @@
+# Slice 03 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 03
+Purpose: Port registry repository and preflight integration.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- Generic evidence paths under `.codex/evidence/slice-*` are reserved for prior workflows and must not be modified.
+- No evidence for this slice is written directly below `.codex/evidence/`.
+
+## Stream Assignment
+
+- Main executor: repository adapter, application preflight integration, composition wiring, tests, and consolidation.
+- Specialist review inputs already recorded from Slice 02 remain applicable:
+  - Senior System Architect: preserve Traefik public ingress semantics and keep diagnostic allocations out of public ingress.
+  - Senior Tester: cover registry loading, malformed YAML, duplicate external ports, unsafe metadata, and preflight port selection.
+
+## Initial Scope
+
+- Add an application repository port for loading the committed port registry.
+- Add a YAML-backed infrastructure adapter for `infra/config/ports.yaml`.
+- Allow preflight checks to derive required host ports from the registry.
+- Keep live infrastructure commands out of scope.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-04-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-04-consolidation.md
@@ -1,0 +1,52 @@
+# Slice 04 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 04
+Purpose: Installation phase registry and dependency graph.
+
+## Implemented Changes
+
+- Added `infra/config/installation-plan.yaml` as the committed declarative installation phase registry.
+- Added a pure domain `InstallationPlan` and `InstallationPhase` model in `tiny_swarm_world.domain.preflight.installation_plan`.
+- Added deterministic dependency ordering with `(order, phase_id)` tie-breaking and cycle detection.
+- Added fail-closed validation for missing dependencies, required phase IDs, required services, duplicate setup workflow phase names, and missing required workflow phases.
+- Extended `SetupWorkflow` with optional typed `installation_plan` ordering.
+- Wired default setup composition to pass `default_installation_plan()` without parsing YAML in domain or application code.
+- Kept YAML parsing out of this slice to preserve the hexagonal boundary; a future infrastructure adapter can load the YAML through an application port.
+
+## Subagent Review
+
+- Read-only Slice 04 reviewer checked risks for deterministic ordering, cycle detection, missing required phases/services, and architecture boundaries.
+- Reviewer recommendation applied:
+  - Phase graph moved to a separate domain module instead of `setup_manifest.py`.
+  - YAML is not parsed by domain or `SetupWorkflow`.
+  - Tests cover deterministic order, cycles, unknown dependency targets, missing required phases, missing required services, and workflow fail-closed behavior.
+
+## Evidence Path Guard
+
+- Evidence written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic `.codex/evidence/slice-*` files were not used for this slice.
+- Prior evidence for `workflow-replace-rabbitmq-with-apache-pulsar` remains out of scope and unchanged.
+
+## Verification
+
+- `PYTHONPATH=src python3 -m unittest tests.application.services.setup.test_setup_workflow tests.domain.preflight.test_preflight_result`
+  - Result: passed, 46 tests.
+- YAML static parse check for `infra/config/installation-plan.yaml`
+  - Result: passed, schema version 1, 13 phases, first `preflight`, last `validation`.
+- `git diff --check`
+  - Result: passed.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 403 source files.
+  - Unit tests: passed, 930 tests, 18 skipped.
+
+## Architecture And ADR Status
+
+- Hexagonal boundary preserved: phase-plan domain code imports no YAML, filesystem, infrastructure, command runner, or application service code.
+- SetupWorkflow consumes typed domain objects only.
+- No live infrastructure commands were executed.
+- No ADR required for this slice because it adds deterministic setup ordering within the approved workflow architecture.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-04-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-04-distribution.md
@@ -1,0 +1,23 @@
+# Slice 04 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 04
+Purpose: Installation phase registry and dependency graph.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- This slice must not write generic evidence files directly under `.codex/evidence/`.
+- Existing generic Slice 01 evidence belongs to another workflow and remains out of scope.
+
+## Stream Assignment
+
+- Main executor: domain phase-plan model, setup workflow ordering, central config, targeted tests, and consolidation.
+- Subagent reviewer: read-only Slice 04 risk review for deterministic ordering, cycle detection, missing required phase fail-closed behavior, and architecture boundaries.
+
+## Initial Scope
+
+- Add a central installation phase declaration at `infra/config/installation-plan.yaml`.
+- Add domain validation for acyclic phase dependencies and deterministic topological ordering.
+- Integrate optional installation-plan ordering into `SetupWorkflow`.
+- Add regression tests for ordering, cycles, and missing required workflow phases.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-05-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-05-consolidation.md
@@ -1,0 +1,52 @@
+# Slice 05 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 05
+Purpose: Service registry and stack alignment.
+
+## Implemented Changes
+
+- Expanded `infra/config/services.yml` from Infisical-only config into a service registry for selected stacks plus Traefik ingress.
+- Added `phase_id` and `port_ids` metadata to `ServiceStackContract`.
+- Mapped selected stack contracts to installation phases and port registry IDs.
+- Preserved Portainer bootstrap-cycle protection by keeping Portainer out of Portainer-managed deployment steps.
+- Added `portainer-http` as a compatibility port registry entry.
+- Kept current Pulsar baseline explicit and RabbitMQ absent.
+- Classified current legacy Compose published ports as `compatibility_published_ports`; Traefik-owned ingress ports remain `ingress_published_ports`.
+- Added regression tests for service registry alignment, phase mapping, port mapping, published-port classification, and readiness target separation.
+
+## Subagent Review
+
+- Read-only Slice 05 reviewer reported that config-only edits would be insufficient and that compose/port registry mismatches must not be silently treated as registry-backed.
+- Applied recommendation by explicitly classifying legacy published ports as compatibility in `services.yml`.
+- Did not perform broad Compose published-port rewrites; that would be a deployment migration slice with higher runtime risk.
+
+## Evidence Path Guard
+
+- Evidence written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic `.codex/evidence/slice-*` files were not used for this slice.
+- Prior evidence for `workflow-replace-rabbitmq-with-apache-pulsar` remains out of scope and unchanged.
+
+## Verification
+
+- `PYTHONPATH=src python3 -m unittest tests.domain.deployment.test_service_stack_contract tests.application.services.deployment.test_service_stack_plan tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository`
+  - Result: passed, 62 tests.
+- YAML static parse check for `infra/config/services.yml`, `infra/config/ports.yaml`, and `infra/config/inventory/desired_inventory.yaml`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 403 source files.
+  - Unit tests: passed, 934 tests, 18 skipped.
+
+## Architecture And ADR Status
+
+- Deployment domain contracts now carry static registry metadata only.
+- Static service registry data still does not claim observed runtime readiness.
+- Compose published port migration is explicitly deferred through compatibility classification.
+- No live infrastructure commands were executed.
+- No ADR required because this slice preserves the documented Traefik ingress baseline and does not change runtime exposure behavior.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-05-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-05-distribution.md
@@ -1,0 +1,23 @@
+# Slice 05 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 05
+Purpose: Service registry and stack alignment.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- This slice must not write generic evidence files directly under `.codex/evidence/`.
+- Existing generic Slice 01 evidence belongs to another workflow and remains out of scope.
+
+## Stream Assignment
+
+- Main executor: service stack contract alignment, service registry config, compose metadata tests, and consolidation.
+- Subagent reviewer: read-only Slice 05 risk review for scope, port registry alignment, readiness semantics, and stop conditions.
+
+## Initial Scope
+
+- Add phase and port registry identifiers to service stack contracts.
+- Expand the committed service registry with stack phase and port metadata.
+- Verify selected stacks map to declared installation phases and port registry entries.
+- Keep live deployment, runtime readiness claims, and broad compose port rewrites out of scope.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-06-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-06-consolidation.md
@@ -1,0 +1,50 @@
+# Slice 06 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 06
+Purpose: Health check and validation plan registry.
+
+## Implemented Changes
+
+- Added `infra/config/health-checks.yaml` with static desired readiness checks.
+- Added `infra/config/validation-plan.yaml` with greenpath required evidence targets.
+- Added `ValidationPlan` evaluation in deployment workflows.
+- Required validation evidence now fails closed when missing, blocked, failed, or verified only by static/non-observed evidence.
+- Added observed-evidence marker `evidence_kind=swarm_service_replicas` to Swarm readiness evidence.
+- Added tests that align health checks with service registry, service contracts, installation phases, and validation targets.
+- Kept live health checks out of default quality gates; YAML has `live_default: false`.
+
+## Subagent Review
+
+- Read-only Slice 06 reviewer identified that YAML declarations alone would not enforce missing evidence failures.
+- Applied recommendation by adding an explicit validation-plan evaluator and tests for missing/static/blocked observed evidence.
+- Added Traefik readiness target to health checks and validation plan to avoid service registry drift.
+
+## Evidence Path Guard
+
+- Evidence written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic `.codex/evidence/slice-*` files were not used for this slice.
+- Prior evidence for `workflow-replace-rabbitmq-with-apache-pulsar` remains out of scope and unchanged.
+
+## Verification
+
+- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_verify_swarm_service_readiness tests.application.services.deployment.test_deployment_workflows tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml`
+  - Result: passed, 66 tests.
+- YAML static parse check for `infra/config/health-checks.yaml` and `infra/config/validation-plan.yaml`
+  - Result: passed.
+- `git diff --check`
+  - Result: passed.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 403 source files.
+  - Unit tests: passed, 940 tests, 18 skipped.
+
+## Architecture And ADR Status
+
+- Static health-check and validation-plan declarations are separate from observed runtime evidence.
+- Missing observed evidence reports `FAILED_TO_VERIFY`, never healthy.
+- No live infrastructure commands were executed.
+- No ADR required for this slice because it strengthens validation semantics without changing runtime topology.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-06-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-06-distribution.md
@@ -1,0 +1,23 @@
+# Slice 06 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 06
+Purpose: Health check and validation plan registry.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- This slice must not write generic evidence files directly under `.codex/evidence/`.
+- Existing generic Slice 01 evidence belongs to another workflow and remains out of scope.
+
+## Stream Assignment
+
+- Main executor: health-check registry, validation-plan declarations, workflow fail-closed validation, tests, and consolidation.
+- Subagent reviewer: read-only Slice 06 risk review for desired-check versus observed-evidence separation.
+
+## Initial Scope
+
+- Add static health-check and validation-plan YAML declarations.
+- Add application helpers that validate observed `VerificationResult` evidence against a declared plan.
+- Keep live HTTP or Swarm checks out of default quality gates.
+- Prove missing observed evidence fails closed.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-07-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-07-consolidation.md
@@ -1,0 +1,50 @@
+# Slice 07 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 07
+Purpose: Operator documentation and arc42 synchronization.
+
+## Implemented Changes
+
+- Updated README operator documentation for installation phase, port, service, health-check, and validation registries.
+- Updated deployment and LXC-native setup docs with preflight port registry and live-evidence boundaries.
+- Updated configuration inventory with new product YAML files and their validation status.
+- Updated arc42 building blocks, runtime view, deployment view, concepts, and quality requirements.
+- Updated autonomous setup EPIC with registry baseline and validation-plan fail-closed behavior.
+- Clarified that `installation-plan.yaml`, `services.yml`, `health-checks.yaml`, and `validation-plan.yaml` are static/declarative contract surfaces where runtime YAML adapters are not yet wired.
+
+## Subagent Review
+
+- Read-only Slice 07 documentation reviewer identified overclaims implying runtime YAML loading.
+- Applied recommendation by distinguishing:
+  - typed runtime defaults and contracts;
+  - static YAML declarations;
+  - tests that align declarations;
+  - observed `VerificationResult` evidence required for runtime success.
+
+## Evidence Path Guard
+
+- Evidence written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic `.codex/evidence/slice-*` files were not used for this slice.
+- Prior evidence for `workflow-replace-rabbitmq-with-apache-pulsar` remains out of scope and unchanged.
+
+## Verification
+
+- `git diff --check`
+  - Result: passed.
+- Documentation search for newly introduced Windows-specific commands or file URLs
+  - Result: no matches.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 403 source files.
+  - Unit tests: passed, 940 tests, 18 skipped.
+
+## Architecture And ADR Status
+
+- Documentation describes implemented behavior only.
+- Static/declarative registries are not documented as runtime-loaded where adapters are not wired.
+- Live installation or service health success is not claimed without observed evidence.
+- No ADR required because no accepted architecture decision changed.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-07-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-07-distribution.md
@@ -1,0 +1,23 @@
+# Slice 07 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 07
+Purpose: Operator documentation and arc42 synchronization.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- This slice must not write generic evidence files directly under `.codex/evidence/`.
+- Existing generic Slice 01 evidence belongs to another workflow and remains out of scope.
+
+## Stream Assignment
+
+- Main executor: documentation and arc42 synchronization.
+- Subagent reviewer: read-only documentation review for overclaims, Windows-specific wording, and missing registry/validation explanations.
+
+## Initial Scope
+
+- Document implemented installation phase, port, service, health-check, and validation-plan registries.
+- Keep live installation success clearly unclaimed without observed evidence.
+- Document compatibility/deferred port semantics without changing runtime behavior.
+- Preserve Linux/WSL-only examples and POSIX paths.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-08-consolidation.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-08-consolidation.md
@@ -1,0 +1,38 @@
+# Slice 08 Consolidation Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 08
+Purpose: Full quality gate and execution handoff.
+
+## Final Verification
+
+- `git diff --check`
+  - Result: passed.
+- Generic evidence guard:
+  - `git diff --exit-code -- .codex/evidence/slice-01-distribution.md .codex/evidence/slice-01-consolidation.md`
+  - Result: passed, exit code 0.
+- `python3 tools/quality_gate.py quality`
+  - Result: passed.
+  - Lint: passed.
+  - Import-layer contracts: passed, 3 kept, 0 broken.
+  - Architecture tests: passed.
+  - Typecheck: passed, 403 source files.
+  - Unit tests: passed, 940 tests, 18 skipped.
+
+## Evidence Inventory
+
+- Slice 01 through Slice 08 distribution and consolidation evidence files are stored under `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- No workflow execution evidence was written directly under `.codex/evidence/` with generic slice filenames.
+- Existing generic evidence files for `workflow-replace-rabbitmq-with-apache-pulsar` remained unchanged.
+
+## Handoff
+
+- Branch: `feature/workflow-installation-phases-port-registry-20260620`
+- PR: `https://github.com/MatthiasBurger-Coder/Tiny-Swarm-World/pull/138`
+- Slice commits were pushed after each completed slice.
+- No generated caches, logs, local virtual environments, or secrets were staged.
+
+## ADR Status
+
+- No new ADR is required.
+- The workflow preserves the accepted Traefik public ingress baseline and does not claim live deployment or service health without observed evidence.

--- a/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-08-distribution.md
+++ b/.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-08-distribution.md
@@ -1,0 +1,18 @@
+# Slice 08 Distribution Evidence
+
+Workflow-ID: workflow-install-order-and-port-allocation-20260620
+Slice-ID: 08
+Purpose: Full quality gate and execution handoff.
+
+## Evidence Path Guard
+
+- Target evidence root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+- This slice must not write generic evidence files directly under `.codex/evidence/`.
+- Existing generic Slice 01 evidence belongs to another workflow and remains out of scope.
+
+## Scope
+
+- Run final workflow quality gates.
+- Confirm evidence isolation.
+- Confirm no generated local state is staged.
+- Prepare commit/push handoff evidence for the existing workflow branch and PR.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,22 @@ deployment, and final verification phases. Current live behavior remains
 fail-closed where verification, readiness, credentials, or resource
 requirements are incomplete.
 
+The setup order is mirrored as product configuration in
+`infra/config/installation-plan.yaml` and represented by typed Python domain
+objects. Runtime wiring currently uses the typed `default_installation_plan()`
+and `SetupWorkflow` enforces typed plans when provided. The implemented order
+covers preflight, platform, cluster, network/routing, secrets, artifacts,
+CI/CD, quality, messaging, observability, control, docs, and validation.
+Cycles, missing required phases, missing required services, and missing
+required workflow phases fail closed in tests before setup can report success.
+
+Ports are centrally recorded in `infra/config/ports.yaml`. Traefik owns the
+public ingress baseline on ports `80` and `443`; higher-numbered service ports
+are direct, diagnostic, compatibility, or deferred allocations unless a later
+ADR changes the ingress model. Current compose files still publish some legacy
+compatibility ports, and those are documented in `infra/config/services.yml`
+instead of being treated as registry-backed runtime migrations.
+
 ---
 
 ## Operator Safety Model
@@ -345,6 +361,17 @@ service-access NGINX is the accepted routing design for stable paths such as
 password values are visible only in Infisical's authenticated UI. Operators
 who intentionally want the older base service set can pass
 `--service-profile default`.
+
+Service metadata is declared in `infra/config/services.yml` as a static
+selected-service catalogue for cross-file validation and documentation.
+Runtime deployment selection still uses `ServiceStackContract` domain
+contracts. The catalogue maps selected stacks to installation phases,
+service-stack contracts, port-registry IDs, readiness target IDs, and explicit
+compatibility published ports. Health and greenpath validation declarations
+live in `infra/config/health-checks.yaml` and
+`infra/config/validation-plan.yaml`; these files declare required observed
+evidence, tests align them with contracts, and runtime success still requires
+observed `VerificationResult` evidence.
 
 The Infisical stack runs Infisical with PostgreSQL and Redis. The guided
 installer writes `TSW_INFISICAL_ENCRYPTION_KEY`, `TSW_INFISICAL_AUTH_SECRET`,

--- a/documentation/arc42/05_building_blocks.adoc
+++ b/documentation/arc42/05_building_blocks.adoc
@@ -59,7 +59,10 @@ microservices:
   environment, and update policy. Portainer endpoint IDs, stack IDs, Swarm IDs
   and API fallbacks stay inside the infrastructure gateway adapter. The compose
   repository also exposes service names and published ports parsed from each
-  stack's `docker-compose.yml`. Stack mutation is owned by live-consent-gated
+  stack's `docker-compose.yml`. Service-stack contracts now carry static
+  phase IDs and port-registry IDs so they can be aligned with
+  `infra/config/services.yml`, `infra/config/installation-plan.yaml`, and
+  `infra/config/ports.yaml`. Stack mutation is owned by live-consent-gated
   workflow execution, not by service construction. `deployment apply` and
   `deployment verify` can evaluate configured stack, external-input, and
   readiness contracts, but live success still depends on observable registry,
@@ -76,6 +79,13 @@ remains available for explicit `--service-profile default` runs. The
 service-access setup manifest exposes Traefik ingress ports `80` and `443`;
 the service-access compose stack itself publishes service-access NGINX ports
 `80`, `8086`, and `443`.
+
+`infra/config/health-checks.yaml` and `infra/config/validation-plan.yaml`
+belong to the deployment boundary as static desired-state declarations. They
+are aligned by tests, not runtime-loaded by deployment verification yet. The
+application `ValidationPlan` can evaluate observed `VerificationResult`
+evidence and fails closed when required runtime evidence is missing or only
+static stack-registration evidence is present.
 
 The service-access dashboard and NGINX assets are image-packaged under
 `infra/config/compose/service-access/**`, while the stack definition lives under

--- a/documentation/arc42/06_runtime_view.adoc
+++ b/documentation/arc42/06_runtime_view.adoc
@@ -73,7 +73,12 @@ microservice boundary and it does not construct low-level adapters in the entry
 point. The setup bundle wires phase calls for preflight, platform init,
 platform reconcile, platform expose, deployment bootstrap, artifacts prepare,
 artifacts verify, deployment apply, deployment verify, and final platform
-verify. `platform expose` configures the LXC-native manager gateway only; it
+verify. Runtime composition currently passes the typed
+`default_installation_plan()` into `SetupWorkflow`; the committed phase
+registry mirrors that contract for static validation and documentation. The
+typed plan blocks on cycles, missing required phases, missing required
+services, or missing required workflow phases. `platform expose` configures
+the LXC-native manager gateway only; it
 does not proxy individual service containers or worker nodes. It does not wire
 platform reset or destroy behavior; the `install.sh` fresh-install wrapper owns
 the reset prelude before it invokes setup.
@@ -105,8 +110,16 @@ The current artifact and deployment runtime flow is deliberately fail-closed:
   service-readiness verification through deployment workflow ports.
 * `deployment verify` dispatches without live consent and returns `blocked`
   or `failed_to_verify` when observed stack or service-readiness evidence is
-  missing. It does not claim container or service health from endpoint
-  configuration alone.
+missing. It does not claim container or service health from endpoint
+configuration alone.
+
+Greenpath validation is a runtime evidence evaluation step when an application
+`ValidationPlan` is explicitly evaluated; it is not a live probe triggered by
+static YAML configuration. The validation plan accepts only observed
+service-readiness `VerificationResult` evidence with Swarm replica fields.
+Missing required evidence, blocked evidence, failed evidence, or verified
+stack-registration evidence without observed service fields returns blocked or
+failed verification rather than success.
 
 Nexus repository mutation, Docker registry mutation, image build, and image
 push side effects run only through live-consent-gated workflow execution, not

--- a/documentation/arc42/07_deployment_view.adoc
+++ b/documentation/arc42/07_deployment_view.adoc
@@ -40,6 +40,24 @@ separately through observed Swarm service evidence. The service-access deploymen
 uses allowlisted stack environment values and records only neutral
 presence/source classifications in verification evidence.
 
+The deployment configuration model is now split across committed registries:
+
+* `infra/config/installation-plan.yaml` mirrors the typed default setup phase
+  plan and dependencies;
+* `infra/config/ports.yaml` declares desired internal/external service port
+  allocations;
+* `infra/config/services.yml` is a static selected-service catalogue that maps
+  selected stacks to phases, service-stack contracts, port-registry IDs,
+  readiness target IDs, and compatibility published ports;
+* `infra/config/health-checks.yaml` and
+  `infra/config/validation-plan.yaml` declare desired observed evidence
+  targets without running live checks or being loaded by default deployment
+  verification.
+
+Current compose files still publish some legacy host ports. Those ports are
+classified as compatibility in the service registry and are not presented as a
+completed port migration.
+
 == Service Access And Traefik Routing Baseline
 
 The service-access dashboard capability is implemented as repository assets

--- a/documentation/arc42/08_concepts.adoc
+++ b/documentation/arc42/08_concepts.adoc
@@ -78,6 +78,39 @@ This separation lets apply workflows report apply failure and verify failure
 separately without treating generated logs or command output as validated
 runtime evidence.
 
+=== Installation And Port Registries
+
+Installation order is declared separately from executable setup phases.
+`infra/config/installation-plan.yaml` mirrors the intended phase dependency
+graph. Runtime wiring currently uses the typed `default_installation_plan()`;
+the YAML file is a committed contract and documentation surface until a later
+adapter loads it. The Python domain model rejects cycles, unknown
+dependencies, missing required phase IDs, missing required services, duplicate
+setup workflow phases, and missing required workflow phases before setup can
+report success.
+
+`infra/config/ports.yaml` is the central port registry. It records port ranges,
+service port mappings, exposure class, route hosts, and whether a port is part
+of preflight. Traefik owns public ingress on `80` and `443`. Other published
+or desired service ports are direct, diagnostic, compatibility, or deferred
+allocations and must not be silently interpreted as public ingress.
+
+`infra/config/services.yml` statically links selected stacks to installation
+phases, service-stack contracts, port-registry IDs, readiness targets, and
+explicit compatibility published ports. Runtime deployment selection still
+uses `ServiceStackContract` domain contracts. Current Apache Pulsar remains
+the messaging baseline; RabbitMQ is not part of the selected service registry.
+
+=== Health And Validation Evidence
+
+`infra/config/health-checks.yaml` and `infra/config/validation-plan.yaml`
+declare desired observed-state evidence. They are not live probes and do not
+claim health. They are aligned by tests; default deployment verification does
+not yet load them as YAML. The application validation plan evaluates actual
+`VerificationResult` values when provided and fails closed when required
+evidence is missing, blocked, failed, or lacks observed Swarm service fields
+such as stack name, required services, and replica summary.
+
 === Ingress Desired State And Certificate Summaries
 
 The Traefik HTTPS ingress workflow now has provider-neutral domain contracts

--- a/documentation/arc42/10_quality_requirements.adoc
+++ b/documentation/arc42/10_quality_requirements.adoc
@@ -80,6 +80,25 @@ Quality scenarios:
 * optional live smoke validation is documented and invoked separately from the
   default quality gate.
 
+=== Registry And Validation Plans
+
+Quality scenarios:
+
+* installation phases sort deterministically by dependency, order, and phase
+  identifier;
+* dependency cycles, unknown dependencies, missing required phases, missing
+  required services, and missing required workflow phases fail closed;
+* service-stack contracts map to declared installation phases and port-registry
+  IDs;
+* compose published ports are classified as registry-backed, Traefik ingress,
+  compatibility, or deferred;
+* health-check registry entries match service registry and service-stack
+  contracts;
+* validation-plan targets cover the required health-check targets;
+* missing required observed evidence returns `failed_to_verify`;
+* verified static stack-registration evidence does not satisfy service
+  readiness.
+
 === Installation Progress And Cross-Cutting Method Trace Logging
 
 Installation progress and logging are implemented through two correlated

--- a/documentation/configuration/config-contract-inventory.md
+++ b/documentation/configuration/config-contract-inventory.md
@@ -66,7 +66,11 @@ loading, schema checks, or explicit pass-through handling:
 |---|---|---|
 | `infra/config/node-providers/provider_config.yaml` | Managed LXC provider selection, nodes, profiles, resource resolution, evidence metadata. | Strong typed repository validation exists. |
 | `infra/config/inventory/desired_inventory.yaml` | Host-neutral desired inventory. | Domain loading rejects unknown fields and invalid collection shapes. |
-| `infra/config/services.yml` | Service catalogue material. | Needs explicit contract review before being included in the typed config loader. |
+| `infra/config/installation-plan.yaml` | Declarative setup phase registry and dependency graph. | Mirrored by typed `InstallationPlan` domain tests for deterministic order, cycles, required phases, required services, and workflow phase coverage. |
+| `infra/config/ports.yaml` | Central external/internal port registry. | YAML repository and domain tests validate ranges, duplicate external ports, public-ingress ownership, metadata safety, and preflight port selection. |
+| `infra/config/services.yml` | Service catalogue for selected stacks, phases, port IDs, readiness targets, and compatibility published ports. | Cross-file tests align it with desired inventory, service-stack contracts, installation phases, port registry IDs, and compose published-port classifications. |
+| `infra/config/health-checks.yaml` | Desired service-readiness check registry. | Tests align stack, phase, target ID, required services, evidence kind, and `live_default: false` with service contracts and service registry. |
+| `infra/config/validation-plan.yaml` | Greenpath validation evidence target plan. | Tests prove required targets cover health checks and missing/static evidence fails closed through `ValidationPlan`. |
 | `infra/config/cloud-init-manager.yaml` | Cloud-init manager configuration. | Legacy/specialized surface; include only after consumer ownership is verified. |
 | `infra/config/compose/*/docker-compose.yml` | Stack definitions and compose placeholders. | Parsed by compose repository tests for stack content, service names, and published ports; placeholder variables need inventory and template coverage. |
 | `infra/config/secrets/infisical-secrets.yaml` | Managed secret manifest for Infisical synchronization. | `SecretManifestRenderer` validates schema, duplicate keys, key pattern, type, and policy. |

--- a/documentation/deployment/system.adoc
+++ b/documentation/deployment/system.adoc
@@ -79,6 +79,26 @@ construction and preserves blocked, resource-gated, failed-to-apply, and
 failed-to-verify states instead of reporting full deployment success without
 observed evidence.
 
+Setup sequencing is mirrored in `infra/config/installation-plan.yaml` and
+represented by the typed `InstallationPlan` model. Runtime composition
+currently passes the typed `default_installation_plan()` into `SetupWorkflow`;
+the YAML file is the committed declarative contract and static validation
+surface, not yet a runtime-loaded repository adapter. The current phase order
+is preflight, platform, cluster, network/routing, secrets, artifacts, CI/CD,
+quality, messaging, observability, control, docs, and validation. The workflow
+fails closed for dependency cycles, missing required phases, missing required
+services, or missing required workflow phases.
+
+Service registry data is centralized in `infra/config/services.yml` as a
+static selected-service catalogue used for cross-file validation and
+documentation. Runtime stack selection still comes from
+`ServiceStackContract` domain contracts. Each enabled stack maps to an
+installation phase, service-stack contract, readiness target, port-registry
+IDs, and any compatibility published ports. Portainer remains outside the
+Portainer-managed deployment plan to avoid a bootstrap cycle. Apache Pulsar
+remains the selected messaging stack; RabbitMQ is not part of the selected
+baseline.
+
 Setup preflight is idempotent for an already running Tiny Swarm World
 environment. Required ports pass when they are either free or already serve the
 expected local service, reported as `source=existing_expected_service`.
@@ -157,6 +177,12 @@ The localhost defaults above are operator targets for the Linux/WSL execution
 context. They may depend on WSL forwarding state and must not be treated as
 proof that a service is live or healthy.
 
+The committed port registry is `infra/config/ports.yaml`. Traefik owns public
+ingress ports `80` and `443`. High-numbered service allocations are desired
+diagnostic or compatibility targets. Existing compose files may still publish
+legacy host ports; these are classified in `services.yml` and are not silently
+treated as migrated port-registry behavior.
+
 == Stack deployment
 
 The supported stack deployment boundary is the workflow-level setup command.
@@ -203,6 +229,22 @@ The accepted routing direction is Traefik-backed local ingress:
   compatibility route.
 * Wider-than-local exposure and public certificate automation require later
   ADR coverage and tests.
+
+== Health And Validation Registries
+
+`infra/config/health-checks.yaml` declares desired readiness checks by stack,
+target ID, phase, evidence kind, and required services. `live_default: false`
+means the registry is not a live health probe and is not part of the default
+quality gate.
+
+`infra/config/validation-plan.yaml` declares the current greenpath evidence
+targets. Tests align the YAML declarations with service contracts and health
+checks. Runtime verification does not yet load those YAML files directly; when
+the application `ValidationPlan` is explicitly evaluated, it accepts observed
+`VerificationResult` records only. Missing required evidence, blocked
+evidence, failed evidence, or verified evidence without observed runtime
+fields reports `failed_to_verify` or `blocked`; static stack registration does
+not satisfy service readiness.
 
 Portainer may manage the service-access stack only after Portainer is
 reachable. First-time Portainer bootstrap remains outside Portainer-managed

--- a/documentation/epics/autonomous-runnable-setup.md
+++ b/documentation/epics/autonomous-runnable-setup.md
@@ -42,6 +42,21 @@ provider selections such as `multipass_legacy`. Provider-native platform
 reconcile, artifact publication, deployment, Docker Swarm-in-container live
 validation, and WSL2 live proof remain incomplete and fail closed.
 
+The setup baseline now has committed declarative registries for installation
+phases, ports, services, health checks, and greenpath validation evidence:
+
+- `infra/config/installation-plan.yaml`
+- `infra/config/ports.yaml`
+- `infra/config/services.yml`
+- `infra/config/health-checks.yaml`
+- `infra/config/validation-plan.yaml`
+
+These registries are tested as desired-state and evidence contracts. Runtime
+execution currently uses typed domain defaults and service contracts where no
+YAML adapter is wired. The registries do not claim a completed live
+installation. Missing or static-only service readiness evidence remains a
+failed or blocked verification result when validation is evaluated.
+
 ## EPIC Extensions
 
 The service-access dashboard and Vaultwarden baseline extends this EPIC:
@@ -239,6 +254,8 @@ smoke validation is a separate operator action and requires:
 - A missing verification contract returns `blocked`, not success.
 - Service health is never claimed without observed-state or smoke-test
   evidence.
+- The validation plan fails closed when required observed evidence is missing,
+  blocked, failed, or only static stack-registration evidence.
 - LXC-native through LXD or Incus is the default provider direction, while
   provider-native Platform init now covers Docker Engine setup and Swarm
   bootstrap. Remaining artifact, deployment, service-readiness, and live

--- a/documentation/system/lxc-native-setup.adoc
+++ b/documentation/system/lxc-native-setup.adoc
@@ -132,6 +132,13 @@ network, storage, and Docker Swarm profile expectations that later read-only
 provider checks must verify. A missing backend candidate definition blocks
 configuration construction instead of falling back silently.
 
+Host-port preflight reads the typed port registry from `infra/config/ports.yaml`.
+For the service-access profile, only Traefik public ingress ports `80` and
+`443` are required by default preflight. Diagnostic and compatibility
+allocations stay recorded in the registry and service catalogue, but they are
+not treated as required live host-port blockers unless marked as such in the
+registry.
+
 The default live setup command is:
 
 [source,bash]
@@ -267,6 +274,8 @@ Evidence checklist:
 * do not generalize one target's result to another target class;
 * do not report service-stack success unless deployment and service readiness
   phases are also verified for that run.
+* keep static health-check and validation-plan declarations separate from
+  observed `VerificationResult` evidence for that run.
 
 == References
 

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,6 +1,8 @@
 {
   "workflow_version": "installation-phases-port-registry-v1.0.0",
+  "workflow_id": "workflow-install-order-and-port-allocation-20260620",
   "branch": "feature/workflow-installation-phases-port-registry-20260620",
+  "evidence_root": ".codex/evidence/workflow-install-order-and-port-allocation-20260620/",
   "created": "2026-06-20",
   "status": "READY_FOR_WORKFLOW",
   "process_strand": "workflow create",
@@ -49,6 +51,15 @@
     "required": [
       "python3 tools/quality_gate.py quality"
     ]
+  },
+  "evidence_governance": {
+    "required_root": ".codex/evidence/workflow-install-order-and-port-allocation-20260620/",
+    "forbidden_generic_paths": [
+      ".codex/evidence/slice-01-distribution.md",
+      ".codex/evidence/slice-01-consolidation.md"
+    ],
+    "preflight_guard": "Before writing evidence, verify that the target file is absent or belongs to this workflow. Stop if an existing evidence file belongs to another workflow.",
+    "overwrite_policy": "Do not overwrite, modify, truncate, rename, or delete evidence belonging to another workflow."
   },
   "governing_hashes": {
     "AGENTS.md": "FB1EE9B2A878D4662C96B9BC7255F3D7EC151FB2D1997FD981D4D1A34F54EC3F",

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,0 +1,88 @@
+{
+  "workflow_version": "installation-phases-port-registry-v1.0.0",
+  "branch": "feature/workflow-installation-phases-port-registry-20260620",
+  "created": "2026-06-20",
+  "status": "READY_FOR_WORKFLOW",
+  "process_strand": "workflow create",
+  "execution_profile": "FULL_PATH",
+  "affected_areas": [
+    "infra/config/**",
+    "infra/config/compose/**",
+    "src/tiny_swarm_world/domain/preflight/**",
+    "src/tiny_swarm_world/domain/network/**",
+    "src/tiny_swarm_world/domain/deployment/**",
+    "src/tiny_swarm_world/application/ports/repositories/**",
+    "src/tiny_swarm_world/application/services/setup/**",
+    "src/tiny_swarm_world/application/services/platform/**",
+    "src/tiny_swarm_world/application/services/deployment/**",
+    "src/tiny_swarm_world/infrastructure/adapters/repositories/**",
+    "src/tiny_swarm_world/infrastructure/composition.py",
+    "tests/**",
+    "documentation/**"
+  ],
+  "forbidden_areas": [
+    "Java/Maven/Spring Boot structure",
+    "Browser React frontend project",
+    "Kubernetes-first deployment behavior",
+    "Multipass provider support",
+    "Live infrastructure mutation during default quality gates",
+    "Committed secrets, tokens, host IP addresses, local absolute paths, raw command output, or credential-bearing URLs"
+  ],
+  "required_roles": [
+    "Senior Requirement Engineer",
+    "Senior System Architect",
+    "Senior Python Automation Developer",
+    "Senior React Frontend Developer impact check",
+    "Senior Tester"
+  ],
+  "conditional_roles": [
+    "Senior DevOps Engineer",
+    "Senior Documentation Engineer",
+    "Security/secrets reviewer",
+    "Quality Gate Orchestrator"
+  ],
+  "quality_commands": {
+    "targeted": [
+      "git diff --check",
+      "PYTHONPATH=src python3 -m unittest <nearest test modules>"
+    ],
+    "required": [
+      "python3 tools/quality_gate.py quality"
+    ]
+  },
+  "governing_hashes": {
+    "AGENTS.md": "FB1EE9B2A878D4662C96B9BC7255F3D7EC151FB2D1997FD981D4D1A34F54EC3F",
+    "QUALITY.md": "458E5F4D8FBDEDEA1C413E1FF135EC91392A4BB5A5AEA20300DCAC8E209414B6",
+    ".agents/skills/workflow-authoring/SKILL.md": "5EF238CA8A98D08A3594906E5A30100649D4C09E64A01B377D690F6580B1CA03",
+    ".agents/skills/three-amigos-requirement-gatekeeper/SKILL.md": "23DE7D9AAC9D2694EAE26FAC2765D65F369C101AC348DAC24D5F3BBE9E2D3BA4",
+    ".agents/orchestrator/routing-rules.md": "BA3563181DB98DF3F6A1872D676006CF57CC1603C1B0B74D4C41CD3DB02A60A5",
+    "documentation/process/branch-governance.md": "3332F0FB56E7A72FEE3A9B6E89C4D9D5C3BF1198B375CE4D2BBD5C7350588A83",
+    "documentation/epics/autonomous-runnable-setup.md": "758F291E311CF8232937B6820CE6122126C3C8353276E3D38FFF6C5EDE079691",
+    "documentation/epics/service-access-dashboard-vaultwarden.md": "9C93D460A92630F485C0672F26810ECB4832C69D21A8F6F0941DFFA4AACD1606",
+    "documentation/arc42/07_deployment_view.adoc": "8CC484BBB06C42CFEF2E933AB047716B54AEE655E5C62D711E2485151F07BF5C",
+    "documentation/arc42/08_concepts.adoc": "6AD298D14F6AA4BEF530A25C88EA1AB171AC8EF48A295089025D0B716BF78C0F",
+    "documentation/arc42/09_architecture_decisions.adoc": "2C9811C38F1AD2AE4E516C6A4C3C7DBA808FC208B687242C965EB43CCF3FD051",
+    "documentation/arc42/10_quality_requirements.adoc": "F2F824FC64B1DC05AEB8CE49A30833E2F426AED397F1193470ED2DC43BAAB865"
+  },
+  "arc42_check": {
+    "checked_files": [
+      "documentation/arc42/05_building_blocks.adoc",
+      "documentation/arc42/07_deployment_view.adoc",
+      "documentation/arc42/08_concepts.adoc",
+      "documentation/arc42/09_architecture_decisions.adoc",
+      "documentation/arc42/10_quality_requirements.adoc"
+    ],
+    "modified_during_workflow_creation": false,
+    "execution_update_slices": [
+      "01",
+      "07"
+    ]
+  },
+  "stale_when": [
+    "governing hash changes",
+    "workflow.md changes without this pack",
+    "branch mismatch",
+    "ADR changes Traefik ingress or setup safety baseline",
+    "execution slice changes quality commands or file locks"
+  ]
+}

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,9 +1,11 @@
 # Workflow Context Pack
 
 Workflow: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
 Branch: `feature/workflow-installation-phases-port-registry-20260620`
 Created: `2026-06-20`
 Status: `READY_FOR_WORKFLOW`
+Evidence Root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
 
 ## Purpose
 
@@ -65,6 +67,13 @@ Targeted:
 Required final:
 
 - `python3 tools/quality_gate.py quality`
+
+## Evidence Governance
+
+- Evidence files for this workflow must be written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Generic evidence paths such as `.codex/evidence/slice-01-distribution.md` and `.codex/evidence/slice-01-consolidation.md` are forbidden.
+- Before writing evidence, verify that the target file is absent or belongs to this workflow.
+- If an evidence file exists and belongs to another workflow, stop and report a blocker instead of overwriting it.
 
 ## Governing File Hashes
 

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,0 +1,112 @@
+# Workflow Context Pack
+
+Workflow: `installation-phases-port-registry-v1.0.0`
+Branch: `feature/workflow-installation-phases-port-registry-20260620`
+Created: `2026-06-20`
+Status: `READY_FOR_WORKFLOW`
+
+## Purpose
+
+This context pack is a workflow-local navigation aid for executing the installation phases and port registry workflow. It does not replace root `AGENTS.md`, `QUALITY.md`, ADRs, arc42 files, or active workflow files.
+
+## Process Strand
+
+- Active command: `workflow create`
+- Execution profile: `FULL_PATH`
+- Workflow target: deterministic setup phase ordering and central port registry.
+
+## Affected Areas
+
+- `infra/config/**`
+- `infra/config/compose/**`
+- `src/tiny_swarm_world/domain/preflight/**`
+- `src/tiny_swarm_world/domain/network/**`
+- `src/tiny_swarm_world/domain/deployment/**`
+- `src/tiny_swarm_world/application/ports/repositories/**`
+- `src/tiny_swarm_world/application/services/setup/**`
+- `src/tiny_swarm_world/application/services/platform/**`
+- `src/tiny_swarm_world/application/services/deployment/**`
+- `src/tiny_swarm_world/infrastructure/adapters/repositories/**`
+- `src/tiny_swarm_world/infrastructure/composition.py`
+- `tests/**`
+- `documentation/**`
+
+## Forbidden Areas
+
+- Java, Maven, Spring Boot project structure.
+- Browser React frontend project structure.
+- Kubernetes-first deployment behavior.
+- Multipass provider support.
+- Live infrastructure mutation during default quality gates.
+- Committed secrets, tokens, host IP addresses, local absolute paths, raw command output, or credential-bearing URLs.
+
+## Required Roles
+
+- Senior Requirement Engineer
+- Senior System Architect
+- Senior Python Automation Developer
+- Senior React Frontend Developer impact check
+- Senior Tester
+
+## Conditional Roles
+
+- Senior DevOps Engineer for compose, Docker Swarm, LXC exposure, and runtime stack changes.
+- Senior Documentation Engineer for README, arc42, deployment, and system docs.
+- Security/secrets reviewer for credential references, exposed ports, and evidence.
+- Quality Gate Orchestrator for final quality classification.
+
+## Quality Commands
+
+Targeted:
+
+- `git diff --check`
+- `PYTHONPATH=src python3 -m unittest <nearest test modules>`
+
+Required final:
+
+- `python3 tools/quality_gate.py quality`
+
+## Governing File Hashes
+
+| File | SHA256 |
+|---|---|
+| `AGENTS.md` | `FB1EE9B2A878D4662C96B9BC7255F3D7EC151FB2D1997FD981D4D1A34F54EC3F` |
+| `QUALITY.md` | `458E5F4D8FBDEDEA1C413E1FF135EC91392A4BB5A5AEA20300DCAC8E209414B6` |
+| `.agents/skills/workflow-authoring/SKILL.md` | `5EF238CA8A98D08A3594906E5A30100649D4C09E64A01B377D690F6580B1CA03` |
+| `.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md` | `23DE7D9AAC9D2694EAE26FAC2765D65F369C101AC348DAC24D5F3BBE9E2D3BA4` |
+| `.agents/orchestrator/routing-rules.md` | `BA3563181DB98DF3F6A1872D676006CF57CC1603C1B0B74D4C41CD3DB02A60A5` |
+| `documentation/process/branch-governance.md` | `3332F0FB56E7A72FEE3A9B6E89C4D9D5C3BF1198B375CE4D2BBD5C7350588A83` |
+| `documentation/epics/autonomous-runnable-setup.md` | `758F291E311CF8232937B6820CE6122126C3C8353276E3D38FFF6C5EDE079691` |
+| `documentation/epics/service-access-dashboard-vaultwarden.md` | `9C93D460A92630F485C0672F26810ECB4832C69D21A8F6F0941DFFA4AACD1606` |
+| `documentation/arc42/07_deployment_view.adoc` | `8CC484BBB06C42CFEF2E933AB047716B54AEE655E5C62D711E2485151F07BF5C` |
+| `documentation/arc42/08_concepts.adoc` | `6AD298D14F6AA4BEF530A25C88EA1AB171AC8EF48A295089025D0B716BF78C0F` |
+| `documentation/arc42/09_architecture_decisions.adoc` | `2C9811C38F1AD2AE4E516C6A4C3C7DBA808FC208B687242C965EB43CCF3FD051` |
+| `documentation/arc42/10_quality_requirements.adoc` | `F2F824FC64B1DC05AEB8CE49A30833E2F426AED397F1193470ED2DC43BAAB865` |
+
+## Staleness Rules
+
+This context pack is stale when:
+
+- any governing hash changes;
+- `documentation/workflow/workflow.md` changes without updating this pack;
+- any branch mismatch is detected;
+- an ADR changes the Traefik ingress or setup safety baseline;
+- a workflow execution slice changes quality commands or allowed file locks.
+
+## Branch Evidence
+
+- Dedicated branch: `feature/workflow-installation-phases-port-registry-20260620`
+- Branch ref verification: `git show-ref --verify --quiet refs/heads/feature/workflow-installation-phases-port-registry-20260620`
+- Active branch verification: `git branch --show-current`
+
+## arc42 Check
+
+Checked during workflow creation:
+
+- `documentation/arc42/05_building_blocks.adoc`
+- `documentation/arc42/07_deployment_view.adoc`
+- `documentation/arc42/08_concepts.adoc`
+- `documentation/arc42/09_architecture_decisions.adoc`
+- `documentation/arc42/10_quality_requirements.adoc`
+
+No arc42 file was modified during workflow creation. Slice 01 and Slice 07 own execution-time synchronization.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,0 +1,983 @@
+# Workflow: Installation Phases And Port Registry
+
+Version: `installation-phases-port-registry-v1.0.0`
+Created: `2026-06-20`
+Branch: `feature/workflow-installation-phases-port-registry-20260620`
+Status: `READY_FOR_WORKFLOW`
+
+## Executive Summary
+
+Create an executable workflow for making Tiny Swarm World installation order and port allocation deterministic. The workflow covers a central port registry, installation phase registry, dependency graph, health/validation plan, and the Python automation needed to consume those declarations through existing hexagonal boundaries.
+
+The current repository already accepts Traefik-backed centralized ingress on ports `80` and `443` for the service-access setup profile. This workflow must not silently replace that ADR-backed ingress baseline with high-numbered gateway ports. High-numbered service ports may be introduced as direct, diagnostic, or compatibility mappings only after the architecture slice records the intended port model.
+
+## Requirement Clarification Gate
+
+Original Request:
+
+- Create a workflow for fixed installation order and a clean port concept for Tiny Swarm World services.
+- Model install phases from preflight through LXC/LXD/Incus, Docker Swarm, secrets, registry, CI/CD, quality, messaging, observability, service access, Swagger/API docs, and greenpath validation.
+- Introduce central files such as `ports.yaml`, `installation-plan.yaml`, `services.yaml`, `dependencies.yaml`, `health-checks.yaml`, and `validation-plan.yaml`.
+
+Interpreted Intent:
+
+- Build a workflow that later implements declarative setup planning and port governance without bypassing the current Python automation, live-consent, Docker Swarm, LXC-native, and hexagonal architecture constraints.
+
+Change Type:
+
+- Product behavior workflow for Python automation, configuration, deployment contracts, tests, and documentation.
+
+Affected Process Strand:
+
+- `workflow create`
+- later `workflow execute` over setup, platform, artifacts, deployment, preflight, and documentation strands.
+
+Affected Architecture Area:
+
+- Domain: installation plan, port registry, dependency graph, health/validation concepts.
+- Application: setup orchestration, preflight checks, deployment plan construction, validation sequencing.
+- Infrastructure: YAML repositories for new registries and compose/stack configuration integration.
+- Configuration: `infra/config/**` desired-state files.
+- Documentation: arc42 deployment/concepts/quality and operator setup guidance.
+
+Explicit Requirements:
+
+- Define fixed installation phases.
+- Define fixed service dependencies.
+- Define central port ranges and service port assignments.
+- Keep ports centrally declared instead of hard-coded across compose files, Python code, and templates.
+- Add port preflight checks.
+- Add phase-level health and validation checks.
+- Keep service-access/control UI as a late-installed but first-used operator entry point.
+
+Implicit Requirements:
+
+- Preserve Linux/WSL-only operation.
+- Preserve LXC-native through LXD or Incus as the supported node-provider direction.
+- Preserve Docker Swarm-first deployment.
+- Preserve current live-infrastructure consent and fail-closed behavior.
+- Use structured YAML parsing and repository adapters.
+- Do not claim live service health without observed-state or smoke evidence.
+- Do not introduce React, Java, Maven, Spring Boot, Kubernetes-first behavior, or direct live scripts as canonical behavior.
+
+Assumptions:
+
+- The central registry belongs under `infra/config` unless the architecture slice finds a stronger existing desired-state location.
+- Traefik `80/443` remains the public centralized ingress baseline unless an ADR change is explicitly authored.
+- High-numbered ports are useful for direct/diagnostic host mappings, local compatibility endpoints, and preflight conflict detection.
+- Observability services such as Prometheus, Grafana, Loki, and Alertmanager can be modeled as optional until repository compose contracts exist.
+- RabbitMQ is a requested target service, but the current repository baseline contains Apache Pulsar rather than RabbitMQ. RabbitMQ must be added only through a service-stack slice with tests and docs, or documented as deferred if not selected.
+
+Non-Goals:
+
+- No live LXD, Incus, LXC, Docker Swarm, compose, Portainer, Nexus, Jenkins, SonarQube, Infisical, Pulsar, RabbitMQ, Prometheus, Grafana, or Swagger mutation during default verification.
+- No replacement of accepted Traefik ingress without ADR coverage.
+- No browser React frontend project.
+- No Java/Maven/Spring Boot structure.
+- No Kubernetes-first migration.
+- No committed secrets, host IPs, Swarm tokens, local absolute paths, or credential-bearing URLs.
+
+Risks:
+
+- The proposed high-numbered gateway ports can conflict with the accepted Traefik `80/443` ingress direction if treated as public ingress replacement.
+- Existing compose files still publish several direct ports such as `8080`, `8081`, `9000`, `9001`, `5000`, `5001`, `6650`, `7750`, `8087`, `9527`, and `8084`.
+- Service registry work can touch shared deployment contracts and must be sliced carefully.
+- RabbitMQ and observability services are not currently present as compose stacks in the verified baseline.
+
+Open Questions:
+
+- Should RabbitMQ replace, complement, or remain separate from the existing Pulsar baseline? This is non-blocking if RabbitMQ is modeled as deferred or optional until a later explicit service-selection decision.
+- Should high-numbered ports become direct host ports while Traefik remains the main user ingress, or should they become a later ADR-backed ingress replacement? The workflow assumes direct/diagnostic use until ADR says otherwise.
+
+Blocking Questions:
+
+- None for workflow authoring.
+
+Confidence Level:
+
+- `92%`
+
+Decision:
+
+- `READY_FOR_WORKFLOW`
+
+## Five-Role Three Amigos Review
+
+Senior Requirement Engineer:
+
+- Requirements are concrete enough for workflow authoring. The workflow must record Pulsar vs RabbitMQ and Traefik vs high-port gateway assumptions instead of hiding them.
+
+Senior System Architect:
+
+- The workflow fits the autonomous setup and service-access EPICs when it keeps setup orchestration in Python, uses ports/adapters for YAML loading, and preserves accepted Traefik ingress unless an ADR changes it.
+
+Senior Python Automation Developer:
+
+- Implementation should introduce typed domain models and repository ports before wiring setup/preflight/deployment behavior. Compose and manifest integration must use structured YAML APIs.
+
+Senior React Frontend Developer:
+
+- No React frontend impact is approved. Service-access remains an infrastructure dashboard/static asset and console/status UI remains terminal-only unless a later workflow verifies a browser frontend module.
+
+Senior Tester:
+
+- Default gates must use static and mocked tests. Targeted tests should cover YAML schema validation, duplicate port detection, phase dependency ordering, preflight conflict reporting, health-check planning, and fail-closed validation semantics.
+
+Dependency / Deadlock Validator:
+
+- The slice order is acyclic: architecture decision first, registry schema second, domain/application consumers third, deployment/compose migration after consumers, validation last.
+
+Does the implementation still match the EPIC?
+
+- Yes, if execution preserves the autonomous runnable setup EPIC and service-access EPIC boundaries and does not claim live runnable success before evidence exists.
+
+## Execution Profile
+
+`executionProfile=FULL_PATH`
+
+Reason:
+
+- The workflow affects setup/deployment behavior, configuration contracts, port allocation, service ordering, quality gates, architecture documentation, and possible future service-stack expansion.
+
+Required Full Reviews:
+
+- Senior Requirement Engineer
+- Senior System Architect
+- Senior Python Automation Developer
+- Senior React Frontend Developer impact check
+- Senior Tester
+- Senior Documentation Engineer
+- Senior DevOps Engineer where deployment and runtime configuration are touched
+- Security review where secrets, credential references, or service exposure are touched
+
+Quality Commands:
+
+- Targeted during execution: relevant `PYTHONPATH=src python3 -m unittest ...` commands per slice.
+- Required before commit/push of implementation slices: `python3 tools/quality_gate.py quality`.
+- Documentation-only targeted gate: `git diff --check`.
+
+## Target Picture
+
+Tiny Swarm World has one declarative setup model that can answer:
+
+- which phase runs in which order;
+- which services belong to each phase;
+- which services depend on previous phases or service readiness;
+- which external host ports are reserved, diagnostic, or ingress-owned;
+- which internal container ports remain unchanged;
+- which preflight checks block mutation;
+- which health checks verify each phase;
+- which validation checks prove the greenpath without claiming live success by default.
+
+## Verified Baseline
+
+Repository evidence checked during workflow creation:
+
+- Root branch was `main`, then workflow branch `feature/workflow-installation-phases-port-registry-20260620` was created and verified.
+- Root `AGENTS.md` defines Linux/WSL-only, Python automation, Docker Swarm-first, LXC-native direction.
+- `QUALITY.md` defines `python3 tools/quality_gate.py quality` and targeted gates.
+- `documentation/epics/autonomous-runnable-setup.md` requires preflight, resource, port, secret, platform, artifact, deployment, and readiness checks before full runnable success.
+- `documentation/epics/service-access-dashboard-vaultwarden.md` requires service-access/Vaultwarden safety and forbids React scope.
+- `documentation/arc42/07_deployment_view.adoc` documents Traefik `80/443` as the current service-access public ingress baseline.
+- `documentation/arc42/08_concepts.adoc` documents desired inventory, observed state, evidence, ingress, and workflow distribution concepts.
+- `src/tiny_swarm_world/domain/preflight/setup_manifest.py` currently owns setup port and secret requirements.
+- `src/tiny_swarm_world/domain/deployment/service_stack_contract.py` currently owns service stack endpoint defaults.
+- `infra/config/compose/**/docker-compose.yml` currently contains direct published ports for several stacks.
+
+## Target Outcome
+
+After `workflow execute`, the repository should contain:
+
+- a central port registry with tested ranges, uniqueness, service mapping, internal/external semantics, and ingress/direct exposure classification;
+- a central installation phase registry with dependency ordering and required/optional service membership;
+- application services that consume the registries through ports and domain models;
+- setup/preflight behavior that checks required host ports before mutation;
+- deployment/service-stack planning that is aligned with the registry;
+- health and validation planning that fails closed when evidence is unavailable;
+- synchronized arc42 and operator documentation.
+
+## Scope
+
+In scope:
+
+- `infra/config` desired-state files for ports, phases, dependencies, health checks, and validation plans.
+- Python domain models for port registry and installation plan concepts.
+- Application ports/services for registry loading, phase ordering, preflight planning, and validation planning.
+- Infrastructure YAML repositories and composition wiring.
+- Existing compose stack contract alignment for Portainer, Nexus, Jenkins, SonarQube, Apache Pulsar, Swagger/NGINX, Infisical, service-access, and Traefik.
+- Tests for schema validation, ordering, duplicate detection, preflight integration, deployment planning, and evidence semantics.
+- Documentation and arc42 synchronization.
+
+Out of scope:
+
+- Live infrastructure execution.
+- Claims that services are live-installed, reachable, or healthy.
+- Browser React frontend implementation.
+- Replacing Pulsar with RabbitMQ without explicit service selection and compose contract.
+- Replacing Traefik `80/443` public ingress without ADR coverage.
+
+## Architecture Constraints
+
+- Preserve hexagonal boundaries.
+- Domain code must not import YAML, filesystem, command runners, HTTP clients, logging, Docker clients, or infrastructure adapters.
+- Application services may orchestrate domain objects and ports but must not parse files or run shell commands directly.
+- Infrastructure adapters implement YAML and filesystem details.
+- Composition remains in `src/tiny_swarm_world/infrastructure/composition.py` and related composition modules.
+- Config files under `infra/config` are product behavior and must be validated through structured YAML APIs.
+- Default tests and quality gates must not run live infrastructure commands.
+
+## Python Automation Assessment
+
+Expected Python surfaces:
+
+- New or extended domain models for port ranges, service ports, installation phases, dependency edges, health checks, and validation steps.
+- New application ports for loading those desired-state declarations.
+- Infrastructure YAML repositories using `ruamel.yaml` in the established style.
+- Setup/preflight/deployment services that consume typed data, not raw YAML dictionaries.
+- Composition wiring that keeps concrete repositories out of application service constructors.
+
+## Frontend Assessment
+
+- No browser React frontend is in scope.
+- The existing service-access static dashboard may need route/port display updates only if the registry becomes the source for its catalog.
+- Console/status UI impact is limited to setup progress and validation status wording if execution slices change operator output.
+
+## Test Strategy
+
+Regression-first tests should cover:
+
+- central port registry loads valid YAML and rejects duplicate external ports;
+- invalid port range, invalid service id, host-specific values, and credential-bearing URL rejection;
+- installation phases sort deterministically and reject cycles;
+- setup manifest required ports are derived from or checked against the central registry;
+- service stack endpoint contracts align with registry entries and do not claim readiness;
+- compose published ports are either registry-backed, ingress-owned, or explicitly diagnostic/deferred;
+- health and validation plans fail closed when an observed-state source is missing;
+- default quality gates remain mocked/static and do not execute live infrastructure.
+
+## Resilience Requirements
+
+- Port conflict preflight must block before mutation.
+- Dependency cycles must block workflow planning.
+- Missing health-check evidence must produce `blocked` or `failed_to_verify`, never success.
+- Resource-gated profiles must remain distinct from full runnable success.
+- Secrets must be represented by source names or external secret names, not values.
+- Evidence must stay redacted and under ignored `.tiny-swarm-world/**` paths.
+
+## Ordered Slices
+
+### Slice 01 - Architecture And Port Model Decision
+
+Purpose:
+
+- Record the exact port model before implementation: Traefik `80/443` remains the current public ingress baseline; high-numbered ports are direct/diagnostic/compatibility allocations unless an ADR explicitly changes ingress.
+
+Prerequisites:
+
+- Workflow branch active.
+
+```yaml
+slice_id: "01"
+profile: "FULL_PATH"
+owner: "Senior System Architect"
+secondary_reviewers:
+  - "Senior Requirement Engineer"
+  - "Senior Documentation Engineer"
+affected_files:
+  - "documentation/arc42/07_deployment_view.adoc"
+  - "documentation/arc42/08_concepts.adoc"
+  - "documentation/arc42/09_architecture_decisions.adoc"
+  - "documentation/architecture/adr-traefik-https-ingress-existing-ca.adoc"
+affected_modules: []
+affected_contracts:
+  - "Traefik ingress baseline"
+  - "service-access setup profile"
+dependencies: []
+parallel_group: "architecture"
+file_locks:
+  - "documentation/arc42/**"
+  - "documentation/architecture/adr-traefik-https-ingress-existing-ca.adoc"
+contract_locks:
+  - "public ingress port model"
+architecture_locks:
+  - "Docker Swarm-first deployment"
+  - "LXC-native provider direction"
+quality_gates:
+  targeted:
+    - "git diff --check"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Check and update deployment/concepts/ADR index if the port model changes."
+  adr: "Required only if replacing Traefik 80/443 public ingress with high-numbered public gateway ports."
+stop_conditions:
+  - "Stop if high-numbered ports would contradict accepted Traefik ingress without an ADR."
+```
+
+Done Criteria:
+
+- The workflow execution records whether the port registry governs direct ports, public ingress, or both.
+- arc42 remains aligned with the selected model.
+- ADR need is explicitly resolved.
+
+Verification Commands:
+
+- `git diff --check`
+
+### Slice 02 - Central Port Registry Contract
+
+Purpose:
+
+- Add a central desired-state port registry under `infra/config` with range definitions, service mappings, external/internal semantics, exposure class, and ownership metadata.
+
+Prerequisites:
+
+- Slice 01 completed.
+
+```yaml
+slice_id: "02"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior System Architect"
+  - "Senior Tester"
+affected_files:
+  - "infra/config/ports.yaml"
+  - "src/tiny_swarm_world/domain/preflight/setup_manifest.py"
+  - "src/tiny_swarm_world/domain/network/port_forwarding_plan.py"
+  - "tests/domain/preflight/test_preflight_result.py"
+  - "tests/domain/network/test_port_forwarding_plan.py"
+affected_modules:
+  - "tiny_swarm_world.domain.preflight"
+  - "tiny_swarm_world.domain.network"
+affected_contracts:
+  - "Port registry schema"
+dependencies:
+  - "01"
+parallel_group: "backend"
+file_locks:
+  - "infra/config/ports.yaml"
+  - "src/tiny_swarm_world/domain/**"
+  - "tests/domain/**"
+contract_locks:
+  - "port registry schema"
+architecture_locks:
+  - "domain parser-independent model"
+quality_gates:
+  targeted:
+    - "PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Concepts may need a port registry summary."
+  adr: "Not expected unless ingress baseline changes."
+stop_conditions:
+  - "Stop if the registry would contain host-specific IP addresses, secrets, or credential-bearing URLs."
+  - "Stop if domain code would parse YAML directly."
+```
+
+Done Criteria:
+
+- Port ranges and service port entries are centrally declared.
+- Duplicate external ports are rejected by tests.
+- Internal container ports can remain service defaults while external mappings are governed.
+
+Verification Commands:
+
+- `PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result`
+
+### Slice 03 - Port Registry Repository And Preflight Integration
+
+Purpose:
+
+- Load the port registry through an application repository port and infrastructure YAML adapter, then integrate required host-port checks into setup preflight planning.
+
+Prerequisites:
+
+- Slice 02 completed.
+
+```yaml
+slice_id: "03"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior Tester"
+  - "Senior DevOps Engineer"
+affected_files:
+  - "src/tiny_swarm_world/application/ports/repositories/port_port_registry_repository.py"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/port_registry_yaml_repository.py"
+  - "src/tiny_swarm_world/application/services/platform/preflight_service.py"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py"
+  - "tests/application/services/platform/test_preflight_service.py"
+affected_modules:
+  - "tiny_swarm_world.application.ports.repositories"
+  - "tiny_swarm_world.infrastructure.adapters.repositories"
+  - "tiny_swarm_world.application.services.platform"
+affected_contracts:
+  - "setup preflight port availability"
+dependencies:
+  - "02"
+parallel_group: "backend"
+file_locks:
+  - "src/tiny_swarm_world/application/ports/repositories/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
+  - "src/tiny_swarm_world/application/services/platform/preflight_service.py"
+  - "src/tiny_swarm_world/infrastructure/composition.py"
+  - "tests/infrastructure/adapters/repositories/**"
+  - "tests/application/services/platform/test_preflight_service.py"
+contract_locks:
+  - "port registry repository contract"
+  - "preflight blocker semantics"
+architecture_locks:
+  - "application depends on ports, infrastructure implements adapters"
+quality_gates:
+  targeted:
+    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository tests.application.services.platform.test_preflight_service"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Update concepts/building blocks if a new repository port is introduced."
+  adr: "Not expected."
+stop_conditions:
+  - "Stop if preflight executes live networking commands in default tests."
+  - "Stop if infrastructure repository details leak into domain or application models."
+```
+
+Done Criteria:
+
+- Registry YAML loads via infrastructure adapter.
+- Application preflight can report port conflicts as blockers.
+- Tests use fakes/mocks and no live socket mutation.
+
+Verification Commands:
+
+- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository tests.application.services.platform.test_preflight_service`
+
+### Slice 04 - Installation Phase Registry And Dependency Graph
+
+Purpose:
+
+- Add a central phase plan for setup order and validate acyclic dependencies for preflight, platform, cluster, network/routing, secrets, artifacts, CI/CD, quality, messaging, observability, control, docs, and validation phases.
+
+Prerequisites:
+
+- Slice 01 completed.
+
+```yaml
+slice_id: "04"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior Requirement Engineer"
+  - "Senior Tester"
+affected_files:
+  - "infra/config/installation-plan.yaml"
+  - "src/tiny_swarm_world/domain/preflight/setup_manifest.py"
+  - "src/tiny_swarm_world/application/services/setup/workflow.py"
+  - "tests/application/services/setup/test_setup_workflow.py"
+  - "tests/domain/preflight/test_preflight_result.py"
+affected_modules:
+  - "tiny_swarm_world.domain.preflight"
+  - "tiny_swarm_world.application.services.setup"
+affected_contracts:
+  - "installation phase registry"
+  - "setup phase sequencing"
+dependencies:
+  - "01"
+parallel_group: "backend"
+file_locks:
+  - "infra/config/installation-plan.yaml"
+  - "src/tiny_swarm_world/domain/preflight/**"
+  - "src/tiny_swarm_world/application/services/setup/**"
+  - "tests/application/services/setup/**"
+contract_locks:
+  - "setup workflow phase order"
+architecture_locks:
+  - "fail-closed setup orchestration"
+quality_gates:
+  targeted:
+    - "PYTHONPATH=src python3 -m unittest tests.application.services.setup.test_setup_workflow tests.domain.preflight.test_preflight_result"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Runtime/deployment view should summarize ordered setup phases."
+  adr: "Not expected."
+stop_conditions:
+  - "Stop if dependency cycles exist."
+  - "Stop if a missing phase verification path can still report success."
+```
+
+Done Criteria:
+
+- Installation phases are declared centrally.
+- Phase dependencies sort deterministically.
+- Cycle and missing-required-service cases fail closed.
+
+Verification Commands:
+
+- `PYTHONPATH=src python3 -m unittest tests.application.services.setup.test_setup_workflow tests.domain.preflight.test_preflight_result`
+
+### Slice 05 - Service Registry And Stack Alignment
+
+Purpose:
+
+- Align service stack contracts, desired inventory, compose stack metadata, and registry service names so each selected service has a phase, dependency, port classification, and readiness target.
+
+Prerequisites:
+
+- Slices 02 and 04 completed.
+
+```yaml
+slice_id: "05"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior DevOps Engineer"
+  - "Senior Tester"
+affected_files:
+  - "infra/config/services.yml"
+  - "infra/config/inventory/desired_inventory.yaml"
+  - "infra/config/compose/**/docker-compose.yml"
+  - "src/tiny_swarm_world/domain/deployment/service_stack_contract.py"
+  - "src/tiny_swarm_world/application/services/deployment/service_stack_plan.py"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
+  - "tests/domain/deployment/test_service_stack_contract.py"
+  - "tests/application/services/deployment/test_service_stack_plan.py"
+  - "tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py"
+affected_modules:
+  - "tiny_swarm_world.domain.deployment"
+  - "tiny_swarm_world.application.services.deployment"
+  - "tiny_swarm_world.infrastructure.adapters.repositories"
+affected_contracts:
+  - "service stack contract"
+  - "compose published port extraction"
+  - "desired inventory selected stacks"
+dependencies:
+  - "02"
+  - "04"
+parallel_group: "runtime"
+file_locks:
+  - "infra/config/services.yml"
+  - "infra/config/inventory/desired_inventory.yaml"
+  - "infra/config/compose/**"
+  - "src/tiny_swarm_world/domain/deployment/**"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
+contract_locks:
+  - "service stack registry"
+  - "compose stack port mapping"
+architecture_locks:
+  - "Deployment responsibility boundary"
+quality_gates:
+  targeted:
+    - "PYTHONPATH=src python3 -m unittest tests.domain.deployment.test_service_stack_contract tests.application.services.deployment.test_service_stack_plan tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Update deployment view when direct published ports change or are reclassified."
+  adr: "Required if service exposure model changes beyond documented Traefik/direct-port compatibility."
+stop_conditions:
+  - "Stop if Portainer becomes a bootstrap dependency for Portainer."
+  - "Stop if service readiness is claimed from static config alone."
+  - "Stop if RabbitMQ is added without service-stack contract, compose, tests, and docs."
+```
+
+Done Criteria:
+
+- Selected services map to registry entries and phases.
+- Compose published ports are either registry-backed, ingress-owned, or explicitly deferred.
+- Current Pulsar baseline and any RabbitMQ decision are explicit.
+
+Verification Commands:
+
+- `PYTHONPATH=src python3 -m unittest tests.domain.deployment.test_service_stack_contract tests.application.services.deployment.test_service_stack_plan tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml`
+
+### Slice 06 - Health Check And Validation Plan Registry
+
+Purpose:
+
+- Add health-check and validation-plan declarations that distinguish static readiness plans from observed runtime evidence.
+
+Prerequisites:
+
+- Slices 04 and 05 completed.
+
+```yaml
+slice_id: "06"
+profile: "FULL_PATH"
+owner: "Senior Python Automation Developer"
+secondary_reviewers:
+  - "Senior Tester"
+  - "Senior DevOps Engineer"
+affected_files:
+  - "infra/config/health-checks.yaml"
+  - "infra/config/validation-plan.yaml"
+  - "src/tiny_swarm_world/application/services/deployment/verify_swarm_service_readiness.py"
+  - "src/tiny_swarm_world/application/services/deployment/workflows.py"
+  - "tests/application/services/deployment/test_verify_swarm_service_readiness.py"
+  - "tests/application/services/deployment/test_deployment_workflows.py"
+affected_modules:
+  - "tiny_swarm_world.application.services.deployment"
+affected_contracts:
+  - "health check registry"
+  - "greenpath validation plan"
+dependencies:
+  - "04"
+  - "05"
+parallel_group: "quality"
+file_locks:
+  - "infra/config/health-checks.yaml"
+  - "infra/config/validation-plan.yaml"
+  - "src/tiny_swarm_world/application/services/deployment/**"
+  - "tests/application/services/deployment/**"
+contract_locks:
+  - "service readiness evidence semantics"
+architecture_locks:
+  - "observed-state evidence remains local and redacted"
+quality_gates:
+  targeted:
+    - "PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_verify_swarm_service_readiness tests.application.services.deployment.test_deployment_workflows"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Update quality requirements with validation-plan fail-closed behavior."
+  adr: "Not expected."
+stop_conditions:
+  - "Stop if HTTP checks are documented as live default quality gates."
+  - "Stop if missing observed evidence reports healthy."
+```
+
+Done Criteria:
+
+- Health checks and greenpath validation steps are centrally declared.
+- Runtime evidence remains separate from desired checks.
+- Tests prove missing evidence fails closed.
+
+Verification Commands:
+
+- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_verify_swarm_service_readiness tests.application.services.deployment.test_deployment_workflows`
+
+### Slice 07 - Operator Documentation And Arc42 Synchronization
+
+Purpose:
+
+- Update operator docs, arc42, and EPIC references to explain the installation phase model, port registry, current Traefik ingress baseline, and validation semantics.
+
+Prerequisites:
+
+- Slices 02 through 06 completed or explicitly skipped with evidence.
+
+```yaml
+slice_id: "07"
+profile: "FULL_PATH"
+owner: "Senior Documentation Engineer"
+secondary_reviewers:
+  - "Senior System Architect"
+  - "Senior Requirement Engineer"
+  - "Senior Tester"
+affected_files:
+  - "README.md"
+  - "documentation/deployment/system.adoc"
+  - "documentation/system/lxc-native-setup.adoc"
+  - "documentation/configuration/config-contract-inventory.md"
+  - "documentation/arc42/05_building_blocks.adoc"
+  - "documentation/arc42/06_runtime_view.adoc"
+  - "documentation/arc42/07_deployment_view.adoc"
+  - "documentation/arc42/08_concepts.adoc"
+  - "documentation/arc42/10_quality_requirements.adoc"
+  - "documentation/epics/autonomous-runnable-setup.md"
+affected_modules: []
+affected_contracts:
+  - "operator setup documentation"
+dependencies:
+  - "02"
+  - "03"
+  - "04"
+  - "05"
+  - "06"
+parallel_group: "documentation"
+file_locks:
+  - "README.md"
+  - "documentation/**"
+contract_locks:
+  - "documented setup behavior"
+architecture_locks:
+  - "arc42 deployment and concept consistency"
+quality_gates:
+  targeted:
+    - "git diff --check"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Must be synchronized."
+  adr: "Only if execution changed accepted architecture decisions."
+stop_conditions:
+  - "Stop if docs would claim live installation or health without evidence."
+  - "Stop if docs use Windows-specific setup commands or paths."
+```
+
+Done Criteria:
+
+- Documentation describes implemented behavior only.
+- Planned services remain clearly marked as planned, optional, or deferred.
+- arc42 is consistent with registry and setup behavior.
+
+Verification Commands:
+
+- `git diff --check`
+
+### Slice 08 - Full Quality Gate And Execution Handoff
+
+Purpose:
+
+- Run final verification, classify any failures through repository quality rules, and prepare the workflow evidence for commit/push readiness if requested.
+
+Prerequisites:
+
+- Slices 01 through 07 completed or explicitly stopped with evidence.
+
+```yaml
+slice_id: "08"
+profile: "FULL_PATH"
+owner: "Senior Tester"
+secondary_reviewers:
+  - "Quality Gate Orchestrator"
+  - "Senior Workflow Architect"
+affected_files:
+  - ".codex/evidence/**"
+  - "documentation/workflow/context-pack.md"
+  - "documentation/workflow/context-pack.json"
+affected_modules: []
+affected_contracts:
+  - "quality gate evidence"
+dependencies:
+  - "07"
+parallel_group: "quality"
+file_locks:
+  - ".codex/evidence/**"
+  - "documentation/workflow/**"
+contract_locks:
+  - "workflow execute evidence"
+architecture_locks: []
+quality_gates:
+  targeted:
+    - "git diff --check"
+  required:
+    - "python3 tools/quality_gate.py quality"
+documentation:
+  arc42: "Confirm synchronized."
+  adr: "Confirm no missing ADR remains."
+stop_conditions:
+  - "Stop on failed or unverifiable required quality gate."
+  - "Stop if generated local artifacts, caches, logs, or secrets appear in git status."
+```
+
+Done Criteria:
+
+- Required gates are run or explicitly justified if skipped.
+- Evidence records targeted and full gate outcomes.
+- No generated local state is staged.
+
+Verification Commands:
+
+- `python3 tools/quality_gate.py quality`
+
+## Slice Dependency Graph
+
+```text
+01
+|\
+| +-- 04
+|     \
+02 ----+-- 05 -- 06 -- 07 -- 08
+  \
+   +-- 03
+```
+
+Execution order:
+
+1. Slice 01
+2. Slice 02 and Slice 04 may run after Slice 01 if isolated worktrees are used and file locks are disjoint.
+3. Slice 03 may run after Slice 02.
+4. Slice 05 waits for Slices 02 and 04.
+5. Slice 06 waits for Slices 04 and 05.
+6. Slice 07 waits for implementation slices.
+7. Slice 08 runs last.
+
+## Parallel Execution
+
+- Can this workflow run in parallel? `limited`
+- Conflicting workflows: any workflow that touches `infra/config/**`, setup/deployment services, compose stack contracts, `documentation/arc42/**`, or service-access/Traefik ingress.
+- Shared files: `src/tiny_swarm_world/infrastructure/composition.py`, `src/tiny_swarm_world/domain/preflight/setup_manifest.py`, `src/tiny_swarm_world/domain/deployment/service_stack_contract.py`, `infra/config/compose/**`, `documentation/arc42/**`.
+- Shared infrastructure: LXC/LXD/Incus, Docker Swarm, compose stacks, Portainer, Nexus, Jenkins, SonarQube, Infisical, Pulsar, service-access, Traefik.
+- Requires isolated worktree: `yes`
+- Requires serialized live validation: `yes`
+- Merge-order constraints: architecture and registry contracts before consumers; documentation after behavior; final quality last.
+
+Parallelization Opportunities:
+
+- Slice 02 and Slice 04 may be split after Slice 01 if Three Amigos confirms disjoint files.
+- Slice 03 can run in parallel with Slice 04 after Slice 02 only if setup manifest files are not shared.
+- Documentation drafting for Slice 07 may begin read-only earlier, but writes wait until implementation behavior is known.
+
+## Automatic Work Distribution Policy
+
+During `workflow execute`, Codex must analyze every slice for safe specialist stream decomposition before implementation.
+
+Stream map:
+
+- backend: Senior Python Automation Developer for domain, application, ports, repositories, and composition.
+- frontend: console/status UI skills for terminal/status output; browser React impact check is N/A unless a verified frontend module exists.
+- tests: Senior Tester and quality-gate skills.
+- runtime: Senior DevOps Engineer for compose, Docker Swarm, LXC exposure, and service-stack runtime contracts.
+- documentation: Senior Documentation Engineer.
+- quality: Quality Gate Orchestrator and Senior Tester.
+- architecture: Senior System Architect and arc42 governance.
+- security: security and secrets/configuration review where port exposure, credentials, or evidence are touched.
+
+`workflow execute` must use real Codex subagents where supported. If callable subagents are unavailable, the executor must perform explicit role-based fallback review in the main thread and record that fallback in `.codex/evidence/slice-<number>-distribution.md`.
+
+Before implementation for each slice:
+
+- write `.codex/evidence/slice-<number>-distribution.md`;
+- record whether the slice can be split into backend, frontend, tests, runtime, documentation, quality, architecture, or security streams;
+- record file locks, contract locks, and stop conditions.
+
+After implementation for each implemented slice:
+
+- write `.codex/evidence/slice-<number>-consolidation.md`;
+- record accepted stream changes, rejected changes, tests run, and remaining risk.
+
+Non-parallelization rules:
+
+- Do not parallelize overlapping files.
+- Do not parallelize unclear architecture boundaries.
+- Do not parallelize contradictory requirements.
+- Do not parallelize mandatory ordering.
+- Do not parallelize shared migrations or strict schema/config sequencing.
+- Do not parallelize generated-file conflicts.
+- Do not parallelize when Three Amigos marks the slice not safely parallelizable.
+- Do not parallelize unclear secrets handling.
+- Do not parallelize weakened safety guards.
+
+Codex remains final integration owner for consolidation, tests, evidence, PR readiness, and merge readiness.
+
+## Git Worktree Execution Rule
+
+Every executable stream must use an isolated worktree and stream branch when parallelized.
+
+Stream branch format:
+
+```text
+feature/workflow-installation-phases-port-registry-20260620-slice-<number>-<stream>
+```
+
+Rules:
+
+- Verify the stream branch belongs to this workflow before writing.
+- Do not implement on `main`, `master`, `develop`, or shared branches.
+- Stream workers must not merge directly into the main workflow branch.
+- Codex consolidates stream results into `feature/workflow-installation-phases-port-registry-20260620` after evidence and tests pass.
+- Live validation is serialized unless isolated disposable infrastructure is explicitly approved.
+
+## Role Ownership Map
+
+- Senior Workflow Architect: workflow dependency ordering and execution handoff.
+- Senior Requirement Engineer: requirement drift, EPIC fit, open assumptions.
+- Senior System Architect: architecture boundaries, Traefik/port model, ADR need.
+- Senior Python Automation Developer: domain, application, repositories, composition, tests.
+- Senior React Frontend Developer: mandatory impact check; no React scope approved.
+- Senior Tester: regression design and quality gate evidence.
+- Senior DevOps Engineer: compose, Swarm, LXC exposure, service-stack runtime contracts.
+- Senior Documentation Engineer: README, arc42, deployment/system docs.
+- Security reviewer: secrets, credential references, port exposure, evidence redaction.
+
+## Quality Gate Expectations
+
+Use commands from `QUALITY.md` only.
+
+Targeted gates:
+
+- `git diff --check` for documentation-only slices.
+- `PYTHONPATH=src python3 -m unittest <nearest test modules>` for implementation slices.
+
+Required final gate:
+
+```bash
+python3 tools/quality_gate.py quality
+```
+
+The default quality gate must not execute live infrastructure commands.
+
+## Documentation Synchronization Points
+
+- Slice 01: arc42 and ADR check for port model.
+- Slice 05: deployment view if compose published ports or service stack endpoint behavior changes.
+- Slice 06: quality requirements if validation evidence semantics change.
+- Slice 07: README, deployment docs, system docs, configuration docs, EPIC notes, and arc42 synchronization.
+
+## Stop Conditions
+
+Stop workflow execution if:
+
+- active branch is not the workflow branch or its approved stream branch;
+- a slice would touch files outside its allowed scope;
+- Traefik ingress would be replaced without ADR coverage;
+- live infrastructure commands would be required without explicit approval;
+- domain/application/infrastructure dependency direction would be violated;
+- service health would be claimed without observed-state or smoke evidence;
+- secrets, tokens, local IP addresses, local absolute paths, or raw command output would be committed or persisted as evidence;
+- RabbitMQ is added without explicit service-stack contract, compose, tests, and docs;
+- quality commands cannot be verified from `QUALITY.md`;
+- unrelated local changes appear and ownership is unclear.
+
+## Uncertainty Escalation Rules
+
+- Port model conflict: escalate to Senior System Architect and ADR steward.
+- Pulsar vs RabbitMQ service-selection conflict: escalate to Senior Requirement Engineer and Senior System Architect.
+- Secret-handling uncertainty: escalate to security and secrets/configuration review.
+- Quality gate uncertainty: escalate to Senior Tester and Quality Gate Orchestrator.
+- Branch or file-lock conflict: escalate to Senior Workflow Architect and conflict-resolution skill.
+
+## Commit And Push Plan
+
+- Do not commit or push during workflow creation unless explicitly requested.
+- During `workflow execute`, each slice commit must represent exactly one slice.
+- `push auto` is not implied by this workflow. If later requested, it must run the full guarded lifecycle described in root `AGENTS.md`.
+
+## Definition Of Done
+
+- `documentation/workflow/workflow.md` exists and validates against workflow-authoring structure.
+- `documentation/workflow/context-pack.md` and `documentation/workflow/context-pack.json` exist.
+- Branch evidence is recorded.
+- Slices include YAML metadata, dependencies, file locks, quality gates, documentation impact, and stop conditions.
+- arc42 check status is recorded.
+- `workflow execute` can start from this workflow without guessing scope.
+
+## Handoff To Workflow Execute
+
+`workflow execute` may proceed after verifying:
+
+- active branch is `feature/workflow-installation-phases-port-registry-20260620`;
+- `documentation/workflow/context-pack.json` hashes still match governing files;
+- no unrelated or unclear local changes exist;
+- slice metadata is intact;
+- S3/S3D preflight confirms dependency order and file locks;
+- live infrastructure commands remain out of default gates unless explicitly approved.
+
+## arc42 Check Status
+
+Checked during workflow creation:
+
+- `documentation/arc42/05_building_blocks.adoc`
+- `documentation/arc42/07_deployment_view.adoc`
+- `documentation/arc42/08_concepts.adoc`
+- `documentation/arc42/09_architecture_decisions.adoc`
+- `documentation/arc42/10_quality_requirements.adoc`
+
+Result:
+
+- arc42 already documents the current Traefik `80/443` ingress baseline, desired/observed state separation, evidence redaction, and service-access profile boundaries.
+- No arc42 file was changed during workflow creation.
+- Slice 01 and Slice 07 are responsible for arc42 updates during execution if implementation changes behavior or documented contracts.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,9 +1,11 @@
 # Workflow: Installation Phases And Port Registry
 
 Version: `installation-phases-port-registry-v1.0.0`
+Workflow ID: `workflow-install-order-and-port-allocation-20260620`
 Created: `2026-06-20`
 Branch: `feature/workflow-installation-phases-port-registry-20260620`
 Status: `READY_FOR_WORKFLOW`
+Evidence Root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
 
 ## Executive Summary
 
@@ -745,7 +747,7 @@ secondary_reviewers:
   - "Quality Gate Orchestrator"
   - "Senior Workflow Architect"
 affected_files:
-  - ".codex/evidence/**"
+  - ".codex/evidence/workflow-install-order-and-port-allocation-20260620/**"
   - "documentation/workflow/context-pack.md"
   - "documentation/workflow/context-pack.json"
 affected_modules: []
@@ -755,7 +757,7 @@ dependencies:
   - "07"
 parallel_group: "quality"
 file_locks:
-  - ".codex/evidence/**"
+  - ".codex/evidence/workflow-install-order-and-port-allocation-20260620/**"
   - "documentation/workflow/**"
 contract_locks:
   - "workflow execute evidence"
@@ -836,17 +838,31 @@ Stream map:
 - architecture: Senior System Architect and arc42 governance.
 - security: security and secrets/configuration review where port exposure, credentials, or evidence are touched.
 
-`workflow execute` must use real Codex subagents where supported. If callable subagents are unavailable, the executor must perform explicit role-based fallback review in the main thread and record that fallback in `.codex/evidence/slice-<number>-distribution.md`.
+`workflow execute` must use real Codex subagents where supported. If callable subagents are unavailable, the executor must perform explicit role-based fallback review in the main thread and record that fallback in `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-distribution.md`.
+
+Evidence governance:
+
+- Evidence files must never be written directly into `.codex/evidence/` using generic slice names.
+- Every workflow must write evidence into its dedicated workflow-specific subdirectory.
+- This workflow writes evidence only under `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
+- Forbidden generic paths include `.codex/evidence/slice-01-distribution.md` and `.codex/evidence/slice-01-consolidation.md`.
+
+Evidence collision preflight guard:
+
+- Before writing evidence, check whether the target file already exists.
+- If the target file exists and belongs to another workflow, stop and report a blocker.
+- Do not overwrite, modify, truncate, rename, or delete evidence belonging to another workflow.
+- Existing generic evidence files for unrelated workflows must remain unchanged.
 
 Before implementation for each slice:
 
-- write `.codex/evidence/slice-<number>-distribution.md`;
+- write `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-distribution.md`;
 - record whether the slice can be split into backend, frontend, tests, runtime, documentation, quality, architecture, or security streams;
 - record file locks, contract locks, and stop conditions.
 
 After implementation for each implemented slice:
 
-- write `.codex/evidence/slice-<number>-consolidation.md`;
+- write `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-consolidation.md`;
 - record accepted stream changes, rejected changes, tests run, and remaining risk.
 
 Non-parallelization rules:

--- a/infra/config/health-checks.yaml
+++ b/infra/config/health-checks.yaml
@@ -1,0 +1,94 @@
+schema_version: "1"
+metadata:
+  workflow_id: workflow-install-order-and-port-allocation-20260620
+  policy: "Health checks declare desired checks only; runtime evidence must come from observed VerificationResult records."
+checks:
+  - id: portainer-service-readiness
+    stack: portainer
+    target_id: deployment:portainer-service-readiness
+    phase: platform
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - portainer
+      - agent
+    live_default: false
+
+  - id: nexus-service-readiness
+    stack: nexus
+    target_id: deployment:nexus-service-readiness
+    phase: artifacts
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - nexus
+    live_default: false
+
+  - id: jenkins-service-readiness
+    stack: jenkins
+    target_id: deployment:jenkins-service-readiness
+    phase: cicd
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - jenkins
+    live_default: false
+
+  - id: pulsar-service-readiness
+    stack: pulsar
+    target_id: deployment:pulsar-service-readiness
+    phase: messaging
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - pulsar
+      - pulsar-manager
+    live_default: false
+
+  - id: sonarqube-service-readiness
+    stack: sonarqube
+    target_id: deployment:sonarqube-service-readiness
+    phase: quality
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - sonarqube
+      - sonar_db
+    live_default: false
+
+  - id: swagger-service-readiness
+    stack: swagger
+    target_id: deployment:swagger-service-readiness
+    phase: docs
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - swagger-editor
+      - swagger-ui
+      - swagger-api
+      - swagger-nginx
+    live_default: false
+
+  - id: infisical-service-readiness
+    stack: infisical
+    target_id: deployment:infisical-service-readiness
+    phase: secrets
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - infisical
+      - infisical-db
+      - infisical-redis
+    live_default: false
+
+  - id: service-access-service-readiness
+    stack: service-access
+    target_id: deployment:service-access-service-readiness
+    phase: control
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - service-access-dashboard
+      - service-access-nginx
+    live_default: false
+
+  - id: traefik-service-readiness
+    stack: traefik
+    target_id: deployment:traefik-service-readiness
+    phase: network-routing
+    evidence_kind: swarm_service_replicas
+    required_services:
+      - traefik
+    live_default: false

--- a/infra/config/installation-plan.yaml
+++ b/infra/config/installation-plan.yaml
@@ -1,0 +1,164 @@
+schema_version: 1
+metadata:
+  workflow_id: workflow-install-order-and-port-allocation-20260620
+  public_ingress_owner: traefik
+  note: >
+    Declarative installation phase registry. Runtime parsing requires a future
+    infrastructure repository adapter; domain and setup workflow code consume
+    typed InstallationPlan objects only.
+required_services:
+  - docker
+  - swarm
+  - traefik
+  - infisical
+  - nexus
+  - jenkins
+  - sonarqube
+  - pulsar
+  - service-access
+  - swagger
+required_phase_ids:
+  - preflight
+  - platform
+  - cluster
+  - network-routing
+  - secrets
+  - artifacts
+  - cicd
+  - quality
+  - messaging
+  - control
+  - docs
+  - validation
+phases:
+  - id: preflight
+    order: 0
+    required: true
+    depends_on: []
+    services: []
+    workflow_phases:
+      - preflight
+
+  - id: platform
+    order: 10
+    required: true
+    depends_on:
+      - preflight
+    services: []
+    workflow_phases:
+      - platform init
+      - platform reconcile
+
+  - id: cluster
+    order: 20
+    required: true
+    depends_on:
+      - platform
+    services:
+      - docker
+      - swarm
+    workflow_phases: []
+
+  - id: network-routing
+    order: 30
+    required: true
+    depends_on:
+      - cluster
+    services:
+      - traefik
+    workflow_phases:
+      - platform expose
+
+  - id: secrets
+    order: 40
+    required: true
+    depends_on:
+      - network-routing
+    services:
+      - infisical
+    workflow_phases:
+      - deployment bootstrap
+
+  - id: artifacts
+    order: 50
+    required: true
+    depends_on:
+      - secrets
+    services:
+      - nexus
+    workflow_phases:
+      - artifacts prepare
+      - artifacts verify
+
+  - id: cicd
+    order: 60
+    required: true
+    depends_on:
+      - artifacts
+      - secrets
+    services:
+      - jenkins
+    workflow_phases: []
+
+  - id: quality
+    order: 70
+    required: true
+    depends_on:
+      - artifacts
+      - secrets
+    services:
+      - sonarqube
+    workflow_phases: []
+
+  - id: messaging
+    order: 80
+    required: true
+    depends_on:
+      - secrets
+    services:
+      - pulsar
+    workflow_phases: []
+
+  - id: observability
+    order: 90
+    required: false
+    depends_on:
+      - network-routing
+    services:
+      - prometheus
+      - grafana
+      - loki
+      - alertmanager
+    workflow_phases: []
+
+  - id: control
+    order: 100
+    required: true
+    depends_on:
+      - cicd
+      - quality
+      - messaging
+    services:
+      - service-access
+    workflow_phases: []
+
+  - id: docs
+    order: 110
+    required: true
+    depends_on:
+      - control
+    services:
+      - swagger
+      - openapi-aggregator
+    workflow_phases: []
+
+  - id: validation
+    order: 120
+    required: true
+    depends_on:
+      - docs
+    services: []
+    workflow_phases:
+      - deployment apply
+      - deployment verify
+      - platform verify

--- a/infra/config/ports.yaml
+++ b/infra/config/ports.yaml
@@ -1,0 +1,231 @@
+schema_version: "1"
+metadata:
+  ingress_baseline: "traefik"
+  public_ingress_policy: "Traefik owns public ingress ports 80 and 443."
+  direct_port_policy: "High-numbered ports are direct, diagnostic, compatibility, or preflight allocations unless a later ADR changes public ingress."
+ranges:
+  - id: public-ingress
+    start: 80
+    end: 443
+    description: "ADR-backed local public ingress owned by Traefik."
+  - id: core-gateway
+    start: 10000
+    end: 10999
+    description: "Core access, gateway, and control surfaces."
+  - id: cicd
+    start: 11000
+    end: 11999
+    description: "CI/CD service access."
+  - id: code-quality
+    start: 12000
+    end: 12999
+    description: "Code quality service access."
+  - id: artifacts
+    start: 13000
+    end: 13999
+    description: "Artifact, registry, and repository service access."
+  - id: messaging
+    start: 14000
+    end: 14999
+    description: "Messaging service access."
+  - id: observability
+    start: 15000
+    end: 15999
+    description: "Observability service access."
+  - id: documentation
+    start: 16000
+    end: 16999
+    description: "Documentation and API explorer service access."
+  - id: security-secrets
+    start: 17000
+    end: 17999
+    description: "Security and secret-management service access."
+  - id: tiny-services
+    start: 18000
+    end: 18999
+    description: "Tiny Swarm World internal application surfaces."
+  - id: reserved-experimental
+    start: 19000
+    end: 19999
+    description: "Reserved experimental allocations."
+ports:
+  - id: traefik-http
+    service_id: traefik
+    internal_port: 80
+    external_port: 80
+    exposure: public_ingress
+    range_id: public-ingress
+    protocol: tcp
+    route_host: tsw.local
+    required_for_preflight: true
+  - id: traefik-https
+    service_id: traefik
+    internal_port: 443
+    external_port: 443
+    exposure: public_ingress
+    range_id: public-ingress
+    protocol: tcp
+    route_host: tsw.local
+    required_for_preflight: true
+  - id: service-access-http
+    service_id: service-access
+    internal_port: 80
+    external_port: 10000
+    exposure: diagnostic
+    range_id: core-gateway
+    protocol: tcp
+    route_host: service-access.tsw.local
+    required_for_preflight: false
+  - id: api-gateway-http
+    service_id: api-gateway
+    internal_port: 80
+    external_port: 10080
+    exposure: diagnostic
+    range_id: core-gateway
+    protocol: tcp
+    route_host: gateway.tsw.local
+    required_for_preflight: false
+  - id: api-gateway-https
+    service_id: api-gateway
+    internal_port: 443
+    external_port: 10443
+    exposure: diagnostic
+    range_id: core-gateway
+    protocol: tcp
+    route_host: gateway.tsw.local
+    required_for_preflight: false
+  - id: jenkins-http
+    service_id: jenkins
+    internal_port: 8080
+    external_port: 11080
+    exposure: diagnostic
+    range_id: cicd
+    protocol: tcp
+    route_host: jenkins.tsw.local
+    required_for_preflight: false
+  - id: jenkins-agent
+    service_id: jenkins
+    internal_port: 50000
+    external_port: 11050
+    exposure: diagnostic
+    range_id: cicd
+    protocol: tcp
+    required_for_preflight: false
+  - id: sonarqube-http
+    service_id: sonarqube
+    internal_port: 9000
+    external_port: 12000
+    exposure: diagnostic
+    range_id: code-quality
+    protocol: tcp
+    route_host: sonarqube.tsw.local
+    required_for_preflight: false
+  - id: nexus-http
+    service_id: nexus
+    internal_port: 8081
+    external_port: 13081
+    exposure: diagnostic
+    range_id: artifacts
+    protocol: tcp
+    route_host: nexus.tsw.local
+    required_for_preflight: false
+  - id: nexus-docker-http
+    service_id: nexus
+    internal_port: 5000
+    external_port: 13500
+    exposure: diagnostic
+    range_id: artifacts
+    protocol: tcp
+    required_for_preflight: false
+  - id: nexus-docker-https
+    service_id: nexus
+    internal_port: 5001
+    external_port: 13501
+    exposure: diagnostic
+    range_id: artifacts
+    protocol: tcp
+    required_for_preflight: false
+  - id: pulsar-broker
+    service_id: pulsar
+    internal_port: 6650
+    external_port: 14050
+    exposure: diagnostic
+    range_id: messaging
+    protocol: tcp
+    required_for_preflight: false
+  - id: pulsar-admin-api
+    service_id: pulsar
+    internal_port: 8080
+    external_port: 14087
+    exposure: diagnostic
+    range_id: messaging
+    protocol: tcp
+    required_for_preflight: false
+  - id: prometheus-http
+    service_id: prometheus
+    internal_port: 9090
+    external_port: 15090
+    exposure: diagnostic
+    range_id: observability
+    protocol: tcp
+    route_host: prometheus.tsw.local
+    required_for_preflight: false
+  - id: grafana-http
+    service_id: grafana
+    internal_port: 3000
+    external_port: 15300
+    exposure: diagnostic
+    range_id: observability
+    protocol: tcp
+    route_host: grafana.tsw.local
+    required_for_preflight: false
+  - id: swagger-ui
+    service_id: swagger
+    internal_port: 8080
+    external_port: 16080
+    exposure: diagnostic
+    range_id: documentation
+    protocol: tcp
+    route_host: swagger.tsw.local
+    required_for_preflight: false
+  - id: openapi-aggregator
+    service_id: swagger
+    internal_port: 8084
+    external_port: 16081
+    exposure: diagnostic
+    range_id: documentation
+    protocol: tcp
+    required_for_preflight: false
+  - id: infisical-http
+    service_id: infisical
+    internal_port: 8080
+    external_port: 17080
+    exposure: diagnostic
+    range_id: security-secrets
+    protocol: tcp
+    route_host: infisical.tsw.local
+    required_for_preflight: false
+  - id: tiny-swarm-frontend
+    service_id: tiny-swarm
+    internal_port: 8080
+    external_port: 18080
+    exposure: diagnostic
+    range_id: tiny-services
+    protocol: tcp
+    required_for_preflight: false
+  - id: tiny-swarm-backend
+    service_id: tiny-swarm
+    internal_port: 8081
+    external_port: 18081
+    exposure: diagnostic
+    range_id: tiny-services
+    protocol: tcp
+    required_for_preflight: false
+  - id: tiny-swarm-agent
+    service_id: tiny-swarm-agent
+    internal_port: 8082
+    external_port: 18082
+    exposure: diagnostic
+    range_id: tiny-services
+    protocol: tcp
+    required_for_preflight: false

--- a/infra/config/ports.yaml
+++ b/infra/config/ports.yaml
@@ -67,6 +67,15 @@ ports:
     protocol: tcp
     route_host: tsw.local
     required_for_preflight: true
+  - id: portainer-http
+    service_id: portainer
+    internal_port: 9000
+    external_port: 10001
+    exposure: compatibility
+    range_id: core-gateway
+    protocol: tcp
+    route_host: portainer.tsw.local
+    required_for_preflight: false
   - id: service-access-http
     service_id: service-access
     internal_port: 80

--- a/infra/config/services.yml
+++ b/infra/config/services.yml
@@ -1,7 +1,117 @@
+schema_version: "1"
+metadata:
+  workflow_id: workflow-install-order-and-port-allocation-20260620
+  readiness_policy: "Static registry data must not claim observed runtime readiness."
+  port_policy: >
+    Port IDs reference infra/config/ports.yaml target allocations. Legacy
+    published Compose ports remain classified as compatibility until a
+    dedicated deployment migration changes stack publication.
 services:
+  portainer:
+    enabled: true
+    stack: portainer
+    phase: platform
+    required_services:
+      - portainer
+      - agent
+    port_ids:
+      - portainer-http
+    readiness_target: deployment:portainer-service-readiness
+    compatibility_published_ports:
+      - 9000
+
+  nexus:
+    enabled: true
+    stack: nexus
+    phase: artifacts
+    required_services:
+      - nexus
+    port_ids:
+      - nexus-http
+      - nexus-docker-http
+      - nexus-docker-https
+    readiness_target: deployment:nexus-service-readiness
+    compatibility_published_ports:
+      - 8081
+      - 5000
+      - 5001
+
+  jenkins:
+    enabled: true
+    stack: jenkins
+    phase: cicd
+    required_services:
+      - jenkins
+    port_ids:
+      - jenkins-http
+      - jenkins-agent
+    readiness_target: deployment:jenkins-service-readiness
+    compatibility_published_ports:
+      - 8080
+      - 50000
+
+  pulsar:
+    enabled: true
+    stack: pulsar
+    phase: messaging
+    required_services:
+      - pulsar
+      - pulsar-manager
+    port_ids:
+      - pulsar-broker
+      - pulsar-admin-api
+    readiness_target: deployment:pulsar-service-readiness
+    compatibility_published_ports:
+      - 6650
+      - 8087
+      - 9527
+      - 7750
+
+  sonarqube:
+    enabled: true
+    stack: sonarqube
+    phase: quality
+    required_services:
+      - sonarqube
+      - sonar_db
+    port_ids:
+      - sonarqube-http
+    readiness_target: deployment:sonarqube-service-readiness
+    compatibility_published_ports:
+      - 9001
+
+  swagger:
+    enabled: true
+    stack: swagger
+    phase: docs
+    required_services:
+      - swagger-editor
+      - swagger-ui
+      - swagger-api
+      - swagger-nginx
+    port_ids:
+      - swagger-ui
+      - openapi-aggregator
+    readiness_target: deployment:swagger-service-readiness
+    compatibility_published_ports:
+      - 8082
+      - 8083
+      - 8084
+
   infisical:
     enabled: true
+    stack: infisical
+    phase: secrets
     mode: self_hosted
+    required_services:
+      - infisical
+      - infisical-db
+      - infisical-redis
+    port_ids:
+      - infisical-http
+    readiness_target: deployment:infisical-service-readiness
+    compatibility_published_ports:
+      - 8086
     bootstrap:
       enabled: true
       organization: "Tiny Swarm World"
@@ -12,3 +122,33 @@ services:
     endpoint:
       internal_url: "http://infisical:8080"
       external_url: "http://localhost:8086"
+
+  service-access:
+    enabled: true
+    stack: service-access
+    phase: control
+    required_services:
+      - service-access-dashboard
+      - service-access-nginx
+    port_ids:
+      - service-access-http
+    readiness_target: deployment:service-access-service-readiness
+    ingress_published_ports:
+      - 80
+      - 443
+    compatibility_published_ports:
+      - 8086
+
+  traefik:
+    enabled: true
+    stack: traefik
+    phase: network-routing
+    required_services:
+      - traefik
+    port_ids:
+      - traefik-http
+      - traefik-https
+    readiness_target: deployment:traefik-service-readiness
+    ingress_published_ports:
+      - 80
+      - 443

--- a/infra/config/validation-plan.yaml
+++ b/infra/config/validation-plan.yaml
@@ -1,0 +1,18 @@
+schema_version: "1"
+metadata:
+  workflow_id: workflow-install-order-and-port-allocation-20260620
+  policy: "Validation evaluates observed evidence only; missing evidence is failed-to-verify."
+plans:
+  greenpath:
+    required_targets:
+      - deployment:portainer-service-readiness
+      - deployment:nexus-service-readiness
+      - deployment:jenkins-service-readiness
+      - deployment:pulsar-service-readiness
+      - deployment:sonarqube-service-readiness
+      - deployment:swagger-service-readiness
+      - deployment:infisical-service-readiness
+      - deployment:service-access-service-readiness
+      - deployment:traefik-service-readiness
+    optional_targets: []
+    live_default: false

--- a/src/tiny_swarm_world/application/ports/repositories/port_port_registry_repository.py
+++ b/src/tiny_swarm_world/application/ports/repositories/port_port_registry_repository.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tiny_swarm_world.domain.network import PortRegistry
+
+
+class PortPortRegistryRepository(ABC):
+    @abstractmethod
+    def load(self) -> PortRegistry:
+        """Load the desired port registry from committed product configuration."""
+        pass

--- a/src/tiny_swarm_world/application/services/deployment/__init__.py
+++ b/src/tiny_swarm_world/application/services/deployment/__init__.py
@@ -62,6 +62,7 @@ from tiny_swarm_world.application.services.deployment.workflows import (
     DeploymentWorkflowKind,
     DeploymentWorkflowResult,
     DeploymentWorkflowStatus,
+    ValidationPlan,
 )
 
 __all__ = [
@@ -96,6 +97,7 @@ __all__ = [
     "SecretRedactor",
     "VerifyExternalSwarmInput",
     "VerifySwarmServiceReadiness",
+    "ValidationPlan",
     "build_default_service_stack_steps",
     "redact_mapping",
 ]

--- a/src/tiny_swarm_world/application/services/deployment/verify_swarm_service_readiness.py
+++ b/src/tiny_swarm_world/application/services/deployment/verify_swarm_service_readiness.py
@@ -149,6 +149,7 @@ def _readiness_evidence(
     )
     return {
         "attempt": str(attempt),
+        "evidence_kind": "swarm_service_replicas",
         "missing_services": ",".join(missing),
         "phase": "verify",
         "replicas": ",".join(f"{name}={replicas}" for name, replicas in sorted(replica_summary.items())),

--- a/src/tiny_swarm_world/application/services/deployment/workflows.py
+++ b/src/tiny_swarm_world/application/services/deployment/workflows.py
@@ -277,6 +277,115 @@ class DeploymentVerifyWorkflow:
         )
 
 
+@dataclass(frozen=True)
+class ValidationPlan:
+    name: str
+    required_targets: tuple[str, ...]
+    optional_targets: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("validation plan name must not be empty")
+        required_targets = _normalized_target_ids(self.required_targets, "required_targets")
+        optional_targets = _normalized_target_ids(self.optional_targets, "optional_targets")
+        overlap = sorted(set(required_targets) & set(optional_targets))
+        if overlap:
+            raise ValueError("validation plan targets must not be both required and optional")
+        object.__setattr__(self, "name", self.name.strip())
+        object.__setattr__(self, "required_targets", required_targets)
+        object.__setattr__(self, "optional_targets", optional_targets)
+
+    def evaluate(
+        self,
+        evidence: Sequence[VerificationResult],
+    ) -> DeploymentWorkflowResult:
+        evidence_by_target = {item.target_id: item for item in evidence}
+        results: list[VerificationResult] = []
+        for target_id in self.required_targets:
+            verification = evidence_by_target.get(target_id)
+            if verification is None:
+                results.append(
+                    VerificationResult(
+                        target_id=target_id,
+                        status=VerificationStatus.FAILED_TO_VERIFY,
+                        message="Required validation evidence is missing.",
+                        evidence={
+                            "phase": "validation",
+                            "reason": "required_evidence_missing",
+                            "validation_plan": self.name,
+                        },
+                    )
+                )
+                continue
+            if verification.status == VerificationStatus.VERIFIED and not _has_observed_evidence(
+                verification
+            ):
+                results.append(
+                    VerificationResult(
+                        target_id=target_id,
+                        status=VerificationStatus.FAILED_TO_VERIFY,
+                        message="Required validation evidence is not observed runtime evidence.",
+                        evidence={
+                            "phase": "validation",
+                            "reason": "observed_evidence_missing",
+                            "validation_plan": self.name,
+                        },
+                    )
+                )
+                continue
+            results.append(verification)
+
+        for target_id in self.optional_targets:
+            verification = evidence_by_target.get(target_id)
+            if verification is not None:
+                results.append(verification)
+
+        if any(result.status == VerificationStatus.BLOCKED for result in results):
+            status = DeploymentWorkflowStatus.BLOCKED
+            message = "deployment validation is blocked by observed evidence."
+            reason = "validation evidence contains blocked target"
+        elif any(result.status != VerificationStatus.VERIFIED for result in results):
+            status = DeploymentWorkflowStatus.FAILED_TO_VERIFY
+            message = "deployment validation failed for observed evidence."
+            reason = "validation evidence missing or failed"
+        else:
+            status = DeploymentWorkflowStatus.COMPLETED
+            message = "deployment validation completed for observed evidence."
+            reason = "required validation evidence verified"
+
+        return DeploymentWorkflowResult(
+            kind=DeploymentWorkflowKind.VERIFY,
+            status=status,
+            message=message,
+            reason=reason,
+            verification_results=tuple(results),
+        )
+
+
+def _normalized_target_ids(values: tuple[str, ...], field_name: str) -> tuple[str, ...]:
+    normalized = tuple(value.strip() for value in values)
+    if any(not value for value in normalized):
+        raise ValueError(f"validation plan {field_name} entries must not be empty")
+    duplicates = sorted(
+        target_id
+        for target_id in set(normalized)
+        if normalized.count(target_id) > 1
+    )
+    if duplicates:
+        raise ValueError(f"validation plan {field_name} contains duplicate targets")
+    return normalized
+
+
+def _has_observed_evidence(verification: VerificationResult) -> bool:
+    if verification.evidence.get("readiness_observed") == "false":
+        return False
+    return (
+        "replicas" in verification.evidence
+        and "required_services" in verification.evidence
+        and "stack_name" in verification.evidence
+    )
+
+
 def _step_has_verification(step: DeploymentApplyStep | DeploymentVerifyCheck) -> bool:
     return callable(getattr(step, "verify", None))
 

--- a/src/tiny_swarm_world/application/services/platform/preflight_service.py
+++ b/src/tiny_swarm_world/application/services/platform/preflight_service.py
@@ -7,6 +7,7 @@ from tiny_swarm_world.application.ports.configuration import ConfigurationSource
 from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
 from tiny_swarm_world.application.services.configuration import ConfigurationValidationService
 from tiny_swarm_world.domain.configuration import ConfigurationFinding
+from tiny_swarm_world.domain.network import PortRegistry
 from tiny_swarm_world.domain.preflight import (
     HostEnvironmentReport,
     LiveConsent,
@@ -16,6 +17,7 @@ from tiny_swarm_world.domain.preflight import (
     PreflightResult,
     PreflightSeverity,
     PreflightStatus,
+    RequiredPort,
     default_preflight_configuration,
 )
 
@@ -26,10 +28,12 @@ class PreflightService:
         host_probe: PortHostPreflightProbe,
         configuration: PreflightConfiguration | None = None,
         configuration_validation: ConfigurationValidationService | None = None,
+        port_registry: PortRegistry | None = None,
     ):
         self.host_probe = host_probe
         self.configuration = configuration or default_preflight_configuration()
         self.configuration_validation = configuration_validation
+        self.port_registry = port_registry
 
     async def run(self, live_consent: LiveConsent | None = None) -> PreflightResult:
         await asyncio.sleep(0)
@@ -280,7 +284,7 @@ class PreflightService:
 
     def _port_checks(self) -> tuple[PreflightCheck, ...]:
         checks: list[PreflightCheck] = []
-        for required_port in self.configuration.required_ports:
+        for required_port in self._required_ports():
             check_id = f"PORT-{required_port.port}"
             if self.host_probe.port_available(required_port.port):
                 checks.append(
@@ -354,6 +358,15 @@ class PreflightService:
                 )
             )
         return tuple(checks)
+
+    def _required_ports(self) -> tuple[RequiredPort, ...]:
+        if self.port_registry is None:
+            return self.configuration.required_ports
+        return tuple(
+            RequiredPort(mapping.external_port, mapping.port_id)
+            for mapping in self.port_registry.preflight_ports
+            if mapping.external_port is not None
+        )
 
     def _secret_checks(self) -> tuple[PreflightCheck, ...]:
         checks: list[PreflightCheck] = []

--- a/src/tiny_swarm_world/application/services/setup/workflow.py
+++ b/src/tiny_swarm_world/application/services/setup/workflow.py
@@ -19,7 +19,7 @@ from tiny_swarm_world.application.services.artifacts import ArtifactWorkflowResu
 from tiny_swarm_world.application.services.deployment import DeploymentWorkflowResult
 from tiny_swarm_world.application.services.platform.workflow_taxonomy import PlatformWorkflowResult
 from tiny_swarm_world.application.services.shared import MethodTraceWrapper
-from tiny_swarm_world.domain.preflight import LiveConsent, PreflightResult
+from tiny_swarm_world.domain.preflight import InstallationPlan, LiveConsent, PreflightResult
 
 
 class SetupWorkflowKind(str, Enum):
@@ -116,12 +116,14 @@ class SetupWorkflow:
         progress: PortWorkflowProgress | None = None,
         method_trace: PortMethodTrace | None = None,
         trace_correlation_id: str | None = None,
+        installation_plan: InstallationPlan | None = None,
     ):
         self.phases = tuple(phases)
         self.live_consent = live_consent
         self.progress = progress or NullWorkflowProgress()
         self.method_trace = method_trace or NullMethodTrace()
         self.trace_correlation_id = trace_correlation_id
+        self.installation_plan = installation_plan
 
     async def run(self) -> SetupWorkflowResult:
         return await MethodTraceWrapper(
@@ -154,7 +156,27 @@ class SetupWorkflow:
                 reason="live consent is required before setup orchestration can run",
             )
 
-        if not self.phases:
+        try:
+            phases = self._ordered_phases()
+        except ValueError as exc:
+            self._report_progress(
+                phase="setup",
+                target="setup",
+                task=RUN_SETUP_WORKFLOW_TASK,
+                step="phase configuration",
+                status=SetupWorkflowStatus.BLOCKED.value,
+                result=SetupWorkflowStatus.BLOCKED.value,
+                safe_message="Setup run is blocked by the installation phase plan.",
+                recovery_hint="Repair the installation phase plan before retrying.",
+            )
+            return SetupWorkflowResult(
+                kind=SetupWorkflowKind.RUN,
+                status=SetupWorkflowStatus.BLOCKED,
+                message="setup run is blocked by the installation phase plan.",
+                reason=str(exc),
+            )
+
+        if not phases:
             self._report_progress(
                 phase="setup",
                 target="setup",
@@ -173,7 +195,7 @@ class SetupWorkflow:
             )
 
         phase_results: list[SetupPhaseResult] = []
-        for phase in self.phases:
+        for phase in phases:
             _print_phase_progress(phase.name, "START")
             self._report_phase_progress(
                 phase_name=phase.name,
@@ -195,7 +217,7 @@ class SetupWorkflow:
                 )
                 phase_results.append(failed_phase)
                 not_run_phase_results = _not_run_phase_results(
-                    self.phases[len(phase_results) :]
+                    phases[len(phase_results) :]
                 )
                 self._report_phase_progress(
                     phase_name=phase.name,
@@ -232,7 +254,7 @@ class SetupWorkflow:
                 )
                 phase_results.append(failed_phase)
                 not_run_phase_results = _not_run_phase_results(
-                    self.phases[len(phase_results) :]
+                    phases[len(phase_results) :]
                 )
                 self._report_phase_progress(
                     phase_name=phase.name,
@@ -274,7 +296,7 @@ class SetupWorkflow:
 
             setup_status = _setup_status_for_phase_status(phase_status)
             not_run_phase_results = _not_run_phase_results(
-                self.phases[len(phase_results) :]
+                phases[len(phase_results) :]
             )
             self._report_not_run_phase_progress(not_run_phase_results)
             self._report_stopped_progress(setup_status.value)
@@ -307,6 +329,11 @@ class SetupWorkflow:
             executed=True,
             phase_results=tuple(phase_results),
         )
+
+    def _ordered_phases(self) -> tuple[SetupWorkflowPhase, ...]:
+        if self.installation_plan is None:
+            return self.phases
+        return self.installation_plan.arrange_workflow_phases(self.phases)
 
     def _report_phase_progress(
         self,

--- a/src/tiny_swarm_world/domain/deployment/service_stack_contract.py
+++ b/src/tiny_swarm_world/domain/deployment/service_stack_contract.py
@@ -52,11 +52,15 @@ class ServiceEndpoint:
 class ServiceStackContract:
     stack_name: str
     required_services: tuple[str, ...]
+    phase_id: str | None = None
+    port_ids: tuple[str, ...] = ()
     endpoints: tuple[ServiceEndpoint, ...] = ()
 
     def __post_init__(self) -> None:
         if not STACK_NAME_PATTERN.fullmatch(self.stack_name):
             raise ValueError("service stack name contains invalid characters")
+        if self.phase_id is not None and not STACK_NAME_PATTERN.fullmatch(self.phase_id):
+            raise ValueError("service stack phase id contains invalid characters")
         if not self.required_services:
             raise ValueError("service stack contract requires at least one service")
         invalid_services = [
@@ -66,7 +70,15 @@ class ServiceStackContract:
         ]
         if invalid_services:
             raise ValueError("service stack contract contains invalid service names")
+        invalid_port_ids = [
+            port_id
+            for port_id in self.port_ids
+            if not SERVICE_NAME_PATTERN.fullmatch(port_id)
+        ]
+        if invalid_port_ids:
+            raise ValueError("service stack contract contains invalid port ids")
         object.__setattr__(self, "required_services", tuple(self.required_services))
+        object.__setattr__(self, "port_ids", tuple(self.port_ids))
         object.__setattr__(self, "endpoints", tuple(self.endpoints))
 
     @property
@@ -84,6 +96,8 @@ class ServiceStackContract:
     def to_dict(self) -> dict[str, object]:
         return {
             "endpoints": [endpoint.to_dict() for endpoint in self.endpoints],
+            "phase_id": self.phase_id,
+            "port_ids": list(self.port_ids),
             "required_services": list(self.required_services),
             "service_readiness_target_id": self.service_readiness_target_id,
             "stack_target_id": self.stack_target_id,
@@ -95,11 +109,15 @@ DEFAULT_SERVICE_STACK_CONTRACTS = (
     ServiceStackContract(
         "portainer",
         ("portainer", "agent"),
+        phase_id="platform",
+        port_ids=("portainer-http",),
         endpoints=(ServiceEndpoint("portainer", "http://localhost:9000"),),
     ),
     ServiceStackContract(
         "nexus",
         ("nexus",),
+        phase_id="artifacts",
+        port_ids=("nexus-http", "nexus-docker-http", "nexus-docker-https"),
         endpoints=(
             ServiceEndpoint("nexus", "http://localhost:8081"),
             ServiceEndpoint("nexus-docker-registry", "http://localhost:5000"),
@@ -108,11 +126,15 @@ DEFAULT_SERVICE_STACK_CONTRACTS = (
     ServiceStackContract(
         "jenkins",
         ("jenkins",),
+        phase_id="cicd",
+        port_ids=("jenkins-http", "jenkins-agent"),
         endpoints=(ServiceEndpoint("jenkins", "http://localhost:8080"),),
     ),
     ServiceStackContract(
         "pulsar",
         ("pulsar", "pulsar-manager"),
+        phase_id="messaging",
+        port_ids=("pulsar-broker", "pulsar-admin-api"),
         endpoints=(
             ServiceEndpoint("pulsar-admin-api", "http://localhost:8087"),
             ServiceEndpoint("pulsar-manager", "http://localhost:9527"),
@@ -122,11 +144,15 @@ DEFAULT_SERVICE_STACK_CONTRACTS = (
     ServiceStackContract(
         "sonarqube",
         ("sonarqube", "sonar_db"),
+        phase_id="quality",
+        port_ids=("sonarqube-http",),
         endpoints=(ServiceEndpoint("sonarqube", "http://localhost:9001"),),
     ),
     ServiceStackContract(
         "swagger",
         ("swagger-editor", "swagger-ui", "swagger-api", "swagger-nginx"),
+        phase_id="docs",
+        port_ids=("swagger-ui", "openapi-aggregator"),
         endpoints=(ServiceEndpoint("swagger", "http://localhost:8084"),),
     ),
 )
@@ -134,6 +160,8 @@ DEFAULT_SERVICE_STACK_CONTRACTS = (
 SERVICE_ACCESS_STACK_CONTRACT = ServiceStackContract(
     "service-access",
     ("service-access-dashboard", "service-access-nginx"),
+    phase_id="control",
+    port_ids=("service-access-http",),
     endpoints=(
         ServiceEndpoint("service-access", "http://localhost"),
     ),
@@ -142,6 +170,8 @@ SERVICE_ACCESS_STACK_CONTRACT = ServiceStackContract(
 INFISICAL_STACK_CONTRACT = ServiceStackContract(
     "infisical",
     ("infisical", "infisical-db", "infisical-redis"),
+    phase_id="secrets",
+    port_ids=("infisical-http",),
     endpoints=(ServiceEndpoint("infisical", "http://localhost:8086"),),
 )
 

--- a/src/tiny_swarm_world/domain/network/__init__.py
+++ b/src/tiny_swarm_world/domain/network/__init__.py
@@ -7,15 +7,23 @@ from tiny_swarm_world.domain.network.lxc_proxy_device_plan import LxcProxyDevice
 from tiny_swarm_world.domain.network.network import Network
 from tiny_swarm_world.domain.network.port_forwarding_plan import (
     ForwardingStrategy,
+    PortExposureClass,
     PortForwardingPlan,
+    PortRange,
+    PortRegistry,
+    ServicePortMapping,
 )
 
 __all__ = [
     "ForwardingStrategy",
+    "PortExposureClass",
     "ContainerNetworkPlan",
     "ContainerNetworkPurpose",
     "IpValue",
     "LxcProxyDevicePlan",
     "Network",
     "PortForwardingPlan",
+    "PortRange",
+    "PortRegistry",
+    "ServicePortMapping",
 ]

--- a/src/tiny_swarm_world/domain/network/port_forwarding_plan.py
+++ b/src/tiny_swarm_world/domain/network/port_forwarding_plan.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import ipaddress
+import re
 from dataclasses import dataclass
 from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
+from urllib.parse import urlparse
 
 
 class ForwardingStrategy(str, Enum):
@@ -10,6 +15,157 @@ class ForwardingStrategy(str, Enum):
     WSL2_NETSH_DOCUMENTED = "wsl2_netsh_documented"
     WSL2_IPTABLES_OPTIONAL = "wsl2_iptables_optional"
     UNSUPPORTED = "unsupported"
+
+
+SERVICE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+RANGE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+
+
+class PortExposureClass(str, Enum):
+    PUBLIC_INGRESS = "public_ingress"
+    DIRECT = "direct"
+    DIAGNOSTIC = "diagnostic"
+    COMPATIBILITY = "compatibility"
+    INTERNAL = "internal"
+
+
+@dataclass(frozen=True)
+class PortRange:
+    range_id: str
+    start: int
+    end: int
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.range_id, "range_id", RANGE_IDENTIFIER_PATTERN)
+        _validate_port(self.start, "start")
+        _validate_port(self.end, "end")
+        if self.start > self.end:
+            raise ValueError("port range start must be less than or equal to end")
+        object.__setattr__(self, "description", self.description.strip())
+
+    def contains(self, port: int) -> bool:
+        _validate_port(port, "port")
+        return self.start <= port <= self.end
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.range_id,
+            "start": self.start,
+            "end": self.end,
+            "description": self.description,
+        }
+
+
+@dataclass(frozen=True)
+class ServicePortMapping:
+    service_id: str
+    port_id: str
+    internal_port: int
+    external_port: int | None
+    exposure: PortExposureClass
+    range_id: str | None = None
+    protocol: str = "tcp"
+    route_host: str | None = None
+    required_for_preflight: bool = True
+    metadata: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        _validate_identifier(self.service_id, "service_id", SERVICE_IDENTIFIER_PATTERN)
+        _validate_identifier(self.port_id, "port_id", SERVICE_IDENTIFIER_PATTERN)
+        _validate_port(self.internal_port, "internal_port")
+        if self.external_port is not None:
+            _validate_port(self.external_port, "external_port")
+        if self.range_id is not None:
+            _validate_identifier(self.range_id, "range_id", RANGE_IDENTIFIER_PATTERN)
+        exposure = PortExposureClass(self.exposure)
+        _validate_public_ingress_ownership(
+            self.service_id,
+            self.external_port,
+            exposure,
+        )
+        normalized_protocol = self.protocol.strip().lower()
+        if normalized_protocol not in {"tcp", "udp"}:
+            raise ValueError("protocol must be tcp or udp")
+        route_host = _validate_route_host(self.route_host)
+        object.__setattr__(self, "protocol", normalized_protocol)
+        object.__setattr__(self, "route_host", route_host)
+        object.__setattr__(self, "exposure", exposure)
+        object.__setattr__(
+            self,
+            "metadata",
+            MappingProxyType(_safe_metadata(self.metadata or {})),
+        )
+
+    @property
+    def externally_visible(self) -> bool:
+        return self.external_port is not None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "service_id": self.service_id,
+            "port_id": self.port_id,
+            "internal_port": self.internal_port,
+            "external_port": self.external_port,
+            "exposure": self.exposure.value,
+            "range_id": self.range_id,
+            "protocol": self.protocol,
+            "route_host": self.route_host,
+            "required_for_preflight": self.required_for_preflight,
+            "metadata": dict(self.metadata or {}),
+        }
+
+
+@dataclass(frozen=True)
+class PortRegistry:
+    ranges: tuple[PortRange, ...]
+    mappings: tuple[ServicePortMapping, ...]
+    metadata: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        ranges = tuple(self.ranges)
+        mappings = tuple(self.mappings)
+        _reject_duplicate_range_ids(ranges)
+        _reject_overlapping_ranges(ranges)
+        _validate_mapping_ranges(ranges, mappings)
+        _reject_duplicate_external_ports(mappings)
+        object.__setattr__(self, "ranges", ranges)
+        object.__setattr__(self, "mappings", mappings)
+        object.__setattr__(
+            self,
+            "metadata",
+            MappingProxyType(_safe_metadata(self.metadata or {})),
+        )
+
+    @property
+    def external_ports(self) -> tuple[int, ...]:
+        return tuple(
+            mapping.external_port
+            for mapping in self.mappings
+            if mapping.external_port is not None
+        )
+
+    @property
+    def preflight_ports(self) -> tuple[ServicePortMapping, ...]:
+        return tuple(
+            mapping
+            for mapping in self.mappings
+            if mapping.external_port is not None and mapping.required_for_preflight
+        )
+
+    def mapping_for_port_id(self, port_id: str) -> ServicePortMapping:
+        _validate_identifier(port_id, "port_id", SERVICE_IDENTIFIER_PATTERN)
+        for mapping in self.mappings:
+            if mapping.port_id == port_id:
+                return mapping
+        raise KeyError(port_id)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "metadata": dict(self.metadata or {}),
+            "ranges": [port_range.to_dict() for port_range in self.ranges],
+            "ports": [mapping.to_dict() for mapping in self.mappings],
+        }
 
 
 @dataclass(frozen=True)
@@ -55,3 +211,129 @@ class PortForwardingPlan:
 def _validate_port(value: int, field_name: str) -> None:
     if not isinstance(value, int) or value < 1 or value > 65535:
         raise ValueError(f"{field_name} must be a TCP port between 1 and 65535")
+
+
+def _validate_identifier(value: str, field_name: str, pattern: re.Pattern[str]) -> None:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise ValueError(f"{field_name} contains invalid characters")
+
+
+def _validate_route_host(value: str | None) -> str | None:
+    if value is None:
+        return None
+    route_host = value.strip().lower()
+    if not route_host:
+        return None
+    if "://" in route_host or "@" in route_host or "/" in route_host:
+        raise ValueError("route_host must be a host name, not a URL")
+    try:
+        ipaddress.ip_address(route_host)
+    except ValueError:
+        return route_host
+    raise ValueError("route_host must not be a host-specific IP address")
+
+
+def _validate_public_ingress_ownership(
+    service_id: str,
+    external_port: int | None,
+    exposure: PortExposureClass,
+) -> None:
+    if exposure is not PortExposureClass.PUBLIC_INGRESS:
+        return
+    if service_id != "traefik" or external_port not in {80, 443}:
+        raise ValueError("public ingress ports must be Traefik-owned 80 or 443")
+
+
+def _safe_metadata(metadata: Mapping[str, str]) -> dict[str, str]:
+    safe_metadata: dict[str, str] = {}
+    for key, value in metadata.items():
+        normalized_key = str(key).strip().lower()
+        normalized_value = str(value).strip()
+        if not normalized_key:
+            raise ValueError("metadata keys cannot be empty")
+        if _is_sensitive_metadata_key(normalized_key):
+            raise ValueError("port registry metadata must not contain secrets")
+        if _is_host_specific_value(normalized_value):
+            raise ValueError("port registry metadata must not contain host-specific values")
+        if _is_credential_url(normalized_value):
+            raise ValueError("port registry metadata must not contain credential URLs")
+        safe_metadata[normalized_key] = normalized_value
+    return safe_metadata
+
+
+def _is_sensitive_metadata_key(key: str) -> bool:
+    return any(
+        forbidden in key
+        for forbidden in (
+            "address",
+            "host_ip",
+            "listen_address",
+            "password",
+            "secret",
+            "token",
+            "url",
+            "vm_ip",
+        )
+    )
+
+
+def _is_host_specific_value(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_credential_url(value: str) -> bool:
+    if "://" not in value:
+        return False
+    parsed = urlparse(value)
+    return bool(parsed.username or parsed.password)
+
+
+def _reject_duplicate_range_ids(ranges: tuple[PortRange, ...]) -> None:
+    seen: set[str] = set()
+    for port_range in ranges:
+        if port_range.range_id in seen:
+            raise ValueError("port registry contains duplicate range IDs")
+        seen.add(port_range.range_id)
+
+
+def _reject_overlapping_ranges(ranges: tuple[PortRange, ...]) -> None:
+    ordered_ranges = sorted(ranges, key=lambda port_range: port_range.start)
+    previous: PortRange | None = None
+    for port_range in ordered_ranges:
+        if previous is not None and port_range.start <= previous.end:
+            raise ValueError("port registry ranges must not overlap")
+        previous = port_range
+
+
+def _validate_mapping_ranges(
+    ranges: tuple[PortRange, ...],
+    mappings: tuple[ServicePortMapping, ...],
+) -> None:
+    ranges_by_id = {port_range.range_id: port_range for port_range in ranges}
+    for mapping in mappings:
+        if mapping.range_id is None:
+            continue
+        port_range = ranges_by_id.get(mapping.range_id)
+        if port_range is None:
+            raise ValueError("service port mapping references an unknown range")
+        if mapping.external_port is None:
+            raise ValueError("range_id requires an external_port")
+        if not port_range.contains(mapping.external_port):
+            raise ValueError("external_port must belong to the declared range")
+
+
+def _reject_duplicate_external_ports(
+    mappings: tuple[ServicePortMapping, ...],
+) -> None:
+    seen: dict[tuple[int, str], ServicePortMapping] = {}
+    for mapping in mappings:
+        if mapping.external_port is None:
+            continue
+        key = (mapping.external_port, mapping.protocol)
+        if key in seen:
+            raise ValueError("port registry contains duplicate external ports")
+        seen[key] = mapping

--- a/src/tiny_swarm_world/domain/preflight/__init__.py
+++ b/src/tiny_swarm_world/domain/preflight/__init__.py
@@ -34,6 +34,11 @@ from tiny_swarm_world.domain.preflight.preflight_configuration import (
     default_preflight_configuration,
 )
 from tiny_swarm_world.domain.preflight.preflight_result import PreflightResult
+from tiny_swarm_world.domain.preflight.installation_plan import (
+    InstallationPhase,
+    InstallationPlan,
+    default_installation_plan,
+)
 from tiny_swarm_world.domain.preflight.setup_manifest import (
     SetupManifest,
     SetupPortRequirement,
@@ -54,6 +59,8 @@ __all__ = [
     "HostEnvironmentReport",
     "HostRuntimeReadiness",
     "HostRuntimeReadinessStatus",
+    "InstallationPhase",
+    "InstallationPlan",
     "LiveConsent",
     "PreflightCategory",
     "PreflightCheck",
@@ -75,5 +82,6 @@ __all__ = [
     "SetupSecretRequirement",
     "SetupServiceRequirement",
     "default_preflight_configuration",
+    "default_installation_plan",
     "default_setup_manifest",
 ]

--- a/src/tiny_swarm_world/domain/preflight/installation_plan.py
+++ b/src/tiny_swarm_world/domain/preflight/installation_plan.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping, TypeVar
+
+
+PHASE_IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9.-]*$")
+WorkflowPhase = TypeVar("WorkflowPhase")
+
+
+@dataclass(frozen=True)
+class InstallationPhase:
+    phase_id: str
+    order: int
+    required: bool = True
+    depends_on: tuple[str, ...] = ()
+    services: tuple[str, ...] = ()
+    workflow_phase_names: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_phase_identifier(self.phase_id, "phase_id")
+        if not isinstance(self.order, int) or self.order < 0:
+            raise ValueError("installation phase order must be a non-negative integer")
+        depends_on = tuple(_normalized_identifier(item, "depends_on") for item in self.depends_on)
+        if self.phase_id in depends_on:
+            raise ValueError("installation phase cannot depend on itself")
+        object.__setattr__(self, "depends_on", depends_on)
+        object.__setattr__(self, "services", _normalized_non_empty_tuple(self.services, "services"))
+        object.__setattr__(
+            self,
+            "workflow_phase_names",
+            _normalized_non_empty_tuple(self.workflow_phase_names, "workflow_phase_names"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.phase_id,
+            "order": self.order,
+            "required": self.required,
+            "depends_on": list(self.depends_on),
+            "services": list(self.services),
+            "workflow_phases": list(self.workflow_phase_names),
+        }
+
+
+@dataclass(frozen=True)
+class InstallationPlan:
+    phases: tuple[InstallationPhase, ...]
+    required_phase_ids: tuple[str, ...] = ()
+    required_services: tuple[str, ...] = ()
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        phases = tuple(self.phases)
+        required_phase_ids = tuple(
+            _normalized_identifier(item, "required_phase_ids")
+            for item in self.required_phase_ids
+        )
+        required_services = _normalized_non_empty_tuple(
+            self.required_services,
+            "required_services",
+        )
+        _reject_duplicate_phase_ids(phases)
+        _reject_missing_dependencies(phases)
+        _reject_missing_required_phases(phases, required_phase_ids)
+        _ordered_installation_phases(phases)
+        _reject_missing_required_services(phases, required_services)
+        object.__setattr__(self, "phases", phases)
+        object.__setattr__(self, "required_phase_ids", required_phase_ids)
+        object.__setattr__(self, "required_services", required_services)
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    @property
+    def phase_ids(self) -> tuple[str, ...]:
+        return tuple(phase.phase_id for phase in self.phases)
+
+    @property
+    def required_workflow_phase_names(self) -> tuple[str, ...]:
+        return tuple(
+            workflow_phase
+            for phase in self.ordered_phases()
+            if phase.required
+            for workflow_phase in phase.workflow_phase_names
+        )
+
+    def ordered_phases(self) -> tuple[InstallationPhase, ...]:
+        return _ordered_installation_phases(self.phases)
+
+    def ordered_workflow_phase_names(self) -> tuple[str, ...]:
+        return tuple(
+            workflow_phase
+            for phase in self.ordered_phases()
+            for workflow_phase in phase.workflow_phase_names
+        )
+
+    def arrange_workflow_phases(
+        self,
+        phases: tuple[WorkflowPhase, ...],
+    ) -> tuple[WorkflowPhase, ...]:
+        by_name: dict[str, WorkflowPhase] = {}
+        for phase in phases:
+            name = str(getattr(phase, "name", "")).strip()
+            if not name:
+                raise ValueError("setup workflow phase must have a non-empty name")
+            if name in by_name:
+                raise ValueError(f"duplicate setup workflow phase '{name}'")
+            by_name[name] = phase
+
+        declared_names = self.ordered_workflow_phase_names()
+        declared_name_set = set(declared_names)
+        missing_required = tuple(
+            name for name in self.required_workflow_phase_names if name not in by_name
+        )
+        if missing_required:
+            raise ValueError(
+                "required setup workflow phases are missing: "
+                + ", ".join(missing_required)
+            )
+
+        unknown = tuple(name for name in by_name if name not in declared_name_set)
+        if unknown:
+            raise ValueError(
+                "setup workflow phases are not declared in installation plan: "
+                + ", ".join(unknown)
+            )
+
+        return tuple(by_name[name] for name in declared_names if name in by_name)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "metadata": dict(self.metadata),
+            "required_phase_ids": list(self.required_phase_ids),
+            "required_services": list(self.required_services),
+            "phases": [phase.to_dict() for phase in self.phases],
+        }
+
+
+def default_installation_plan() -> InstallationPlan:
+    return InstallationPlan(
+        phases=(
+            InstallationPhase(
+                phase_id="preflight",
+                order=0,
+                workflow_phase_names=("preflight",),
+            ),
+            InstallationPhase(
+                phase_id="platform",
+                order=10,
+                depends_on=("preflight",),
+                workflow_phase_names=("platform init", "platform reconcile"),
+            ),
+            InstallationPhase(
+                phase_id="cluster",
+                order=20,
+                depends_on=("platform",),
+                services=("docker", "swarm"),
+            ),
+            InstallationPhase(
+                phase_id="network-routing",
+                order=30,
+                depends_on=("cluster",),
+                services=("traefik",),
+                workflow_phase_names=("platform expose",),
+            ),
+            InstallationPhase(
+                phase_id="secrets",
+                order=40,
+                depends_on=("network-routing",),
+                services=("infisical",),
+                workflow_phase_names=("deployment bootstrap",),
+            ),
+            InstallationPhase(
+                phase_id="artifacts",
+                order=50,
+                depends_on=("secrets",),
+                services=("nexus",),
+                workflow_phase_names=("artifacts prepare", "artifacts verify"),
+            ),
+            InstallationPhase(
+                phase_id="cicd",
+                order=60,
+                depends_on=("artifacts", "secrets"),
+                services=("jenkins",),
+            ),
+            InstallationPhase(
+                phase_id="quality",
+                order=70,
+                depends_on=("artifacts", "secrets"),
+                services=("sonarqube",),
+            ),
+            InstallationPhase(
+                phase_id="messaging",
+                order=80,
+                depends_on=("secrets",),
+                services=("pulsar",),
+            ),
+            InstallationPhase(
+                phase_id="observability",
+                order=90,
+                required=False,
+                depends_on=("network-routing",),
+                services=("prometheus", "grafana", "loki", "alertmanager"),
+            ),
+            InstallationPhase(
+                phase_id="control",
+                order=100,
+                depends_on=("cicd", "quality", "messaging"),
+                services=("service-access",),
+            ),
+            InstallationPhase(
+                phase_id="docs",
+                order=110,
+                depends_on=("control",),
+                services=("swagger", "openapi-aggregator"),
+            ),
+            InstallationPhase(
+                phase_id="validation",
+                order=120,
+                depends_on=("docs",),
+                workflow_phase_names=(
+                    "deployment apply",
+                    "deployment verify",
+                    "platform verify",
+                ),
+            ),
+        ),
+        required_phase_ids=(
+            "preflight",
+            "platform",
+            "cluster",
+            "network-routing",
+            "secrets",
+            "artifacts",
+            "cicd",
+            "quality",
+            "messaging",
+            "control",
+            "docs",
+            "validation",
+        ),
+        required_services=(
+            "docker",
+            "swarm",
+            "traefik",
+            "infisical",
+            "nexus",
+            "jenkins",
+            "sonarqube",
+            "pulsar",
+            "service-access",
+            "swagger",
+        ),
+        metadata={
+            "workflow_id": "workflow-install-order-and-port-allocation-20260620",
+            "public_ingress_owner": "traefik",
+        },
+    )
+
+
+def _ordered_installation_phases(
+    phases: tuple[InstallationPhase, ...],
+) -> tuple[InstallationPhase, ...]:
+    by_id = {phase.phase_id: phase for phase in phases}
+    pending = set(by_id)
+    ordered: list[InstallationPhase] = []
+    while pending:
+        ready = sorted(
+            (
+                by_id[phase_id]
+                for phase_id in pending
+                if all(dependency not in pending for dependency in by_id[phase_id].depends_on)
+            ),
+            key=lambda phase: (phase.order, phase.phase_id),
+        )
+        if not ready:
+            raise ValueError("installation phase dependency graph contains a cycle")
+        phase = ready[0]
+        ordered.append(phase)
+        pending.remove(phase.phase_id)
+    return tuple(ordered)
+
+
+def _reject_duplicate_phase_ids(phases: tuple[InstallationPhase, ...]) -> None:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for phase in phases:
+        if phase.phase_id in seen:
+            duplicates.append(phase.phase_id)
+        seen.add(phase.phase_id)
+    if duplicates:
+        raise ValueError("duplicate installation phase ids: " + ", ".join(sorted(duplicates)))
+
+
+def _reject_missing_dependencies(phases: tuple[InstallationPhase, ...]) -> None:
+    phase_ids = {phase.phase_id for phase in phases}
+    missing = sorted(
+        {
+            dependency
+            for phase in phases
+            for dependency in phase.depends_on
+            if dependency not in phase_ids
+        }
+    )
+    if missing:
+        raise ValueError("installation phase dependencies are missing: " + ", ".join(missing))
+
+
+def _reject_missing_required_phases(
+    phases: tuple[InstallationPhase, ...],
+    required_phase_ids: tuple[str, ...],
+) -> None:
+    phase_ids = {phase.phase_id for phase in phases}
+    missing = sorted(set(required_phase_ids) - phase_ids)
+    if missing:
+        raise ValueError("required installation phases are missing: " + ", ".join(missing))
+
+
+def _reject_missing_required_services(
+    phases: tuple[InstallationPhase, ...],
+    required_services: tuple[str, ...],
+) -> None:
+    declared_services = {service for phase in phases if phase.required for service in phase.services}
+    missing = sorted(set(required_services) - declared_services)
+    if missing:
+        raise ValueError("required installation services are missing: " + ", ".join(missing))
+
+
+def _validate_phase_identifier(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not PHASE_IDENTIFIER_PATTERN.fullmatch(value):
+        raise ValueError(f"{field_name} contains invalid characters")
+
+
+def _normalized_identifier(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    _validate_phase_identifier(normalized, field_name)
+    return normalized
+
+
+def _normalized_non_empty_tuple(values: tuple[str, ...], field_name: str) -> tuple[str, ...]:
+    normalized = tuple(value.strip() for value in values)
+    if any(not value for value in normalized):
+        raise ValueError(f"{field_name} entries must be non-empty")
+    return normalized

--- a/src/tiny_swarm_world/infrastructure/adapters/repositories/port_registry_yaml_repository.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/repositories/port_registry_yaml_repository.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from ruamel.yaml import YAML
+
+from tiny_swarm_world.application.ports.repositories.port_port_registry_repository import (
+    PortPortRegistryRepository,
+)
+from tiny_swarm_world.domain.network import (
+    PortExposureClass,
+    PortRange,
+    PortRegistry,
+    ServicePortMapping,
+)
+from tiny_swarm_world.infrastructure.project_paths import config_root
+
+
+DEFAULT_PORT_REGISTRY_PATH = Path("ports.yaml")
+
+
+class PortRegistryYamlRepository(PortPortRegistryRepository):
+    def __init__(self, path: Path | None = None):
+        self.path = path or (config_root() / DEFAULT_PORT_REGISTRY_PATH)
+        self.yaml = YAML(typ="safe")
+
+    def load(self) -> PortRegistry:
+        if not self.path.exists():
+            return PortRegistry(ranges=(), mappings=())
+
+        data = self.yaml.load(self.path.read_text(encoding="utf-8"))
+        if data is None:
+            return PortRegistry(ranges=(), mappings=())
+        if not isinstance(data, Mapping):
+            raise ValueError("port registry YAML root must be a mapping")
+
+        return PortRegistry(
+            ranges=_ranges_from(data.get("ranges", ())),
+            mappings=_mappings_from(data.get("ports", ())),
+            metadata=_metadata_from(data.get("metadata", {})),
+        )
+
+
+def _ranges_from(value: object) -> tuple[PortRange, ...]:
+    if not isinstance(value, list):
+        raise ValueError("port registry ranges must be a list")
+    return tuple(_range_from(item) for item in value)
+
+
+def _range_from(value: object) -> PortRange:
+    if not isinstance(value, Mapping):
+        raise ValueError("port registry range entries must be mappings")
+    return PortRange(
+        range_id=_string(value, "id"),
+        start=_integer(value, "start"),
+        end=_integer(value, "end"),
+        description=str(value.get("description", "")),
+    )
+
+
+def _mappings_from(value: object) -> tuple[ServicePortMapping, ...]:
+    if not isinstance(value, list):
+        raise ValueError("port registry ports must be a list")
+    return tuple(_mapping_from(item) for item in value)
+
+
+def _mapping_from(value: object) -> ServicePortMapping:
+    if not isinstance(value, Mapping):
+        raise ValueError("port registry port entries must be mappings")
+    return ServicePortMapping(
+        service_id=_string(value, "service_id"),
+        port_id=_string(value, "id"),
+        internal_port=_integer(value, "internal_port"),
+        external_port=_optional_integer(value, "external_port"),
+        exposure=PortExposureClass(_string(value, "exposure")),
+        range_id=_optional_string(value, "range_id"),
+        protocol=str(value.get("protocol", "tcp")),
+        route_host=_optional_string(value, "route_host"),
+        required_for_preflight=bool(value.get("required_for_preflight", True)),
+        metadata=_metadata_from(value.get("metadata", {})),
+    )
+
+
+def _metadata_from(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        raise ValueError("port registry metadata must be a mapping")
+    return {str(key): str(item) for key, item in value.items()}
+
+
+def _string(value: Mapping[Any, Any], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str):
+        raise ValueError(f"port registry field '{key}' must be a string")
+    return item
+
+
+def _optional_string(value: Mapping[Any, Any], key: str) -> str | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, str):
+        raise ValueError(f"port registry field '{key}' must be a string")
+    return item
+
+
+def _integer(value: Mapping[Any, Any], key: str) -> int:
+    item = value.get(key)
+    if not isinstance(item, int):
+        raise ValueError(f"port registry field '{key}' must be an integer")
+    return item
+
+
+def _optional_integer(value: Mapping[Any, Any], key: str) -> int | None:
+    item = value.get(key)
+    if item is None:
+        return None
+    if not isinstance(item, int):
+        raise ValueError(f"port registry field '{key}' must be an integer")
+    return item

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -118,6 +118,7 @@ from tiny_swarm_world.domain.preflight import (
     LiveConsent,
     PreflightConfiguration,
     ProviderPreflightMetadata,
+    default_installation_plan,
     default_setup_manifest,
     default_preflight_configuration,
     RequiredDependency,
@@ -1150,6 +1151,7 @@ def build_setup_services(
                 progress=workflow_progress,
                 method_trace=method_trace,
                 trace_correlation_id=trace_correlation_id,
+                installation_plan=default_installation_plan(),
             )
         )
     )

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -174,6 +174,9 @@ from tiny_swarm_world.infrastructure.adapters.repositories.node_provider_config_
     NodeProviderConfig,
     NodeProviderConfigYamlRepository,
 )
+from tiny_swarm_world.infrastructure.adapters.repositories.port_registry_yaml_repository import (
+    PortRegistryYamlRepository,
+)
 from tiny_swarm_world.infrastructure.os_types import OsTypes
 from tiny_swarm_world.infrastructure.adapters.repositories.verification_evidence_local_repository import (
     VerificationEvidenceLocalRepository,
@@ -443,10 +446,12 @@ def build_preflight_service(
     node_provider_request: NodeProviderSelectionRequest | None = None,
     configuration_validation: ConfigurationValidationService | None = None,
 ) -> PreflightService:
+    port_registry = PortRegistryYamlRepository().load()
     return PreflightService(
         HostPreflightProbe(),
         _preflight_configuration_for_provider(service_profile, node_provider_request),
         configuration_validation=configuration_validation,
+        port_registry=port_registry,
     )
 
 

--- a/tests/application/services/deployment/test_deployment_workflows.py
+++ b/tests/application/services/deployment/test_deployment_workflows.py
@@ -14,6 +14,7 @@ from tiny_swarm_world.application.services.deployment.workflows import (
     DeploymentVerifyWorkflow,
     DeploymentWorkflowKind,
     DeploymentWorkflowStatus,
+    ValidationPlan,
 )
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 
@@ -301,6 +302,91 @@ class TestDeploymentWorkflows(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(DeploymentWorkflowStatus.COMPLETED, result.status)
         self.assertEqual(VerificationStatus.VERIFIED, result.verification_results[0].status)
         self.assertEqual("active", result.verification_results[0].evidence["access_state"])
+
+    async def test_validation_plan_fails_closed_when_required_evidence_is_missing(self):
+        plan = ValidationPlan(
+            "greenpath",
+            required_targets=("deployment:nexus-service-readiness",),
+        )
+
+        result = plan.evaluate(())
+
+        self.assertEqual(DeploymentWorkflowStatus.FAILED_TO_VERIFY, result.status)
+        self.assertEqual(
+            "required_evidence_missing",
+            result.verification_results[0].evidence["reason"],
+        )
+
+    async def test_validation_plan_rejects_verified_static_evidence(self):
+        plan = ValidationPlan(
+            "greenpath",
+            required_targets=("deployment:nexus-service-readiness",),
+        )
+
+        result = plan.evaluate(
+            (
+                VerificationResult(
+                    target_id="deployment:nexus-service-readiness",
+                    status=VerificationStatus.VERIFIED,
+                    message="Stack registration verified.",
+                    evidence={
+                        "phase": "verify",
+                        "readiness_observed": "false",
+                        "registration_scope": "deployment_gateway_stack",
+                    },
+                ),
+            )
+        )
+
+        self.assertEqual(DeploymentWorkflowStatus.FAILED_TO_VERIFY, result.status)
+        self.assertEqual(
+            "observed_evidence_missing",
+            result.verification_results[0].evidence["reason"],
+        )
+
+    async def test_validation_plan_completes_with_observed_runtime_evidence(self):
+        plan = ValidationPlan(
+            "greenpath",
+            required_targets=("deployment:nexus-service-readiness",),
+        )
+
+        result = plan.evaluate(
+            (
+                VerificationResult(
+                    target_id="deployment:nexus-service-readiness",
+                    status=VerificationStatus.VERIFIED,
+                    message="Swarm services reached desired replica counts.",
+                    evidence={
+                        "phase": "verify",
+                        "evidence_kind": "swarm_service_replicas",
+                        "replicas": "nexus=1/1",
+                        "required_services": "nexus",
+                        "stack_name": "nexus",
+                    },
+                ),
+            )
+        )
+
+        self.assertEqual(DeploymentWorkflowStatus.COMPLETED, result.status)
+
+    async def test_validation_plan_blocks_when_required_evidence_blocks(self):
+        plan = ValidationPlan(
+            "greenpath",
+            required_targets=("deployment:nexus-service-readiness",),
+        )
+
+        result = plan.evaluate(
+            (
+                VerificationResult(
+                    target_id="deployment:nexus-service-readiness",
+                    status=VerificationStatus.BLOCKED,
+                    message="Readiness check blocked.",
+                    evidence={"phase": "verify"},
+                ),
+            )
+        )
+
+        self.assertEqual(DeploymentWorkflowStatus.BLOCKED, result.status)
 
     async def test_apply_workflow_stops_later_stacks_when_verification_blocks(self):
         first_step = _OrderedApplyStep("deployment:nexus-stack", VerificationStatus.VERIFIED)

--- a/tests/application/services/deployment/test_service_stack_plan.py
+++ b/tests/application/services/deployment/test_service_stack_plan.py
@@ -63,6 +63,26 @@ class TestServiceStackPlan(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("portainer", tuple(step.service_stack.stack_name for step in steps))
         self.assertTrue(all(step.compose_repository is compose_repository for step in steps))
         self.assertTrue(all(step.deployment_gateway is deployment_gateway for step in steps))
+        self.assertEqual(
+            {
+                "nexus": "artifacts",
+                "jenkins": "cicd",
+                "pulsar": "messaging",
+                "sonarqube": "quality",
+                "swagger": "docs",
+                "infisical": "secrets",
+                "service-access": "control",
+            },
+            {step.service_stack.stack_name: step.service_stack.phase_id for step in steps},
+        )
+        self.assertEqual(
+            ("pulsar-broker", "pulsar-admin-api"),
+            next(
+                step.service_stack.port_ids
+                for step in steps
+                if step.service_stack.stack_name == "pulsar"
+            ),
+        )
 
     def test_service_stack_steps_can_exclude_bootstrap_owned_stacks(self):
         steps = build_service_stack_steps(

--- a/tests/application/services/deployment/test_verify_swarm_service_readiness.py
+++ b/tests/application/services/deployment/test_verify_swarm_service_readiness.py
@@ -31,6 +31,8 @@ class TestVerifySwarmServiceReadiness(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(VerificationStatus.VERIFIED, verification.status)
         self.assertEqual("deployment:sonarqube-service-readiness", verification.target_id)
         self.assertEqual("sonarqube", verification.evidence["stack_name"])
+        self.assertEqual("swarm_service_replicas", verification.evidence["evidence_kind"])
+        self.assertIn("sonarqube=1/1", verification.evidence["replicas"])
 
     async def test_fails_when_required_service_does_not_converge(self):
         runtime = _FakeSwarmRuntime((SwarmServiceStatus("nexus_nexus", 0, 1),))

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -13,6 +13,12 @@ from tiny_swarm_world.domain.configuration import (
     ConfigurationValidationResult,
 )
 from tiny_swarm_world.domain.deployment import ServiceStackProfile
+from tiny_swarm_world.domain.network import (
+    PortExposureClass,
+    PortRange,
+    PortRegistry,
+    ServicePortMapping,
+)
 from tiny_swarm_world.domain.preflight import (
     HostEnvironmentKind,
     HostEnvironmentReport,
@@ -298,6 +304,56 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertIn("SECRET-TSW_CUSTOM_SECRET", check_ids)
         self.assertNotIn("PORT-9000", check_ids)
         self.assertNotIn("SECRET-TSW_PORTAINER_ADMIN_PASSWORD", check_ids)
+
+    async def test_preflight_uses_port_registry_external_ports_when_provided(self):
+        registry = PortRegistry(
+            ranges=(PortRange("public-ingress", 80, 443),),
+            mappings=(
+                ServicePortMapping(
+                    service_id="traefik",
+                    port_id="traefik-http",
+                    internal_port=80,
+                    external_port=80,
+                    exposure=PortExposureClass.PUBLIC_INGRESS,
+                    range_id="public-ingress",
+                    required_for_preflight=True,
+                ),
+            ),
+        )
+
+        result = await PreflightService(
+            _fake_probe(port_availability={80: False}),
+            port_registry=registry,
+        ).run()
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+
+        self.assertIn("PORT-80", failed_by_id)
+        self.assertEqual("80", failed_by_id["PORT-80"].evidence["port"])
+        self.assertEqual("traefik-http", failed_by_id["PORT-80"].evidence["service"])
+
+    async def test_preflight_ignores_non_preflight_registry_ports(self):
+        registry = PortRegistry(
+            ranges=(PortRange("diagnostic", 10000, 19999),),
+            mappings=(
+                ServicePortMapping(
+                    service_id="jenkins",
+                    port_id="jenkins-http",
+                    internal_port=8080,
+                    external_port=11080,
+                    exposure=PortExposureClass.DIAGNOSTIC,
+                    range_id="diagnostic",
+                    required_for_preflight=False,
+                ),
+            ),
+        )
+
+        result = await PreflightService(
+            _fake_probe(port_availability={11080: False}),
+            port_registry=registry,
+        ).run()
+
+        self.assertNotIn("PORT-11080", {check.check_id for check in result.checks})
 
     async def test_incomplete_live_consent_fails_preflight(self):
         result = await PreflightService(_fake_probe()).run(

--- a/tests/application/services/setup/test_setup_workflow.py
+++ b/tests/application/services/setup/test_setup_workflow.py
@@ -34,6 +34,8 @@ from tiny_swarm_world.application.services.platform.workflow_taxonomy import (
 )
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 from tiny_swarm_world.domain.preflight import (
+    InstallationPhase,
+    InstallationPlan,
     LIVE_CONSENT_ENVIRONMENT_VALUE,
     LIVE_CONSENT_PHRASE,
     LiveConsent,
@@ -80,6 +82,66 @@ class TestSetupWorkflow(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.executed)
         self.assertEqual(["preflight", "platform init"], calls)
         self.assertEqual(["preflight", "platform init"], [phase.name for phase in result.phase_results])
+
+    async def test_installation_plan_orders_configured_phases_before_execution(self):
+        calls: list[str] = []
+        workflow = SetupWorkflow(
+            (
+                SetupWorkflowPhase("validation", lambda: _completed_result("validation", calls)),
+                SetupWorkflowPhase("preflight", lambda: _completed_result("preflight", calls)),
+                SetupWorkflowPhase("platform init", lambda: _completed_result("platform init", calls)),
+            ),
+            live_consent=_accepted_live_consent(),
+            installation_plan=_minimal_installation_plan(),
+        )
+
+        result = await workflow.run()
+
+        self.assertEqual(SetupWorkflowStatus.COMPLETED, result.status)
+        self.assertEqual(["preflight", "platform init", "validation"], calls)
+        self.assertEqual(
+            ["preflight", "platform init", "validation"],
+            [phase.name for phase in result.phase_results],
+        )
+
+    async def test_installation_plan_missing_required_phase_blocks_before_execution(self):
+        calls: list[str] = []
+        workflow = SetupWorkflow(
+            (
+                SetupWorkflowPhase("preflight", lambda: _completed_result("preflight", calls)),
+                SetupWorkflowPhase("platform init", lambda: _completed_result("platform init", calls)),
+            ),
+            live_consent=_accepted_live_consent(),
+            installation_plan=_minimal_installation_plan(),
+        )
+
+        result = await workflow.run()
+
+        self.assertEqual(SetupWorkflowStatus.BLOCKED, result.status)
+        self.assertFalse(result.executed)
+        self.assertEqual([], calls)
+        self.assertIn("required setup workflow phases are missing", result.reason)
+
+    async def test_installation_plan_preserves_downstream_not_run_after_blocked_phase(self):
+        calls: list[str] = []
+        workflow = SetupWorkflow(
+            (
+                SetupWorkflowPhase("validation", lambda: _completed_result("validation", calls)),
+                SetupWorkflowPhase("preflight", lambda: _completed_result("preflight", calls)),
+                SetupWorkflowPhase("platform init", lambda: _blocked_result("platform init", calls)),
+            ),
+            live_consent=_accepted_live_consent(),
+            installation_plan=_minimal_installation_plan(),
+        )
+
+        result = await workflow.run()
+
+        self.assertEqual(SetupWorkflowStatus.BLOCKED, result.status)
+        self.assertEqual(["preflight", "platform init"], calls)
+        self.assertEqual(
+            ["completed", "blocked", "not_run"],
+            [phase.status for phase in result.phase_results],
+        )
 
     async def test_prints_progress_for_each_configured_phase(self):
         calls: list[str] = []
@@ -509,6 +571,30 @@ def _completed_result(name: str, calls: list[str]) -> ArtifactWorkflowResult:
         message=f"{name} completed.",
         reason="completed",
         executed=True,
+    )
+
+
+def _minimal_installation_plan() -> InstallationPlan:
+    return InstallationPlan(
+        phases=(
+            InstallationPhase(
+                "preflight",
+                0,
+                workflow_phase_names=("preflight",),
+            ),
+            InstallationPhase(
+                "platform",
+                10,
+                depends_on=("preflight",),
+                workflow_phase_names=("platform init",),
+            ),
+            InstallationPhase(
+                "validation",
+                20,
+                depends_on=("platform",),
+                workflow_phase_names=("validation",),
+            ),
+        )
     )
 
 

--- a/tests/domain/deployment/test_service_stack_contract.py
+++ b/tests/domain/deployment/test_service_stack_contract.py
@@ -58,6 +58,18 @@ class TestServiceStackContract(unittest.TestCase):
             tuple(endpoint.url for endpoint in selected_by_name["infisical"].endpoints),
         )
 
+    def test_contracts_expose_phase_and_port_ids_without_readiness_claims(self):
+        nexus = _contract_by_stack("nexus")
+
+        self.assertEqual("artifacts", nexus.phase_id)
+        self.assertEqual(
+            ("nexus-http", "nexus-docker-http", "nexus-docker-https"),
+            nexus.port_ids,
+        )
+        self.assertEqual("deployment:nexus-service-readiness", nexus.service_readiness_target_id)
+        self.assertNotEqual(nexus.stack_target_id, nexus.service_readiness_target_id)
+        self.assertFalse(any(endpoint.readiness_claimed for endpoint in nexus.endpoints))
+
     def test_service_stack_contracts_publish_localhost_endpoint_defaults(self):
         endpoints_by_stack = {
             contract.stack_name: contract.endpoints
@@ -157,6 +169,13 @@ class TestServiceStackContract(unittest.TestCase):
         with self.assertRaises(ValueError):
             ServiceStackContract("nexus", ("Nexus Service",))
 
+    def test_rejects_invalid_phase_or_port_ids(self):
+        with self.assertRaises(ValueError):
+            ServiceStackContract("nexus", ("nexus",), phase_id="../artifacts")
+
+        with self.assertRaises(ValueError):
+            ServiceStackContract("nexus", ("nexus",), port_ids=("Nexus HTTP",))
+
     def test_rejects_host_specific_endpoint_url(self):
         with self.assertRaises(ValueError):
             ServiceEndpoint("service", f"http://{ipv4_address(10, 157, 2, 182)}:8080")
@@ -183,6 +202,8 @@ class TestServiceStackContract(unittest.TestCase):
         self.assertEqual(
             {
                 "endpoints": [],
+                "phase_id": None,
+                "port_ids": [],
                 "required_services": ["nexus"],
                 "service_readiness_target_id": "deployment:nexus-service-readiness",
                 "stack_target_id": "deployment:nexus-stack",
@@ -194,3 +215,11 @@ class TestServiceStackContract(unittest.TestCase):
 
 def _endpoint_urls(endpoints: tuple[ServiceEndpoint, ...]) -> tuple[str, ...]:
     return tuple(endpoint.url for endpoint in endpoints)
+
+
+def _contract_by_stack(stack_name: str) -> ServiceStackContract:
+    return next(
+        contract
+        for contract in service_stack_contracts_for_profile(ServiceStackProfile.SERVICE_ACCESS)
+        if contract.stack_name == stack_name
+    )

--- a/tests/domain/network/test_port_forwarding_plan.py
+++ b/tests/domain/network/test_port_forwarding_plan.py
@@ -2,7 +2,11 @@ import unittest
 
 from tiny_swarm_world.domain.network.port_forwarding_plan import (
     ForwardingStrategy,
+    PortExposureClass,
     PortForwardingPlan,
+    PortRange,
+    PortRegistry,
+    ServicePortMapping,
 )
 
 
@@ -65,3 +69,202 @@ class TestPortForwardingPlan(unittest.TestCase):
                 target_port=9000,
                 remediation=("Fix the service name.",),
             )
+
+
+class TestPortRegistry(unittest.TestCase):
+    def test_accepts_ranges_and_service_mappings_without_parser_dependency(self):
+        registry = _sample_registry()
+
+        self.assertEqual(
+            ("public-ingress", "direct-diagnostic"),
+            tuple(port_range.range_id for port_range in registry.ranges),
+        )
+        self.assertEqual((80, 443, 18081), registry.external_ports)
+        self.assertEqual(
+            (80, 443, 8081),
+            tuple(mapping.internal_port for mapping in registry.mappings),
+        )
+        self.assertEqual(
+            PortExposureClass.PUBLIC_INGRESS,
+            registry.mapping_for_port_id("traefik-http").exposure,
+        )
+        self.assertEqual(
+            PortExposureClass.DIAGNOSTIC,
+            registry.mapping_for_port_id("nexus-ui").exposure,
+        )
+        payload = registry.to_dict()
+        self.assertNotIn("host_ip", repr(payload))
+        self.assertNotIn("vm_ip", repr(payload))
+
+    def test_rejects_duplicate_external_ports(self):
+        with self.assertRaisesRegex(ValueError, "duplicate external ports"):
+            PortRegistry(
+                ranges=(_direct_range(),),
+                mappings=(
+                    _mapping("nexus-ui", external_port=18081),
+                    _mapping("sonarqube-ui", external_port=18081),
+                ),
+            )
+
+    def test_rejects_invalid_port_ranges(self):
+        with self.assertRaisesRegex(ValueError, "start must be a TCP port"):
+            PortRange("bad-low", 0, 1024)
+
+        with self.assertRaisesRegex(ValueError, "end must be a TCP port"):
+            PortRange("bad-high", 1024, 65536)
+
+        with self.assertRaisesRegex(ValueError, "start must be less than or equal"):
+            PortRange("bad-order", 9000, 8000)
+
+    def test_rejects_overlapping_ranges(self):
+        with self.assertRaisesRegex(ValueError, "ranges must not overlap"):
+            PortRegistry(
+                ranges=(
+                    PortRange("first", 10000, 10999),
+                    PortRange("second", 10999, 11999),
+                ),
+                mappings=(),
+            )
+
+    def test_rejects_service_ports_outside_declared_range(self):
+        with self.assertRaisesRegex(ValueError, "external_port must belong"):
+            PortRegistry(
+                ranges=(_direct_range(),),
+                mappings=(
+                    _mapping("nexus-registry", external_port=5000),
+                ),
+            )
+
+    def test_rejects_invalid_service_ids(self):
+        for service_id in (
+            "",
+            "Nexus",
+            "nexus admin",
+            "nexus_admin",
+            "../nexus",
+            "http://nexus",
+        ):
+            with self.subTest(service_id=service_id):
+                with self.assertRaisesRegex(ValueError, "service_id"):
+                    _mapping(service_id, external_port=18081)
+
+    def test_rejects_invalid_internal_and_external_ports(self):
+        for kwargs in (
+            {"internal_port": 0},
+            {"internal_port": 65536},
+            {"external_port": 0},
+            {"external_port": 65536},
+        ):
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaisesRegex(ValueError, "port"):
+                    _mapping("nexus-ui", **kwargs)
+
+    def test_rejects_host_specific_addresses_and_credential_metadata(self):
+        unsafe_metadata = (
+            {"host_ip": "192.168.1.10"},
+            {"listen_address": "10.0.0.5"},
+            {"url": "http://admin:secret@localhost:9000"},
+            {"dashboard_url": "https://user:pass@example.test"},
+            {"secret": "plain-value"},
+            {"token": "plain-value"},
+        )
+        for metadata in unsafe_metadata:
+            with self.subTest(metadata=metadata):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "host-specific|credential|secret",
+                ):
+                    _mapping("unsafe-service", metadata=metadata)
+
+    def test_rejects_host_specific_route_hosts_and_urls(self):
+        for route_host in (
+            "192.168.1.10",
+            "http://admin:secret@localhost:9000",
+        ):
+            with self.subTest(route_host=route_host):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "host-specific|URL",
+                ):
+                    _mapping("unsafe-service", route_host=route_host)
+
+    def test_rejects_non_traefik_public_ingress(self):
+        with self.assertRaisesRegex(ValueError, "Traefik-owned 80 or 443"):
+            _mapping(
+                "gateway",
+                internal_port=80,
+                external_port=10080,
+                exposure=PortExposureClass.PUBLIC_INGRESS,
+                range_id="direct-diagnostic",
+            )
+
+    def test_preserves_internal_external_semantics(self):
+        registry = _sample_registry()
+
+        nexus = registry.mapping_for_port_id("nexus-ui")
+
+        self.assertEqual(8081, nexus.internal_port)
+        self.assertEqual(18081, nexus.external_port)
+        self.assertFalse(nexus.required_for_preflight)
+        payload = registry.to_dict()
+        self.assertEqual(8081, payload["ports"][2]["internal_port"])
+        self.assertEqual(18081, payload["ports"][2]["external_port"])
+        self.assertNotEqual(nexus.internal_port, nexus.external_port)
+
+
+def _direct_range() -> PortRange:
+    return PortRange("direct-diagnostic", 10000, 19999)
+
+
+def _mapping(
+    service_id: str,
+    *,
+    port_id: str | None = None,
+    internal_port: int = 8081,
+    external_port: int | None = 18081,
+    exposure: PortExposureClass = PortExposureClass.DIAGNOSTIC,
+    range_id: str | None = "direct-diagnostic",
+    route_host: str | None = None,
+    metadata: dict[str, str] | None = None,
+) -> ServicePortMapping:
+    return ServicePortMapping(
+        service_id=service_id,
+        port_id=port_id or service_id,
+        internal_port=internal_port,
+        external_port=external_port,
+        exposure=exposure,
+        range_id=range_id,
+        route_host=route_host,
+        required_for_preflight=False,
+        metadata=metadata,
+    )
+
+
+def _sample_registry() -> PortRegistry:
+    return PortRegistry(
+        ranges=(
+            PortRange("public-ingress", 80, 443),
+            _direct_range(),
+        ),
+        mappings=(
+            ServicePortMapping(
+                service_id="traefik",
+                port_id="traefik-http",
+                internal_port=80,
+                external_port=80,
+                exposure=PortExposureClass.PUBLIC_INGRESS,
+                range_id="public-ingress",
+                route_host="tsw.local",
+            ),
+            ServicePortMapping(
+                service_id="traefik",
+                port_id="traefik-https",
+                internal_port=443,
+                external_port=443,
+                exposure=PortExposureClass.PUBLIC_INGRESS,
+                range_id="public-ingress",
+                route_host="tsw.local",
+            ),
+            _mapping("nexus", port_id="nexus-ui"),
+        ),
+    )

--- a/tests/domain/preflight/test_preflight_result.py
+++ b/tests/domain/preflight/test_preflight_result.py
@@ -3,6 +3,8 @@ import unittest
 from tests.support.sonar_safe_literals import sample_text, token_marker
 
 from tiny_swarm_world.domain.preflight import (
+    InstallationPhase,
+    InstallationPlan,
     LIVE_CONSENT_ENVIRONMENT_VALUE,
     LIVE_CONSENT_PHRASE,
     LiveConsent,
@@ -16,6 +18,7 @@ from tiny_swarm_world.domain.preflight import (
     SetupProfile,
     SetupSecretRequirement,
     SetupServiceRequirement,
+    default_installation_plan,
     default_preflight_configuration,
     default_setup_manifest,
 )
@@ -292,4 +295,88 @@ class TestPreflightResult(unittest.TestCase):
                     ),
                 ),
                 evidence_root=".tiny-swarm-world/../leak",
+            )
+
+
+class TestInstallationPlan(unittest.TestCase):
+    def test_default_installation_plan_sorts_full_setup_order(self):
+        plan = default_installation_plan()
+
+        self.assertEqual(
+            (
+                "preflight",
+                "platform",
+                "cluster",
+                "network-routing",
+                "secrets",
+                "artifacts",
+                "cicd",
+                "quality",
+                "messaging",
+                "observability",
+                "control",
+                "docs",
+                "validation",
+            ),
+            tuple(phase.phase_id for phase in plan.ordered_phases()),
+        )
+        self.assertEqual(
+            (
+                "preflight",
+                "platform init",
+                "platform reconcile",
+                "platform expose",
+                "deployment bootstrap",
+                "artifacts prepare",
+                "artifacts verify",
+                "deployment apply",
+                "deployment verify",
+                "platform verify",
+            ),
+            plan.ordered_workflow_phase_names(),
+        )
+
+    def test_installation_plan_sorts_independent_phases_by_order_then_id(self):
+        plan = InstallationPlan(
+            phases=(
+                InstallationPhase("zeta", 20),
+                InstallationPhase("alpha", 20),
+                InstallationPhase("beta", 10),
+            )
+        )
+
+        self.assertEqual(
+            ("beta", "alpha", "zeta"),
+            tuple(phase.phase_id for phase in plan.ordered_phases()),
+        )
+
+    def test_installation_plan_rejects_dependency_cycle(self):
+        with self.assertRaisesRegex(ValueError, "cycle"):
+            InstallationPlan(
+                phases=(
+                    InstallationPhase("platform", 10, depends_on=("secrets",)),
+                    InstallationPhase("secrets", 20, depends_on=("platform",)),
+                )
+            )
+
+    def test_installation_plan_rejects_unknown_dependency(self):
+        with self.assertRaisesRegex(ValueError, "missing"):
+            InstallationPlan(
+                phases=(
+                    InstallationPhase("cicd", 20, depends_on=("artifacts",)),
+                )
+            )
+
+    def test_installation_plan_rejects_missing_required_phase(self):
+        with self.assertRaisesRegex(ValueError, "required installation phases"):
+            InstallationPlan(
+                phases=(InstallationPhase("preflight", 0),),
+                required_phase_ids=("preflight", "validation"),
+            )
+
+    def test_installation_plan_rejects_missing_required_service(self):
+        with self.assertRaisesRegex(ValueError, "required installation services"):
+            InstallationPlan(
+                phases=(InstallationPhase("artifacts", 10, services=("nexus",)),),
+                required_services=("nexus", "jenkins"),
             )

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -12,12 +12,18 @@ from tiny_swarm_world.domain.artifacts import DEFAULT_CONTAINER_IMAGE_CONTRACTS
 from tiny_swarm_world.domain.deployment import (
     DEFAULT_SERVICE_STACK_CONTRACTS,
     SERVICE_ACCESS_STACK_CONTRACT,
+    ServiceStackProfile,
+    service_stack_contracts_for_profile,
 )
+from tiny_swarm_world.domain.preflight import default_installation_plan
 from tiny_swarm_world.domain.node_provider import ManagedLxcBackend
 from tiny_swarm_world.infrastructure.adapters.clients.lxc_swarm_runtime import (
     LxcContainerImagePublisher,
 )
 from tiny_swarm_world.infrastructure.adapters.repositories.compose_file_repository_yaml import ComposeFileRepositoryYaml
+from tiny_swarm_world.infrastructure.adapters.repositories.port_registry_yaml_repository import (
+    PortRegistryYamlRepository,
+)
 
 
 class TestComposeFileRepositoryYaml(unittest.TestCase):
@@ -258,6 +264,82 @@ services:
         self.assertEqual((8081, 5000, 5001), metadata["nexus"]["nexus"])
         self.assertEqual((80, 8086, 443), metadata["service-access"]["service-access-nginx"])
         self.assertEqual((80, 443), metadata["traefik"]["traefik"])
+
+    def test_committed_service_registry_aligns_selected_stacks_with_phase_and_ports(self):
+        repository_root = Path(__file__).resolve().parents[4]
+        registry = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "services.yml").read_text(
+                encoding="utf-8"
+            )
+        )
+        service_entries = registry["services"]
+        expected_stacks = YAML(typ="safe").load(
+            (
+                repository_root / "infra" / "config" / "inventory" / "desired_inventory.yaml"
+            ).read_text(encoding="utf-8")
+        )["expected_stacks"]
+        plan_phase_ids = {phase.phase_id for phase in default_installation_plan().phases}
+        registry_port_ids = {mapping.port_id for mapping in PortRegistryYamlRepository().load().mappings}
+        contract_by_stack = {
+            contract.stack_name: contract
+            for contract in service_stack_contracts_for_profile(ServiceStackProfile.SERVICE_ACCESS)
+        }
+
+        self.assertLessEqual(set(expected_stacks), set(service_entries))
+        self.assertEqual({"traefik"}, set(service_entries) - set(expected_stacks))
+        self.assertEqual(set(expected_stacks), set(contract_by_stack))
+        self.assertNotIn("rabbitmq", service_entries)
+
+        for stack_name in expected_stacks:
+            entry = service_entries[stack_name]
+            with self.subTest(stack_name=stack_name):
+                contract = contract_by_stack[stack_name]
+                self.assertTrue(entry["enabled"])
+                self.assertEqual(stack_name, entry["stack"])
+                self.assertEqual(contract.phase_id, entry["phase"])
+                self.assertIn(entry["phase"], plan_phase_ids)
+                self.assertEqual(list(contract.required_services), entry["required_services"])
+                self.assertEqual(list(contract.port_ids), entry["port_ids"])
+                self.assertEqual(contract.service_readiness_target_id, entry["readiness_target"])
+                self.assertLessEqual(set(entry["port_ids"]), registry_port_ids)
+
+        self.assertEqual("network-routing", service_entries["traefik"]["phase"])
+        self.assertEqual(["traefik"], service_entries["traefik"]["required_services"])
+        self.assertLessEqual(set(service_entries["traefik"]["port_ids"]), registry_port_ids)
+
+    def test_committed_compose_published_ports_are_registry_ingress_or_compatibility(self):
+        repository = ComposeFileRepositoryYaml()
+        repository_root = Path(__file__).resolve().parents[4]
+        service_entries = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "services.yml").read_text(
+                encoding="utf-8"
+            )
+        )["services"]
+        registry_ports_by_id = {
+            mapping.port_id: mapping.external_port
+            for mapping in PortRegistryYamlRepository().load().mappings
+        }
+
+        for stack_name, entry in service_entries.items():
+            published_ports = {
+                port
+                for service in repository.get_services_of(stack_name)
+                for port in service.published_ports
+            }
+            registry_published_ports = {
+                registry_ports_by_id[port_id]
+                for port_id in entry["port_ids"]
+                if registry_ports_by_id[port_id] is not None
+            }
+            classified_ports = (
+                set(entry.get("compatibility_published_ports", ()))
+                | set(entry.get("deferred_published_ports", ()))
+                | set(entry.get("ingress_published_ports", ()))
+                | registry_published_ports
+            )
+
+            with self.subTest(stack_name=stack_name):
+                self.assertLessEqual(published_ports, classified_ports)
 
     def test_committed_jenkins_compose_uses_overridable_registry_image(self):
         repository_root = Path(__file__).resolve().parents[4]

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -341,6 +341,65 @@ services:
             with self.subTest(stack_name=stack_name):
                 self.assertLessEqual(published_ports, classified_ports)
 
+    def test_committed_health_checks_align_with_services_and_contracts(self):
+        repository_root = Path(__file__).resolve().parents[4]
+        health_checks = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "health-checks.yaml").read_text(
+                encoding="utf-8"
+            )
+        )["checks"]
+        service_entries = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "services.yml").read_text(
+                encoding="utf-8"
+            )
+        )["services"]
+        contract_by_stack = {
+            contract.stack_name: contract
+            for contract in service_stack_contracts_for_profile(ServiceStackProfile.SERVICE_ACCESS)
+        }
+        plan_phase_ids = {phase.phase_id for phase in default_installation_plan().phases}
+
+        ids = [check["id"] for check in health_checks]
+        target_ids = [check["target_id"] for check in health_checks]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertEqual(len(target_ids), len(set(target_ids)))
+
+        checks_by_stack = {check["stack"]: check for check in health_checks}
+        self.assertEqual(set(service_entries), set(checks_by_stack))
+        for stack_name, entry in service_entries.items():
+            check = checks_by_stack[stack_name]
+            with self.subTest(stack_name=stack_name):
+                self.assertFalse(check["live_default"])
+                self.assertEqual("swarm_service_replicas", check["evidence_kind"])
+                self.assertEqual(entry["readiness_target"], check["target_id"])
+                self.assertEqual(entry["phase"], check["phase"])
+                self.assertIn(check["phase"], plan_phase_ids)
+                self.assertEqual(entry["required_services"], check["required_services"])
+                if stack_name in contract_by_stack:
+                    contract = contract_by_stack[stack_name]
+                    self.assertEqual(contract.service_readiness_target_id, check["target_id"])
+                    self.assertEqual(list(contract.required_services), check["required_services"])
+
+    def test_committed_validation_plan_covers_required_health_check_targets(self):
+        repository_root = Path(__file__).resolve().parents[4]
+        health_checks = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "health-checks.yaml").read_text(
+                encoding="utf-8"
+            )
+        )["checks"]
+        validation_plan = YAML(typ="safe").load(
+            (repository_root / "infra" / "config" / "validation-plan.yaml").read_text(
+                encoding="utf-8"
+            )
+        )["plans"]["greenpath"]
+        health_targets = {check["target_id"] for check in health_checks}
+        required_targets = validation_plan["required_targets"]
+
+        self.assertFalse(validation_plan["live_default"])
+        self.assertEqual(len(required_targets), len(set(required_targets)))
+        self.assertEqual(health_targets, set(required_targets))
+        self.assertEqual([], validation_plan["optional_targets"])
+
     def test_committed_jenkins_compose_uses_overridable_registry_image(self):
         repository_root = Path(__file__).resolve().parents[4]
         compose_path = (

--- a/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
+++ b/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
@@ -1,0 +1,83 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from tiny_swarm_world.domain.network import PortExposureClass
+from tiny_swarm_world.infrastructure.adapters.repositories.port_registry_yaml_repository import (
+    PortRegistryYamlRepository,
+)
+
+
+class TestPortRegistryYamlRepository(unittest.TestCase):
+    def test_loads_committed_default_port_registry(self):
+        registry = PortRegistryYamlRepository().load()
+
+        self.assertEqual(11, len(registry.ranges))
+        self.assertEqual(21, len(registry.mappings))
+        self.assertEqual((80, 443), tuple(port.external_port for port in registry.preflight_ports))
+        self.assertEqual(
+            PortExposureClass.PUBLIC_INGRESS,
+            registry.mapping_for_port_id("traefik-http").exposure,
+        )
+
+    def test_missing_port_registry_defaults_to_empty_registry(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            registry = PortRegistryYamlRepository(
+                Path(temporary_directory) / "missing.yaml"
+            ).load()
+
+        self.assertEqual((), registry.ranges)
+        self.assertEqual((), registry.mappings)
+
+    def test_rejects_duplicate_external_ports(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            registry_file = Path(temporary_directory) / "ports.yaml"
+            registry_file.write_text(
+                """
+ranges:
+  - id: diagnostic
+    start: 10000
+    end: 19999
+ports:
+  - id: first
+    service_id: first
+    internal_port: 8080
+    external_port: 10080
+    exposure: diagnostic
+    range_id: diagnostic
+  - id: second
+    service_id: second
+    internal_port: 8080
+    external_port: 10080
+    exposure: diagnostic
+    range_id: diagnostic
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "duplicate external ports"):
+                PortRegistryYamlRepository(registry_file).load()
+
+    def test_rejects_unsafe_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            registry_file = Path(temporary_directory) / "ports.yaml"
+            registry_file.write_text(
+                """
+metadata:
+  dashboard_url: "https://user:pass@example.test"
+ranges: []
+ports: []
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "secret|credential"):
+                PortRegistryYamlRepository(registry_file).load()
+
+    def test_rejects_non_mapping_root(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            registry_file = Path(temporary_directory) / "ports.yaml"
+            registry_file.write_text("- invalid\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "root must be a mapping"):
+                PortRegistryYamlRepository(registry_file).load()

--- a/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
+++ b/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
@@ -13,7 +13,7 @@ class TestPortRegistryYamlRepository(unittest.TestCase):
         registry = PortRegistryYamlRepository().load()
 
         self.assertEqual(11, len(registry.ranges))
-        self.assertEqual(21, len(registry.mappings))
+        self.assertEqual(22, len(registry.mappings))
         self.assertEqual((80, 443), tuple(port.external_port for port in registry.preflight_ports))
         self.assertEqual(
             PortExposureClass.PUBLIC_INGRESS,

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -25,6 +25,7 @@ from tiny_swarm_world.application.services.setup import (
 )
 from tiny_swarm_world.domain.inventory import VerificationResult, VerificationStatus
 from tiny_swarm_world.domain.deployment import ServiceStackProfile
+from tiny_swarm_world.domain.network import PortRegistry
 from tiny_swarm_world.domain.preflight import (
     LIVE_CONSENT_ENVIRONMENT_VALUE,
     LIVE_CONSENT_PHRASE,
@@ -136,6 +137,24 @@ class TestComposition(unittest.TestCase):
             },
             workflow_field_names,
         )
+
+    def test_build_preflight_service_loads_port_registry(self):
+        registry = PortRegistry(ranges=(), mappings=())
+        provider_request = composition.NodeProviderSelectionRequest(
+            requested_provider=composition.NodeProviderKind.UNSUPPORTED,
+            backend_candidates=(),
+        )
+
+        with patch.object(composition, "PortRegistryYamlRepository") as repository_class:
+            repository_class.return_value.load.return_value = registry
+
+            service = composition.build_preflight_service(
+                node_provider_request=provider_request,
+            )
+
+        self.assertIs(registry, service.port_registry)
+        repository_class.assert_called_once_with()
+        repository_class.return_value.load.assert_called_once_with()
 
     def test_build_configuration_validation_service_uses_env_file_and_process_environment(self):
         with TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary

- Execute the installation-order and port-allocation workflow end to end.
- Add a central port registry contract, YAML-backed repository, and preflight integration for reserved host-port checks.
- Add the typed installation phase/dependency plan and align service, health-check, and validation declarations with workflow-specific evidence governance.
- Document the workflow-specific evidence path rule and final quality handoff.

## Changed Files / Areas

- `documentation/workflow/workflow.md`
- `documentation/workflow/context-pack.md`
- `documentation/workflow/context-pack.json`
- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
- `infra/config/ports.yaml`
- `infra/config/installation-plan.yaml`
- `infra/config/services.yml`
- `infra/config/health-checks.yaml`
- `infra/config/validation-plan.yaml`
- `src/tiny_swarm_world/domain/network/`
- `src/tiny_swarm_world/domain/preflight/`
- `src/tiny_swarm_world/domain/deployment/`
- `src/tiny_swarm_world/application/services/platform/preflight_service.py`
- `src/tiny_swarm_world/application/services/setup/workflow.py`
- `src/tiny_swarm_world/application/services/deployment/`
- `src/tiny_swarm_world/infrastructure/adapters/repositories/`
- `src/tiny_swarm_world/infrastructure/composition.py`
- `tests/`
- `documentation/`

## Verification

- `git diff --check`: passed
- Generic evidence guard for `.codex/evidence/slice-01-distribution.md` and `.codex/evidence/slice-01-consolidation.md`: passed; existing RabbitMQ-to-Pulsar evidence remained unchanged
- `python3 tools/quality_gate.py quality`: passed
  - ruff lint passed
  - import-linter passed, 3 contracts kept, 0 broken
  - architecture tests passed
  - mypy passed across 403 source files
  - unittest passed: 940 tests, 18 skipped

## Workflow Evidence

- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-distribution.md`
- `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-01-consolidation.md`
- Additional slice evidence through slice 08 is isolated under the same workflow-specific directory.

## Impact

- No live LXD, Incus, Docker Swarm, compose deployment, Nexus, Jenkins, Portainer, Pulsar, SonarQube, Swagger, or networking mutation commands were run.
- Public ingress remains compatible with the existing Traefik `80/443` baseline while high-numbered service ports are represented in the registry as planned exposure metadata.
- Static YAML declarations are documented as configuration contracts; runtime behavior remains explicit through typed domain/application services where implemented.

## Risks and Limitations

- GitHub reported no workflow runs or commit statuses for the PR head SHA during push-auto verification; local repository quality gate passed.
- Runtime deployment of service stacks was not exercised because live infrastructure mutation is outside this workflow execution scope.