### PR TITLE
fix(service-access): publish local access ports

### DIFF
--- a/documentation/deployment/infisical-silent-setup.adoc
+++ b/documentation/deployment/infisical-silent-setup.adoc
@@ -47,9 +47,11 @@ Infisical secrets are written only to ignored local files:
 * `.tiny-swarm-world/local/live-installation.env`
 * `.tiny-swarm/secrets/bootstrap.local.env`
 
-The Infisical-specific file contains the local `TSW_INFISICAL_*` values only.
-Compose and the bootstrap service map those values to Infisical's
-`INITIAL_BOOTSTRAP_*` runtime environment names. Do not commit either file.
+The Infisical bootstrap file contains local `TSW_INFISICAL_*` values and
+non-secret browser URL overrides such as `TSW_DASHBOARD_URL` and
+`TSW_INFISICAL_URL`. Compose and the bootstrap service map the Infisical values
+to Infisical's `INITIAL_BOOTSTRAP_*` runtime environment names. Do not commit
+either file.
 
 == Bootstrap Behavior
 

--- a/infra/config/compose/service-access/dashboard/index.html
+++ b/infra/config/compose/service-access/dashboard/index.html
@@ -213,49 +213,49 @@
         <tbody>
           <tr>
             <th scope="row">jenkins</th>
-            <td><a href="/jenkins" target="_blank" rel="noopener noreferrer">http://localhost/jenkins</a></td>
+            <td><a href="/jenkins" target="_blank" rel="noopener noreferrer">http://localhost:10000/jenkins</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/jenkins</code></a><small>View secret in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">nexus</th>
-            <td><a href="/nexus" target="_blank" rel="noopener noreferrer">http://localhost/nexus</a></td>
+            <td><a href="/nexus" target="_blank" rel="noopener noreferrer">http://localhost:10000/nexus</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/nexus</code></a><small>View secret in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">portainer</th>
-            <td><a href="/portainer" target="_blank" rel="noopener noreferrer">http://localhost/portainer</a></td>
+            <td><a href="/portainer" target="_blank" rel="noopener noreferrer">http://localhost:10000/portainer</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/portainer</code></a><small>View secret in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">pulsar</th>
-            <td><a href="/pulsar" target="_blank" rel="noopener noreferrer">http://localhost/pulsar</a></td>
+            <td><a href="/pulsar" target="_blank" rel="noopener noreferrer">http://localhost:10000/pulsar</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/pulsar-manager</code></a><small>View Pulsar Manager password in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">pulsar admin api</th>
-            <td><a href="/pulsar-admin-api" target="_blank" rel="noopener noreferrer">http://localhost/pulsar-admin-api</a></td>
+            <td><a href="/pulsar-admin-api" target="_blank" rel="noopener noreferrer">http://localhost:10000/pulsar-admin-api</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/pulsar</code></a><small>Admin API token stored in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">service-access</th>
-            <td><a href="/" target="_blank" rel="noopener noreferrer">http://localhost</a></td>
+            <td><a href="/" target="_blank" rel="noopener noreferrer">http://localhost:10000</a></td>
             <td><code>none</code></td>
             <td><span class="pwd"><code>not required</code><small>Dashboard does not require a login</small></span></td>
           </tr>
           <tr>
             <th scope="row">sonarqube</th>
-            <td><a href="/sonarqube" target="_blank" rel="noopener noreferrer">http://localhost/sonarqube</a></td>
+            <td><a href="/sonarqube" target="_blank" rel="noopener noreferrer">http://localhost:10000/sonarqube</a></td>
             <td><code>admin</code></td>
             <td><span class="pwd"><a href="/infisical" target="_blank" rel="noopener noreferrer"><code>platform/sonarqube</code></a><small>View secret in Infisical</small></span></td>
           </tr>
           <tr>
             <th scope="row">swagger</th>
-            <td><a href="/swagger" target="_blank" rel="noopener noreferrer">http://localhost/swagger</a></td>
+            <td><a href="/swagger" target="_blank" rel="noopener noreferrer">http://localhost:10000/swagger</a></td>
             <td><code>none</code></td>
             <td><span class="pwd"><code>not required</code><small>Swagger/NGINX does not require a login</small></span></td>
           </tr>

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -26,6 +26,17 @@ DEFAULT_GENERATED_SECRET_ENV_FILE = ".tiny-swarm/secrets/generated.local.env"
 DEFAULT_NATIVE_LINUX_VENV = ".tiny-swarm-world/install-venv"
 DEFAULT_SECRET_MANIFEST_PATH = Path("infra/config/secrets/infisical-secrets.yaml")
 INSTALLER_REQUIRED_SOURCES = {"generated_local_secret", "placeholder_only"}
+DEFAULT_LOCAL_SERVICE_URL_EXPORTS = {
+    "TSW_DASHBOARD_URL": "http://localhost:10000",
+    "TSW_INFISICAL_URL": "http://localhost:8086",
+    "TSW_JENKINS_URL": "http://localhost:8080",
+    "TSW_NEXUS_URL": "http://localhost:8081",
+    "TSW_PORTAINER_URL": "http://localhost:9000",
+    "TSW_PULSAR_PUBLIC_ADMIN_URL": "http://localhost:8087",
+    "TSW_PULSAR_MANAGER_URL": "http://localhost:7750",
+    "TSW_SONARQUBE_URL": "http://localhost:9001",
+    "TSW_SWAGGER_URL": "http://localhost:8084",
+}
 
 
 @dataclass(frozen=True)
@@ -563,6 +574,7 @@ def _normalized_email_value(value: str) -> str:
 
 def _write_infisical_secret_file(path: Path, env: Mapping[str, str]) -> None:
     exports = {
+        **DEFAULT_LOCAL_SERVICE_URL_EXPORTS,
         "TSW_INFISICAL_ENCRYPTION_KEY": env["TSW_INFISICAL_ENCRYPTION_KEY"],
         "TSW_INFISICAL_AUTH_SECRET": env["TSW_INFISICAL_AUTH_SECRET"],
         "TSW_INFISICAL_POSTGRES_PASSWORD": env["TSW_INFISICAL_POSTGRES_PASSWORD"],

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -943,6 +943,33 @@ services:
         ):
             self.assertNotIn(forbidden_link, dashboard)
 
+    def test_service_access_dashboard_displays_service_access_port(self):
+        dashboard = _service_access_dashboard_html()
+
+        for expected in (
+            "http://localhost:10000",
+            "http://localhost:10000/jenkins",
+            "http://localhost:10000/nexus",
+            "http://localhost:10000/portainer",
+            "http://localhost:10000/pulsar",
+            "http://localhost:10000/pulsar-admin-api",
+            "http://localhost:10000/sonarqube",
+            "http://localhost:10000/swagger",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, dashboard)
+        for stale_url in (
+            "http://localhost/jenkins",
+            "http://localhost/nexus",
+            "http://localhost/portainer",
+            "http://localhost/pulsar",
+            "http://localhost/pulsar-admin-api",
+            "http://localhost/sonarqube",
+            "http://localhost/swagger",
+        ):
+            with self.subTest(stale_url=stale_url):
+                self.assertNotIn(stale_url, dashboard)
+
     def test_service_access_dashboard_links_open_new_tabs_safely(self):
         dashboard = _service_access_dashboard_html()
         collector = _LinkCollector()

--- a/tests/integration/test_post_install_browser_live.py
+++ b/tests/integration/test_post_install_browser_live.py
@@ -60,7 +60,7 @@ class PostInstallConfig:
     def from_environment(cls) -> "PostInstallConfig":
         local_env = _load_shell_environment(Path(os.environ.get("TSW_LIVE_INSTALLATION_ENV", DEFAULT_ENV_FILE)))
         return cls(
-            dashboard_url=_env_value(local_env, "TSW_DASHBOARD_URL", "http://localhost"),
+            dashboard_url=_env_value(local_env, "TSW_DASHBOARD_URL", "http://localhost:10000"),
             vaultwarden_url=_env_value(local_env, "TSW_VAULTWARDEN_URL", "https://localhost"),
             vaultwarden_admin_token=_env_optional(local_env, "TSW_VAULTWARDEN_ADMIN_LOGIN_TOKEN")
             or _env_optional(local_env, "TSW_VAULTWARDEN_ADMIN_TOKEN"),

--- a/tests/live/test_post_install_browser_live.py
+++ b/tests/live/test_post_install_browser_live.py
@@ -151,13 +151,13 @@ class LivePostInstallConfig:
         local_env = _load_shell_environment(
             Path(os.environ.get("TSW_LIVE_INSTALLATION_ENV", DEFAULT_ENV_FILE))
         )
-        dashboard_url = _env_value(local_env, "TSW_DASHBOARD_URL", "http://localhost")
+        dashboard_url = _env_value(local_env, "TSW_DASHBOARD_URL", "http://localhost:10000")
         ingress_base_domain = _env_value(
             local_env,
             "TSW_INGRESS_BASE_DOMAIN",
             "tsw.local",
         )
-        infisical_url = _env_value(local_env, "TSW_INFISICAL_URL", "https://localhost")
+        infisical_url = _env_value(local_env, "TSW_INFISICAL_URL", "http://localhost:8086")
         pulsar_admin_url = _env_value(local_env, "TSW_PULSAR_PUBLIC_ADMIN_URL", "http://localhost:8087")
         pulsar_manager_url = _env_value(
             local_env,
@@ -310,7 +310,7 @@ class StaticPostInstallLiveSuiteTest(unittest.TestCase):
             os.environ,
             {
                 "TSW_LIVE_INSTALLATION_ENV": MISSING_TEST_ENV_FILE,
-                "TSW_DASHBOARD_URL": "http://localhost",
+                "TSW_DASHBOARD_URL": "http://localhost:10000",
                 "TSW_INFISICAL_URL": sample_url("https", "user:credential", "localhost"),
             },
         ):

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -171,6 +171,15 @@ class TestInstallScript(unittest.TestCase):
             infisical_secret_content = (
                 fixture.root / ".tiny-swarm" / "secrets" / "bootstrap.local.env"
             ).read_text()
+            self.assertIn("TSW_DASHBOARD_URL=http://localhost:10000", infisical_secret_content)
+            self.assertIn("TSW_INFISICAL_URL=http://localhost:8086", infisical_secret_content)
+            self.assertIn("TSW_JENKINS_URL=http://localhost:8080", infisical_secret_content)
+            self.assertIn("TSW_NEXUS_URL=http://localhost:8081", infisical_secret_content)
+            self.assertIn("TSW_PORTAINER_URL=http://localhost:9000", infisical_secret_content)
+            self.assertIn("TSW_PULSAR_PUBLIC_ADMIN_URL=http://localhost:8087", infisical_secret_content)
+            self.assertIn("TSW_PULSAR_MANAGER_URL=http://localhost:7750", infisical_secret_content)
+            self.assertIn("TSW_SONARQUBE_URL=http://localhost:9001", infisical_secret_content)
+            self.assertIn("TSW_SWAGGER_URL=http://localhost:8084", infisical_secret_content)
             self.assertIn("TSW_INFISICAL_LOGIN_EMAIL=admin@tiny-swarm-world.local", infisical_secret_content)
             self.assertIn("TSW_INFISICAL_BOOTSTRAP_ADMIN_PASSWORD=", infisical_secret_content)
             self.assertNotIn("export INITIAL_BOOTSTRAP_ADMIN_EMAIL=", infisical_secret_content)


### PR DESCRIPTION
## Summary
- Export non-secret local service URLs into the installer-generated Infisical bootstrap env file.
- Show Service Access dashboard URLs with `http://localhost:10000/...` while keeping safe relative links.
- Align browser/live defaults and documentation with the current Service Access and Infisical ports.

## Changed Areas
- `src/tiny_swarm_world/installer.py`
- `infra/config/compose/service-access/dashboard/index.html`
- post-install browser tests and compose dashboard tests
- Infisical silent setup documentation

## Verification
- PASS: `git diff --check`
- PASS: `python3 tools/quality_gate.py quality`

## Impact
- Local bootstrap env output now includes route overrides matching the current service-access port model.
- Operators see correct port-bearing Service Access URLs.
- No secret values are committed; ignored local bootstrap files remain outside the PR.

## Risks And Limitations
- Existing already-generated local env files need regeneration or local update to pick up the new URL exports.
- The ignored local `.tiny-swarm/secrets/bootstrap.local.env` was updated locally but is intentionally not part of this PR.

## Push Auto
This PR is intended for the full `push auto` lifecycle: wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run local cleanup after merge verification.