### PR TITLE
fix(setup-ui): stabilize setup phase progress output

### DIFF
--- a/documentation/user_guide/installer-console-output.md
+++ b/documentation/user_guide/installer-console-output.md
@@ -14,11 +14,30 @@ Tiny Swarm World Installer
   OK      fresh-install reset completed
 [2/2] live setup
   RUNNING live setup started
+[setup] preflight                 START
+[setup] preflight                 PASSED
+[setup] platform init             START
+[setup] platform init             COMPLETED
+[setup] platform reconcile        START
+[setup] platform reconcile        COMPLETED
+[setup] platform expose           START
+[setup] platform expose           COMPLETED
+[setup] deployment bootstrap      START
+[setup] deployment bootstrap      COMPLETED
+[setup] artifacts prepare         START
+[setup] artifacts prepare         COMPLETED
+[setup] artifacts verify          START
+[setup] artifacts verify          COMPLETED
+[setup] deployment apply          START
 ```
 
 Failure diagnostics include the failed phase, reason, evidence path, and
 suggested commands when available. Suggested commands are printed for operator
 use; the reporter does not execute them.
+
+Setup phase progress is emitted as left-aligned text lines. It must remain
+readable in copied terminal logs and CI output, without cursor-positioned drift
+or truncated fragments such as partial phase names.
 
 Console output must not contain raw JSON, raw Python dictionaries, YAML payloads,
 or internal event object representations. Machine-readable JSON belongs in

--- a/documentation/workflow/installer-console-reporting-policy.md
+++ b/documentation/workflow/installer-console-reporting-policy.md
@@ -31,6 +31,10 @@ Valid console output is stable, line-oriented, and readable:
 [1/2] fresh-install reset
   RUNNING fresh-install reset started
   OK      fresh-install reset completed
+[setup] preflight                 START
+[setup] preflight                 PASSED
+[setup] platform init             START
+[setup] platform init             COMPLETED
 ```
 
 Invalid console output includes raw structured payloads:
@@ -51,6 +55,9 @@ report file.
 
 - Normal and verbose output are human-readable.
 - CI output, when present, is line-based text and not JSON.
+- Setup progress starts each event at the beginning of a text line.
+- Setup progress does not rely on cursor-positioned carriage-return rendering
+  that can drift or split phase names when copied from a terminal.
 - Failed steps include target, reason, evidence path, and suggested checks when available.
 - Reporters render events; they do not execute diagnostic commands.
 - Automated tests fail on raw JSON, dict, YAML, or event repr output.

--- a/src/tiny_swarm_world/application/services/setup/workflow.py
+++ b/src/tiny_swarm_world/application/services/setup/workflow.py
@@ -196,7 +196,6 @@ class SetupWorkflow:
 
         phase_results: list[SetupPhaseResult] = []
         for phase in phases:
-            _print_phase_progress(phase.name, "START")
             self._report_phase_progress(
                 phase_name=phase.name,
                 status="started",
@@ -206,7 +205,6 @@ class SetupWorkflow:
             try:
                 phase_output = await phase.run()
             except Exception as exc:
-                _print_phase_progress(phase.name, "FAILED", exc.__class__.__name__)
                 failed_phase = SetupPhaseResult(
                     name=phase.name,
                     status=SetupWorkflowStatus.FAILED.value,
@@ -243,7 +241,6 @@ class SetupWorkflow:
             try:
                 _result_to_dict(phase_output)
             except ValueError:
-                _print_phase_progress(phase.name, "FAILED", "unsafe result payload")
                 failed_phase = SetupPhaseResult(
                     name=phase.name,
                     status=SetupWorkflowStatus.FAILED.value,
@@ -278,7 +275,6 @@ class SetupWorkflow:
                 )
 
             phase_status = _result_status_value(phase_output)
-            _print_phase_progress(phase.name, phase_status.upper())
             phase_result = SetupPhaseResult(
                 name=phase.name,
                 status=phase_status,
@@ -405,15 +401,6 @@ class SetupWorkflow:
                 recovery_hint=recovery_hint,
             )
         )
-
-
-def _print_phase_progress(phase_name: str, status: str, detail: str | None = None) -> None:
-    message = f"[setup] {phase_name}: {status}"
-    if detail:
-        message = f"{message} ({detail})"
-    print(message, flush=True)
-
-
 def _result_status_value(result: object) -> str:
     if isinstance(result, Mapping):
         return str(result.get("status", "unknown")).lower()

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py
@@ -137,6 +137,9 @@ class LinuxUI(PortUI):
         """
         Runs the curses-based UI.
         """
+        if not self.instances:
+            self._wait_without_curses()
+            return
         try:
             curses.wrapper(self._draw_ui)
         except curses.error:

--- a/src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py
@@ -14,12 +14,17 @@ from tiny_swarm_world.application.ports.ui.port_ui import (
     PortUI,
 )
 
+SETUP_PHASE_WIDTH = 25
+
 
 class TerminalWorkflowProgress(PortWorkflowProgress):
     def __init__(self, ui: PortUI):
         self.ui = ui
 
     def report(self, event: WorkflowProgressEvent) -> None:
+        line = render_workflow_progress_line(event)
+        if line:
+            print(line, flush=True)
         self.ui.update_status_event(
             ConsoleStatusEvent(
                 instance=AGGREGATE_INSTANCE,
@@ -51,3 +56,15 @@ def _trace_result(event: MethodTraceEvent) -> str:
     if event.status == "raised":
         return "failed"
     return event.safe_result or event.status
+
+
+def render_workflow_progress_line(event: WorkflowProgressEvent) -> str:
+    if event.workflow != "setup run" or event.step != "phase progress":
+        return ""
+    return f"[setup] {event.phase:<{SETUP_PHASE_WIDTH}} {_setup_status_label(event)}"
+
+
+def _setup_status_label(event: WorkflowProgressEvent) -> str:
+    if event.status == "started" and event.result == "pending":
+        return "START"
+    return event.result.upper()

--- a/tests/application/services/setup/test_setup_workflow.py
+++ b/tests/application/services/setup/test_setup_workflow.py
@@ -143,7 +143,7 @@ class TestSetupWorkflow(unittest.IsolatedAsyncioTestCase):
             [phase.status for phase in result.phase_results],
         )
 
-    async def test_prints_progress_for_each_configured_phase(self):
+    async def test_does_not_print_progress_directly(self):
         calls: list[str] = []
         workflow = SetupWorkflow(
             (
@@ -157,10 +157,7 @@ class TestSetupWorkflow(unittest.IsolatedAsyncioTestCase):
         with redirect_stdout(output):
             await workflow.run()
 
-        self.assertIn("[setup] preflight: START", output.getvalue())
-        self.assertIn("[setup] preflight: COMPLETED", output.getvalue())
-        self.assertIn("[setup] platform init: START", output.getvalue())
-        self.assertIn("[setup] platform init: COMPLETED", output.getvalue())
+        self.assertEqual("", output.getvalue())
 
     async def test_reports_progress_for_refused_setup(self):
         progress = _RecordingProgress()

--- a/tests/infrastructure/adapters/ui/test_linux_ui.py
+++ b/tests/infrastructure/adapters/ui/test_linux_ui.py
@@ -273,6 +273,14 @@ class TestLinuxUI(unittest.TestCase):
         mock_wrapper.assert_called_once_with(self.ui._draw_ui)
 
     @patch("curses.wrapper")
+    def test_start_ui_uses_plain_wait_for_empty_instance_setup_output(self, mock_wrapper):
+        ui = LinuxUI((), test_mode=True)
+
+        ui.start()
+
+        mock_wrapper.assert_not_called()
+
+    @patch("curses.wrapper")
     def test_start_ui_terminates_when_all_instances_completed(self, mock_wrapper):
         """New Test: Ensures UI terminates when all instances mark result as completed."""
 

--- a/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
+++ b/tests/infrastructure/adapters/ui/test_progress_trace_ui.py
@@ -1,4 +1,6 @@
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 
 from tiny_swarm_world.application.ports.method_trace import MethodTraceEvent
 from tiny_swarm_world.application.ports.progress import WorkflowProgressEvent
@@ -14,6 +16,56 @@ from tiny_swarm_world.infrastructure.adapters.ui.progress_trace_ui import (
 
 
 class TestProgressTraceUi(unittest.TestCase):
+    def test_workflow_progress_renders_setup_phase_lines_without_drift(self):
+        ui = RecordingUI()
+        adapter = TerminalWorkflowProgress(ui)
+        output = StringIO()
+
+        events = (
+            ("preflight", "started", "pending"),
+            ("preflight", "completed", "completed"),
+            ("platform init", "started", "pending"),
+            ("platform init", "completed", "completed"),
+            ("platform expose", "started", "pending"),
+            ("platform expose", "completed", "completed"),
+            ("deployment apply", "started", "pending"),
+        )
+
+        with redirect_stdout(output):
+            for phase, status, result in events:
+                adapter.report(
+                    WorkflowProgressEvent(
+                        workflow="setup run",
+                        phase=phase,
+                        target=phase,
+                        task="Run setup phase",
+                        step="phase progress",
+                        status=status,
+                        result=result,
+                        safe_message="Setup phase progress.",
+                    )
+                )
+
+        lines = output.getvalue().splitlines()
+
+        self.assertEqual(
+            [
+                "[setup] preflight                 START",
+                "[setup] preflight                 COMPLETED",
+                "[setup] platform init             START",
+                "[setup] platform init             COMPLETED",
+                "[setup] platform expose           START",
+                "[setup] platform expose           COMPLETED",
+                "[setup] deployment apply          START",
+            ],
+            lines,
+        )
+        self.assertTrue(all(line.startswith("[setup]") for line in lines))
+        self.assertFalse(any(line.startswith(" ") for line in lines))
+        self.assertFalse(any("\r" in line for line in lines))
+        self.assertFalse(any(line.startswith("pose:") for line in lines))
+        self.assertFalse(any(line.startswith("up]") for line in lines))
+
     def test_workflow_progress_updates_aggregate_status(self):
         ui = RecordingUI()
         adapter = TerminalWorkflowProgress(ui)


### PR DESCRIPTION
Summary:
- move setup phase progress line rendering into the terminal workflow progress adapter
- keep setup workflow progress readable in copied terminal logs and CI output
- add regression coverage and documentation for the line-based setup progress contract

Changed files or areas:
- src/tiny_swarm_world/application/services/setup/workflow.py
- src/tiny_swarm_world/infrastructure/adapters/ui/linux_ui.py
- src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py
- tests/application/services/setup/test_setup_workflow.py
- tests/infrastructure/adapters/ui/test_linux_ui.py
- tests/infrastructure/adapters/ui/test_progress_trace_ui.py
- documentation/user_guide/installer-console-output.md
- documentation/workflow/installer-console-reporting-policy.md

Verification commands and results:
- python3 tools/quality_gate.py quality: passed

Impact:
- setup phase progress now renders as stable left-aligned text lines from UI progress events
- setup workflow no longer prints phase progress directly to stdout

Risks and limitations:
- None

Push auto note:
- This workflow will wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.