### PR TITLE
fix: gate default CLI JSON output behind explicit flag

### DIFF
--- a/.codex/evidence/workflow-console-output-issue-151-20260621/slice-02-consolidation.md
+++ b/.codex/evidence/workflow-console-output-issue-151-20260621/slice-02-consolidation.md
@@ -1,0 +1,65 @@
+# Slice 02 Consolidation
+
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Slice ID: `02`
+
+## Stream Results
+
+- backend: accepted
+- tests: accepted
+
+## Accepted Findings
+
+- Default CLI output now uses human-readable summaries instead of raw JSON.
+- Explicit JSON mode is available through `--json`.
+- Preflight, blocked workflow, and normal workflow result paths now follow the
+  same output gate.
+
+## Rejected Findings
+
+- None.
+
+## Files Changed Per Stream
+
+- backend: `src/tiny_swarm_world/__main__.py`
+- tests: `tests/test_package_entrypoint.py`
+- workflow evidence: `documentation/workflow/*`,
+  `.codex/evidence/workflow-console-output-issue-151-20260621/*`
+
+## Conflicts Found
+
+- Existing entrypoint tests asserted JSON on stdout by default.
+
+## Conflicts Resolved
+
+- Payload-shape assertions now use explicit `--json`.
+- Default-path assertions now check human-readable summaries and absence of raw
+  JSON dumps.
+
+## Tests Executed
+
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.test_package_entrypoint`
+  - passed
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
+  - passed
+- `.\.venv\Scripts\python.exe tools/quality_gate.py test`
+  - failed for repository-wide environment/runtime reasons unrelated to this
+    slice on the current Windows host, including missing `_curses`, missing
+    `pwd`, Windows path handling in `install.sh` tests, and pre-existing
+    cross-platform assumptions in unrelated tests
+
+## SonarQube Findings And Fixes
+
+- Not run.
+
+## Documentation Updates
+
+- Active workflow and context pack replaced with issue-151 remediation workflow.
+- Status proof evidence recorded for issues `#143` and `#151`.
+
+## Final Integration Decision
+
+- Accepted. Targeted regression evidence proves the issue-151 change.
+- Full `quality_gate.py test` could not be claimed green in this host
+  environment; failure set is unrelated to the changed files and should not be
+  misreported as slice regressions.

--- a/.codex/evidence/workflow-console-output-issue-151-20260621/slice-02-distribution.md
+++ b/.codex/evidence/workflow-console-output-issue-151-20260621/slice-02-distribution.md
@@ -1,0 +1,40 @@
+# Slice 02 Distribution
+
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Slice ID: `02`
+Slice Title: `Default Human Output And Explicit JSON Gate`
+Affected Areas: `backend`, `tests`
+Execution Mode: `sequential`
+Selected Streams:
+
+- backend
+- tests
+
+Real Subagents Used: `no`
+Fallback Role-Based Review Used: `no`
+Git Worktrees Used: `no`
+Expected Touched Files/Directories:
+
+- `src/tiny_swarm_world/__main__.py`
+- `tests/test_package_entrypoint.py`
+
+Conflict Risks:
+
+- test expectations tightly coupled to entrypoint output contract
+
+Quality Gates To Run:
+
+- `PYTHONPATH=src python -m unittest tests.test_package_entrypoint`
+- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
+- `python3 tools/quality_gate.py test`
+
+Consolidation Plan:
+
+- apply entrypoint change
+- update output-contract tests
+- run focused verification
+
+Reason Parallelization Rejected:
+
+- backend and tests share the same output contract and a disjoint split would
+  add integration churn without reducing risk.

--- a/.codex/evidence/workflow-console-output-issue-151-20260621/slice-03-consolidation.md
+++ b/.codex/evidence/workflow-console-output-issue-151-20260621/slice-03-consolidation.md
@@ -1,0 +1,49 @@
+# Slice 03 Consolidation
+
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Slice ID: `03`
+
+## Stream Results
+
+- tests: accepted
+- security: accepted
+- documentation/evidence: accepted
+
+## Accepted Findings
+
+- Default stdout/stderr no longer emits raw JSON for the affected CLI paths.
+- Explicit machine-readable output is gated behind `--json` or
+  `TSW_DEBUG_JSON=true`.
+- No new default secret leak risk was identified against
+  `.tiny-swarm/evidence/secrets/secret-inventory.json`.
+- Workflow evidence is now synchronized to executed state and includes slice-03
+  distribution/consolidation artifacts.
+
+## Rejected Findings
+
+- None.
+
+## Subagent Review Notes
+
+- Security subagent conclusion:
+  no new standard secret-leak risk; residual risk remains only on the explicit
+  JSON/debug path and depends on upstream `to_dict()` payload content.
+- Workflow evidence audit conclusion:
+  initial status synchronization and execute-completion evidence were
+  incomplete; corrected in the main thread by updating workflow status and
+  adding slice-03 evidence.
+
+## Tests Executed
+
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.test_package_entrypoint`
+  - passed
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
+  - passed
+- `.\.venv\Scripts\python.exe tools/quality_gate.py test`
+  - failed on unrelated repository-wide host/platform issues; see slice-02 consolidation
+
+## Preliminary Integration Decision
+
+- Targeted workflow-execute verification is complete.
+- Read-only subagent review summaries have been integrated.
+- Active workflow evidence is now consistent with an executed workflow state.

--- a/.codex/evidence/workflow-console-output-issue-151-20260621/slice-03-distribution.md
+++ b/.codex/evidence/workflow-console-output-issue-151-20260621/slice-03-distribution.md
@@ -1,0 +1,41 @@
+# Slice 03 Distribution
+
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Slice ID: `03`
+Slice Title: `Final Verification And Consolidation Evidence`
+Affected Areas: `tests`, `documentation`, `security`
+Execution Mode: `parallel review`
+Selected Streams:
+
+- tests
+- security
+- documentation
+
+Real Subagents Used: `yes`
+Fallback Role-Based Review Used: `no`
+Git Worktrees Used: `no`
+Expected Touched Files/Directories:
+
+- `.codex/evidence/workflow-console-output-issue-151-20260621/**`
+
+Conflict Risks:
+
+- none; review-only subagent work with evidence-only write target in the main thread
+
+Quality Gates To Run:
+
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.test_package_entrypoint`
+- `PYTHONPATH=src .\.venv\Scripts\python.exe -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
+- `.\.venv\Scripts\python.exe tools/quality_gate.py test`
+
+Consolidation Plan:
+
+- collect targeted test results
+- collect security/redaction review against `secret-inventory.json`
+- collect workflow evidence completeness review
+- record final execution outcome
+
+Reason Parallelization Accepted:
+
+- security review and workflow-evidence audit are independent read-only checks
+  and do not overlap with implementation files.

--- a/.codex/evidence/workflow-console-output-issue-151-20260621/status-check.md
+++ b/.codex/evidence/workflow-console-output-issue-151-20260621/status-check.md
@@ -1,0 +1,36 @@
+# Issue Status Check
+
+Date: `2026-06-21`
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Branch: `fix/workflow-console-output-151-20260621`
+
+## Issue 143
+
+Status: `implemented`
+
+Evidence:
+
+- `src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py`
+- `tests/infrastructure/adapters/ui/test_progress_trace_ui.py`
+- `documentation/user_guide/installer-console-output.md`
+
+Conclusion:
+
+- No implementation work required for issue `#143`.
+
+## Issue 151
+
+Status: `open in repository behavior`
+
+Evidence:
+
+- `src/tiny_swarm_world/__main__.py` still emits `json.dumps(...)` on the
+  default CLI path.
+- `tests/test_package_entrypoint.py` still parses JSON from stdout.
+- `documentation/workflow/installer-console-reporting-policy.md` and
+  `documentation/architecture/adr-installer-console-reporting-policy.adoc`
+  already forbid this behavior.
+
+Conclusion:
+
+- Implementation work is required for issue `#151`.

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,99 +1,30 @@
 {
-  "workflow_version": "installation-phases-port-registry-v1.0.0",
-  "workflow_id": "workflow-install-order-and-port-allocation-20260620",
-  "branch": "feature/workflow-installation-phases-port-registry-20260620",
-  "evidence_root": ".codex/evidence/workflow-install-order-and-port-allocation-20260620/",
-  "created": "2026-06-20",
-  "status": "READY_FOR_WORKFLOW",
-  "process_strand": "workflow create",
-  "execution_profile": "FULL_PATH",
+  "workflow": "console-output-issue-151-v1.0.0",
+  "workflow_id": "workflow-console-output-issue-151-20260621",
+  "branch": "fix/workflow-console-output-151-20260621",
+  "status": "EXECUTED_WITH_EVIDENCE",
+  "execution_profile": "NORMAL_PATH",
+  "evidence_root": ".codex/evidence/workflow-console-output-issue-151-20260621/",
   "affected_areas": [
-    "infra/config/**",
-    "infra/config/compose/**",
-    "src/tiny_swarm_world/domain/preflight/**",
-    "src/tiny_swarm_world/domain/network/**",
-    "src/tiny_swarm_world/domain/deployment/**",
-    "src/tiny_swarm_world/application/ports/repositories/**",
-    "src/tiny_swarm_world/application/services/setup/**",
-    "src/tiny_swarm_world/application/services/platform/**",
-    "src/tiny_swarm_world/application/services/deployment/**",
-    "src/tiny_swarm_world/infrastructure/adapters/repositories/**",
-    "src/tiny_swarm_world/infrastructure/composition.py",
-    "tests/**",
-    "documentation/**"
+    "src/tiny_swarm_world/__main__.py",
+    "tests/test_package_entrypoint.py",
+    "documentation/workflow/**",
+    ".codex/evidence/workflow-console-output-issue-151-20260621/**"
   ],
   "forbidden_areas": [
-    "Java/Maven/Spring Boot structure",
-    "Browser React frontend project",
-    "Kubernetes-first deployment behavior",
-    "Multipass provider support",
-    "Live infrastructure mutation during default quality gates",
-    "Committed secrets, tokens, host IP addresses, local absolute paths, raw command output, or credential-bearing URLs"
-  ],
-  "required_roles": [
-    "Senior Requirement Engineer",
-    "Senior System Architect",
-    "Senior Python Automation Developer",
-    "Senior React Frontend Developer impact check",
-    "Senior Tester"
-  ],
-  "conditional_roles": [
-    "Senior DevOps Engineer",
-    "Senior Documentation Engineer",
-    "Security/secrets reviewer",
-    "Quality Gate Orchestrator"
+    "live infrastructure mutation",
+    "domain model changes",
+    "application orchestration changes",
+    "committed secrets or raw env payloads"
   ],
   "quality_commands": {
     "targeted": [
       "git diff --check",
-      "PYTHONPATH=src python3 -m unittest <nearest test modules>"
+      "PYTHONPATH=src python -m unittest tests.test_package_entrypoint",
+      "PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui"
     ],
     "required": [
-      "python3 tools/quality_gate.py quality"
+      "python3 tools/quality_gate.py test"
     ]
-  },
-  "evidence_governance": {
-    "required_root": ".codex/evidence/workflow-install-order-and-port-allocation-20260620/",
-    "forbidden_generic_paths": [
-      ".codex/evidence/slice-01-distribution.md",
-      ".codex/evidence/slice-01-consolidation.md"
-    ],
-    "preflight_guard": "Before writing evidence, verify that the target file is absent or belongs to this workflow. Stop if an existing evidence file belongs to another workflow.",
-    "overwrite_policy": "Do not overwrite, modify, truncate, rename, or delete evidence belonging to another workflow."
-  },
-  "governing_hashes": {
-    "AGENTS.md": "FB1EE9B2A878D4662C96B9BC7255F3D7EC151FB2D1997FD981D4D1A34F54EC3F",
-    "QUALITY.md": "458E5F4D8FBDEDEA1C413E1FF135EC91392A4BB5A5AEA20300DCAC8E209414B6",
-    ".agents/skills/workflow-authoring/SKILL.md": "5EF238CA8A98D08A3594906E5A30100649D4C09E64A01B377D690F6580B1CA03",
-    ".agents/skills/three-amigos-requirement-gatekeeper/SKILL.md": "23DE7D9AAC9D2694EAE26FAC2765D65F369C101AC348DAC24D5F3BBE9E2D3BA4",
-    ".agents/orchestrator/routing-rules.md": "BA3563181DB98DF3F6A1872D676006CF57CC1603C1B0B74D4C41CD3DB02A60A5",
-    "documentation/process/branch-governance.md": "3332F0FB56E7A72FEE3A9B6E89C4D9D5C3BF1198B375CE4D2BBD5C7350588A83",
-    "documentation/epics/autonomous-runnable-setup.md": "758F291E311CF8232937B6820CE6122126C3C8353276E3D38FFF6C5EDE079691",
-    "documentation/epics/service-access-dashboard-vaultwarden.md": "9C93D460A92630F485C0672F26810ECB4832C69D21A8F6F0941DFFA4AACD1606",
-    "documentation/arc42/07_deployment_view.adoc": "8CC484BBB06C42CFEF2E933AB047716B54AEE655E5C62D711E2485151F07BF5C",
-    "documentation/arc42/08_concepts.adoc": "6AD298D14F6AA4BEF530A25C88EA1AB171AC8EF48A295089025D0B716BF78C0F",
-    "documentation/arc42/09_architecture_decisions.adoc": "2C9811C38F1AD2AE4E516C6A4C3C7DBA808FC208B687242C965EB43CCF3FD051",
-    "documentation/arc42/10_quality_requirements.adoc": "F2F824FC64B1DC05AEB8CE49A30833E2F426AED397F1193470ED2DC43BAAB865"
-  },
-  "arc42_check": {
-    "checked_files": [
-      "documentation/arc42/05_building_blocks.adoc",
-      "documentation/arc42/07_deployment_view.adoc",
-      "documentation/arc42/08_concepts.adoc",
-      "documentation/arc42/09_architecture_decisions.adoc",
-      "documentation/arc42/10_quality_requirements.adoc"
-    ],
-    "modified_during_workflow_creation": false,
-    "execution_update_slices": [
-      "01",
-      "07"
-    ]
-  },
-  "stale_when": [
-    "governing hash changes",
-    "workflow.md changes without this pack",
-    "branch mismatch",
-    "ADR changes Traefik ingress or setup safety baseline",
-    "execution slice changes quality commands or file locks"
-  ]
+  }
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,46 +1,35 @@
 # Workflow Context Pack
 
-Workflow: `installation-phases-port-registry-v1.0.0`
-Workflow ID: `workflow-install-order-and-port-allocation-20260620`
-Branch: `feature/workflow-installation-phases-port-registry-20260620`
-Created: `2026-06-20`
-Status: `READY_FOR_WORKFLOW`
-Evidence Root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+Workflow: `console-output-issue-151-v1.0.0`
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Branch: `fix/workflow-console-output-151-20260621`
+Created: `2026-06-21`
+Status: `EXECUTED_WITH_EVIDENCE`
+Evidence Root: `.codex/evidence/workflow-console-output-issue-151-20260621/`
 
 ## Purpose
 
-This context pack is a workflow-local navigation aid for executing the installation phases and port registry workflow. It does not replace root `AGENTS.md`, `QUALITY.md`, ADRs, arc42 files, or active workflow files.
+Focused execution context for proving issue `#143`, remediating issue `#151`,
+and storing console-output evidence without touching live infrastructure.
 
 ## Process Strand
 
-- Active command: `workflow create`
-- Execution profile: `FULL_PATH`
-- Workflow target: deterministic setup phase ordering and central port registry.
+- Active command: `workflow execute`
+- Execution profile: `NORMAL_PATH`
 
 ## Affected Areas
 
-- `infra/config/**`
-- `infra/config/compose/**`
-- `src/tiny_swarm_world/domain/preflight/**`
-- `src/tiny_swarm_world/domain/network/**`
-- `src/tiny_swarm_world/domain/deployment/**`
-- `src/tiny_swarm_world/application/ports/repositories/**`
-- `src/tiny_swarm_world/application/services/setup/**`
-- `src/tiny_swarm_world/application/services/platform/**`
-- `src/tiny_swarm_world/application/services/deployment/**`
-- `src/tiny_swarm_world/infrastructure/adapters/repositories/**`
-- `src/tiny_swarm_world/infrastructure/composition.py`
-- `tests/**`
-- `documentation/**`
+- `src/tiny_swarm_world/__main__.py`
+- `tests/test_package_entrypoint.py`
+- `documentation/workflow/**`
+- `.codex/evidence/workflow-console-output-issue-151-20260621/**`
 
 ## Forbidden Areas
 
-- Java, Maven, Spring Boot project structure.
-- Browser React frontend project structure.
-- Kubernetes-first deployment behavior.
-- Multipass provider support.
-- Live infrastructure mutation during default quality gates.
-- Committed secrets, tokens, host IP addresses, local absolute paths, raw command output, or credential-bearing URLs.
+- live infrastructure mutation
+- domain model changes
+- application orchestration changes
+- committed secrets or raw env payloads
 
 ## Required Roles
 
@@ -52,70 +41,30 @@ This context pack is a workflow-local navigation aid for executing the installat
 
 ## Conditional Roles
 
-- Senior DevOps Engineer for compose, Docker Swarm, LXC exposure, and runtime stack changes.
-- Senior Documentation Engineer for README, arc42, deployment, and system docs.
-- Security/secrets reviewer for credential references, exposed ports, and evidence.
-- Quality Gate Orchestrator for final quality classification.
+- Security reviewer for secret/redaction assertions
 
 ## Quality Commands
 
 Targeted:
 
 - `git diff --check`
-- `PYTHONPATH=src python3 -m unittest <nearest test modules>`
+- `PYTHONPATH=src python -m unittest tests.test_package_entrypoint`
+- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
 
 Required final:
 
-- `python3 tools/quality_gate.py quality`
+- `python3 tools/quality_gate.py test`
 
-## Evidence Governance
+## Governing Inputs
 
-- Evidence files for this workflow must be written only below `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
-- Generic evidence paths such as `.codex/evidence/slice-01-distribution.md` and `.codex/evidence/slice-01-consolidation.md` are forbidden.
-- Before writing evidence, verify that the target file is absent or belongs to this workflow.
-- If an evidence file exists and belongs to another workflow, stop and report a blocker instead of overwriting it.
-
-## Governing File Hashes
-
-| File | SHA256 |
-|---|---|
-| `AGENTS.md` | `FB1EE9B2A878D4662C96B9BC7255F3D7EC151FB2D1997FD981D4D1A34F54EC3F` |
-| `QUALITY.md` | `458E5F4D8FBDEDEA1C413E1FF135EC91392A4BB5A5AEA20300DCAC8E209414B6` |
-| `.agents/skills/workflow-authoring/SKILL.md` | `5EF238CA8A98D08A3594906E5A30100649D4C09E64A01B377D690F6580B1CA03` |
-| `.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md` | `23DE7D9AAC9D2694EAE26FAC2765D65F369C101AC348DAC24D5F3BBE9E2D3BA4` |
-| `.agents/orchestrator/routing-rules.md` | `BA3563181DB98DF3F6A1872D676006CF57CC1603C1B0B74D4C41CD3DB02A60A5` |
-| `documentation/process/branch-governance.md` | `3332F0FB56E7A72FEE3A9B6E89C4D9D5C3BF1198B375CE4D2BBD5C7350588A83` |
-| `documentation/epics/autonomous-runnable-setup.md` | `758F291E311CF8232937B6820CE6122126C3C8353276E3D38FFF6C5EDE079691` |
-| `documentation/epics/service-access-dashboard-vaultwarden.md` | `9C93D460A92630F485C0672F26810ECB4832C69D21A8F6F0941DFFA4AACD1606` |
-| `documentation/arc42/07_deployment_view.adoc` | `8CC484BBB06C42CFEF2E933AB047716B54AEE655E5C62D711E2485151F07BF5C` |
-| `documentation/arc42/08_concepts.adoc` | `6AD298D14F6AA4BEF530A25C88EA1AB171AC8EF48A295089025D0B716BF78C0F` |
-| `documentation/arc42/09_architecture_decisions.adoc` | `2C9811C38F1AD2AE4E516C6A4C3C7DBA808FC208B687242C965EB43CCF3FD051` |
-| `documentation/arc42/10_quality_requirements.adoc` | `F2F824FC64B1DC05AEB8CE49A30833E2F426AED397F1193470ED2DC43BAAB865` |
-
-## Staleness Rules
-
-This context pack is stale when:
-
-- any governing hash changes;
-- `documentation/workflow/workflow.md` changes without updating this pack;
-- any branch mismatch is detected;
-- an ADR changes the Traefik ingress or setup safety baseline;
-- a workflow execution slice changes quality commands or allowed file locks.
+- `AGENTS.md`
+- `QUALITY.md`
+- `documentation/workflow/installer-console-reporting-policy.md`
+- `documentation/user_guide/installer-console-output.md`
+- `documentation/architecture/adr-installer-console-reporting-policy.adoc`
+- `.tiny-swarm/evidence/secrets/secret-inventory.json`
 
 ## Branch Evidence
 
-- Dedicated branch: `feature/workflow-installation-phases-port-registry-20260620`
-- Branch ref verification: `git show-ref --verify --quiet refs/heads/feature/workflow-installation-phases-port-registry-20260620`
-- Active branch verification: `git branch --show-current`
-
-## arc42 Check
-
-Checked during workflow creation:
-
-- `documentation/arc42/05_building_blocks.adoc`
-- `documentation/arc42/07_deployment_view.adoc`
-- `documentation/arc42/08_concepts.adoc`
-- `documentation/arc42/09_architecture_decisions.adoc`
-- `documentation/arc42/10_quality_requirements.adoc`
-
-No arc42 file was modified during workflow creation. Slice 01 and Slice 07 own execution-time synchronization.
+- `git show-ref --verify --quiet refs/heads/fix/workflow-console-output-151-20260621`
+- `git branch --show-current`

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,103 +1,97 @@
-# Workflow: Installation Phases And Port Registry
+# Workflow: Console Output Issue 151 Remediation
 
-Version: `installation-phases-port-registry-v1.0.0`
-Workflow ID: `workflow-install-order-and-port-allocation-20260620`
-Created: `2026-06-20`
-Branch: `feature/workflow-installation-phases-port-registry-20260620`
-Status: `READY_FOR_WORKFLOW`
-Evidence Root: `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`
+Version: `console-output-issue-151-v1.0.0`
+Workflow ID: `workflow-console-output-issue-151-20260621`
+Created: `2026-06-21`
+Branch: `fix/workflow-console-output-151-20260621`
+Status: `EXECUTED_WITH_EVIDENCE`
+Evidence Root: `.codex/evidence/workflow-console-output-issue-151-20260621/`
 
 ## Executive Summary
 
-Create an executable workflow for making Tiny Swarm World installation order and port allocation deterministic. The workflow covers a central port registry, installation phase registry, dependency graph, health/validation plan, and the Python automation needed to consume those declarations through existing hexagonal boundaries.
-
-The current repository already accepts Traefik-backed centralized ingress on ports `80` and `443` for the service-access setup profile. This workflow must not silently replace that ADR-backed ingress baseline with high-numbered gateway ports. High-numbered service ports may be introduced as direct, diagnostic, or compatibility mappings only after the architecture slice records the intended port model.
+Validate issues `#143` and `#151` before implementation, prove whether either
+is already fulfilled, then implement only the remaining console-output gap.
+Issue `#143` is already implemented in the repository and is therefore out of
+implementation scope. Issue `#151` remains open because the default CLI still
+prints raw JSON workflow payloads to stdout.
 
 ## Requirement Clarification Gate
 
 Original Request:
 
-- Create a workflow for fixed installation order and a clean port concept for Tiny Swarm World services.
-- Model install phases from preflight through LXC/LXD/Incus, Docker Swarm, secrets, registry, CI/CD, quality, messaging, observability, service access, Swagger/API docs, and greenpath validation.
-- Introduce central files such as `ports.yaml`, `installation-plan.yaml`, `services.yaml`, `dependencies.yaml`, `health-checks.yaml`, and `validation-plan.yaml`.
+- Setze issue `143 / 151` gemaess `workflow execute with subagents` um.
+- Beweise vor jeder Umsetzung, ob beide Issues bereits umgesetzt wurden.
+- Wenn die Pruefung abgeschlossen ist, soll daraus ein Workflow mit eigenem
+  Branch entstehen, um fehlende Implementierung umzusetzen.
+- Verwende `@secret-inventory.json` als relevanten Nachweis fuer Secret-/Redaction-Risiken.
 
 Interpreted Intent:
 
-- Build a workflow that later implements declarative setup planning and port governance without bypassing the current Python automation, live-consent, Docker Swarm, LXC-native, and hexagonal architecture constraints.
+- Execute a guarded, evidence-backed fix workflow for installer and CLI console
+  output, but only after proving the current implementation state of both
+  issues.
 
 Change Type:
 
-- Product behavior workflow for Python automation, configuration, deployment contracts, tests, and documentation.
+- Product bug-fix workflow for Python CLI output, console UX, tests, workflow
+  evidence, and documentation synchronization.
 
 Affected Process Strand:
 
-- `workflow create`
-- later `workflow execute` over setup, platform, artifacts, deployment, preflight, and documentation strands.
+- `workflow execute`
 
 Affected Architecture Area:
 
-- Domain: installation plan, port registry, dependency graph, health/validation concepts.
-- Application: setup orchestration, preflight checks, deployment plan construction, validation sequencing.
-- Infrastructure: YAML repositories for new registries and compose/stack configuration integration.
-- Configuration: `infra/config/**` desired-state files.
-- Documentation: arc42 deployment/concepts/quality and operator setup guidance.
+- Infrastructure UI adapters
+- Python CLI entrypoint
+- Product-behavior tests
+- Workflow evidence
 
 Explicit Requirements:
 
-- Define fixed installation phases.
-- Define fixed service dependencies.
-- Define central port ranges and service port assignments.
-- Keep ports centrally declared instead of hard-coded across compose files, Python code, and templates.
-- Add port preflight checks.
-- Add phase-level health and validation checks.
-- Keep service-access/control UI as a late-installed but first-used operator entry point.
+- Check issue `#143` implementation status first.
+- Check issue `#151` implementation status first.
+- Use subagents for the execute workflow where safe.
+- Create a dedicated branch before write-capable work.
+- Prove the final implementation with repository evidence and verification.
 
 Implicit Requirements:
 
-- Preserve Linux/WSL-only operation.
-- Preserve LXC-native through LXD or Incus as the supported node-provider direction.
-- Preserve Docker Swarm-first deployment.
-- Preserve current live-infrastructure consent and fail-closed behavior.
-- Use structured YAML parsing and repository adapters.
-- Do not claim live service health without observed-state or smoke evidence.
-- Do not introduce React, Java, Maven, Spring Boot, Kubernetes-first behavior, or direct live scripts as canonical behavior.
+- Preserve hexagonal boundaries.
+- Keep default console output human-readable.
+- Keep machine-readable JSON available only when explicitly requested.
+- Do not leak secrets or raw env payloads to stdout/stderr.
+- Do not execute live infrastructure commands.
 
 Assumptions:
 
-- The central registry belongs under `infra/config` unless the architecture slice finds a stronger existing desired-state location.
-- Traefik `80/443` remains the public centralized ingress baseline unless an ADR change is explicitly authored.
-- High-numbered ports are useful for direct/diagnostic host mappings, local compatibility endpoints, and preflight conflict detection.
-- Observability services such as Prometheus, Grafana, Loki, and Alertmanager can be modeled as optional until repository compose contracts exist.
-- RabbitMQ is a requested target service, but the current repository baseline contains Apache Pulsar rather than RabbitMQ. RabbitMQ must be added only through a service-stack slice with tests and docs, or documented as deferred if not selected.
+- Issue `#151` remediation is limited to CLI/console presentation and tests.
+- `@secret-inventory.json` is a risk/governance input, not an output target.
 
 Non-Goals:
 
-- No live LXD, Incus, LXC, Docker Swarm, compose, Portainer, Nexus, Jenkins, SonarQube, Infisical, Pulsar, RabbitMQ, Prometheus, Grafana, or Swagger mutation during default verification.
-- No replacement of accepted Traefik ingress without ADR coverage.
-- No browser React frontend project.
-- No Java/Maven/Spring Boot structure.
-- No Kubernetes-first migration.
-- No committed secrets, host IPs, Swarm tokens, local absolute paths, or credential-bearing URLs.
+- No live install, reset, LXD/Incus/LXC, Docker Swarm, compose, or service
+  bootstrap execution.
+- No browser UI or curses UI work.
+- No change to setup orchestration semantics.
 
 Risks:
 
-- The proposed high-numbered gateway ports can conflict with the accepted Traefik `80/443` ingress direction if treated as public ingress replacement.
-- Existing compose files still publish several direct ports such as `8080`, `8081`, `9000`, `9001`, `5000`, `5001`, `6650`, `7750`, `8087`, `9527`, and `8084`.
-- Service registry work can touch shared deployment contracts and must be sliced carefully.
-- RabbitMQ and observability services are not currently present as compose stacks in the verified baseline.
+- Existing entrypoint tests currently assert JSON on stdout and must be updated
+  together with the runtime behavior.
+- Console summaries must not weaken failure visibility or evidence references.
 
 Open Questions:
 
-- Should RabbitMQ replace, complement, or remain separate from the existing Pulsar baseline? This is non-blocking if RabbitMQ is modeled as deferred or optional until a later explicit service-selection decision.
-- Should high-numbered ports become direct host ports while Traefik remains the main user ingress, or should they become a later ADR-backed ingress replacement? The workflow assumes direct/diagnostic use until ADR says otherwise.
+- None blocking.
 
 Blocking Questions:
 
-- None for workflow authoring.
+- None.
 
 Confidence Level:
 
-- `92%`
+- `95%`
 
 Decision:
 
@@ -107,893 +101,237 @@ Decision:
 
 Senior Requirement Engineer:
 
-- Requirements are concrete enough for workflow authoring. The workflow must record Pulsar vs RabbitMQ and Traefik vs high-port gateway assumptions instead of hiding them.
+- The request is concrete. Only issue `#151` requires implementation after the
+  repository-state check.
 
 Senior System Architect:
 
-- The workflow fits the autonomous setup and service-access EPICs when it keeps setup orchestration in Python, uses ports/adapters for YAML loading, and preserves accepted Traefik ingress unless an ADR changes it.
+- The fix belongs in the CLI/infrastructure presentation surface. Domain and
+  application behavior must remain unchanged.
 
 Senior Python Automation Developer:
 
-- Implementation should introduce typed domain models and repository ports before wiring setup/preflight/deployment behavior. Compose and manifest integration must use structured YAML APIs.
+- The safest path is to gate JSON emission behind an explicit switch and update
+  tests around the entrypoint output contract.
 
 Senior React Frontend Developer:
 
-- No React frontend impact is approved. Service-access remains an infrastructure dashboard/static asset and console/status UI remains terminal-only unless a later workflow verifies a browser frontend module.
+- No browser frontend impact. N/A beyond confirming console-only scope.
 
 Senior Tester:
 
-- Default gates must use static and mocked tests. Targeted tests should cover YAML schema validation, duplicate port detection, phase dependency ordering, preflight conflict reporting, health-check planning, and fail-closed validation semantics.
-
-Dependency / Deadlock Validator:
-
-- The slice order is acyclic: architecture decision first, registry schema second, domain/application consumers third, deployment/compose migration after consumers, validation last.
-
-Does the implementation still match the EPIC?
-
-- Yes, if execution preserves the autonomous runnable setup EPIC and service-access EPIC boundaries and does not claim live runnable success before evidence exists.
-
-## Execution Profile
-
-`executionProfile=FULL_PATH`
-
-Reason:
-
-- The workflow affects setup/deployment behavior, configuration contracts, port allocation, service ordering, quality gates, architecture documentation, and possible future service-stack expansion.
-
-Required Full Reviews:
-
-- Senior Requirement Engineer
-- Senior System Architect
-- Senior Python Automation Developer
-- Senior React Frontend Developer impact check
-- Senior Tester
-- Senior Documentation Engineer
-- Senior DevOps Engineer where deployment and runtime configuration are touched
-- Security review where secrets, credential references, or service exposure are touched
-
-Quality Commands:
-
-- Targeted during execution: relevant `PYTHONPATH=src python3 -m unittest ...` commands per slice.
-- Required before commit/push of implementation slices: `python3 tools/quality_gate.py quality`.
-- Documentation-only targeted gate: `git diff --check`.
-
-## Target Picture
-
-Tiny Swarm World has one declarative setup model that can answer:
-
-- which phase runs in which order;
-- which services belong to each phase;
-- which services depend on previous phases or service readiness;
-- which external host ports are reserved, diagnostic, or ingress-owned;
-- which internal container ports remain unchanged;
-- which preflight checks block mutation;
-- which health checks verify each phase;
-- which validation checks prove the greenpath without claiming live success by default.
+- Regression coverage must prove that default stdout is human-readable and that
+  explicit JSON mode still emits structured payloads.
 
 ## Verified Baseline
 
-Repository evidence checked during workflow creation:
+- Branch precheck before write-capable work started on `main` with a clean tree.
+- Dedicated branch `fix/workflow-console-output-151-20260621` was created and
+  verified before workflow mutation.
+- Issue `#143` is already implemented:
+  - `src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py`
+  - `tests/infrastructure/adapters/ui/test_progress_trace_ui.py`
+  - `documentation/user_guide/installer-console-output.md`
+- Issue `#151` remains open:
+  - `src/tiny_swarm_world/__main__.py` still prints raw JSON by default.
+  - `tests/test_package_entrypoint.py` still expects JSON on stdout.
+- Secret/redaction risk inventory reviewed:
+  - `.tiny-swarm/evidence/secrets/secret-inventory.json`
 
-- Root branch was `main`, then workflow branch `feature/workflow-installation-phases-port-registry-20260620` was created and verified.
-- Root `AGENTS.md` defines Linux/WSL-only, Python automation, Docker Swarm-first, LXC-native direction.
-- `QUALITY.md` defines `python3 tools/quality_gate.py quality` and targeted gates.
-- `documentation/epics/autonomous-runnable-setup.md` requires preflight, resource, port, secret, platform, artifact, deployment, and readiness checks before full runnable success.
-- `documentation/epics/service-access-dashboard-vaultwarden.md` requires service-access/Vaultwarden safety and forbids React scope.
-- `documentation/arc42/07_deployment_view.adoc` documents Traefik `80/443` as the current service-access public ingress baseline.
-- `documentation/arc42/08_concepts.adoc` documents desired inventory, observed state, evidence, ingress, and workflow distribution concepts.
-- `src/tiny_swarm_world/domain/preflight/setup_manifest.py` currently owns setup port and secret requirements.
-- `src/tiny_swarm_world/domain/deployment/service_stack_contract.py` currently owns service stack endpoint defaults.
-- `infra/config/compose/**/docker-compose.yml` currently contains direct published ports for several stacks.
+## Execution Outcome
+
+- Issue `#143` verified as already implemented.
+- Issue `#151` implemented on this workflow branch.
+- Targeted verification passed.
+- Workflow-execute evidence written under
+  `.codex/evidence/workflow-console-output-issue-151-20260621/`.
+- Full repository-wide `quality_gate.py test` remains red on this Windows host
+  for unrelated platform/repository reasons and is explicitly not claimed green.
 
 ## Target Outcome
 
-After `workflow execute`, the repository should contain:
-
-- a central port registry with tested ranges, uniqueness, service mapping, internal/external semantics, and ingress/direct exposure classification;
-- a central installation phase registry with dependency ordering and required/optional service membership;
-- application services that consume the registries through ports and domain models;
-- setup/preflight behavior that checks required host ports before mutation;
-- deployment/service-stack planning that is aligned with the registry;
-- health and validation planning that fails closed when evidence is unavailable;
-- synchronized arc42 and operator documentation.
+- Default CLI stdout/stderr is line-based and human-readable.
+- Raw JSON payloads are no longer printed by default.
+- Explicit JSON/debug mode exists for deliberate machine-readable output.
+- Tests prove both default human-readable behavior and explicit JSON behavior.
+- Evidence documents that issue `#143` required no code changes and issue
+  `#151` was remediated.
 
 ## Scope
 
 In scope:
 
-- `infra/config` desired-state files for ports, phases, dependencies, health checks, and validation plans.
-- Python domain models for port registry and installation plan concepts.
-- Application ports/services for registry loading, phase ordering, preflight planning, and validation planning.
-- Infrastructure YAML repositories and composition wiring.
-- Existing compose stack contract alignment for Portainer, Nexus, Jenkins, SonarQube, Apache Pulsar, Swagger/NGINX, Infisical, service-access, and Traefik.
-- Tests for schema validation, ordering, duplicate detection, preflight integration, deployment planning, and evidence semantics.
-- Documentation and arc42 synchronization.
+- `src/tiny_swarm_world/__main__.py`
+- `tests/test_package_entrypoint.py`
+- `documentation/workflow/**`
+- optional user-guide synchronization if examples change materially
 
 Out of scope:
 
-- Live infrastructure execution.
-- Claims that services are live-installed, reachable, or healthy.
-- Browser React frontend implementation.
-- Replacing Pulsar with RabbitMQ without explicit service selection and compose contract.
-- Replacing Traefik `80/443` public ingress without ADR coverage.
+- live installer runtime changes
+- setup phase orchestration semantics
+- infrastructure mutation
 
 ## Architecture Constraints
 
-- Preserve hexagonal boundaries.
-- Domain code must not import YAML, filesystem, command runners, HTTP clients, logging, Docker clients, or infrastructure adapters.
-- Application services may orchestrate domain objects and ports but must not parse files or run shell commands directly.
-- Infrastructure adapters implement YAML and filesystem details.
-- Composition remains in `src/tiny_swarm_world/infrastructure/composition.py` and related composition modules.
-- Config files under `infra/config` are product behavior and must be validated through structured YAML APIs.
-- Default tests and quality gates must not run live infrastructure commands.
-
-## Python Automation Assessment
-
-Expected Python surfaces:
-
-- New or extended domain models for port ranges, service ports, installation phases, dependency edges, health checks, and validation steps.
-- New application ports for loading those desired-state declarations.
-- Infrastructure YAML repositories using `ruamel.yaml` in the established style.
-- Setup/preflight/deployment services that consume typed data, not raw YAML dictionaries.
-- Composition wiring that keeps concrete repositories out of application service constructors.
-
-## Frontend Assessment
-
-- No browser React frontend is in scope.
-- The existing service-access static dashboard may need route/port display updates only if the registry becomes the source for its catalog.
-- Console/status UI impact is limited to setup progress and validation status wording if execution slices change operator output.
+- Keep domain free of console formatting.
+- Keep application services free of terminal-specific rendering.
+- Keep CLI and reporter formatting in infrastructure/entrypoint surfaces.
+- Do not print secret-bearing payloads or raw workflow dictionaries by default.
 
 ## Test Strategy
 
-Regression-first tests should cover:
+Targeted:
 
-- central port registry loads valid YAML and rejects duplicate external ports;
-- invalid port range, invalid service id, host-specific values, and credential-bearing URL rejection;
-- installation phases sort deterministically and reject cycles;
-- setup manifest required ports are derived from or checked against the central registry;
-- service stack endpoint contracts align with registry entries and do not claim readiness;
-- compose published ports are either registry-backed, ingress-owned, or explicitly diagnostic/deferred;
-- health and validation plans fail closed when an observed-state source is missing;
-- default quality gates remain mocked/static and do not execute live infrastructure.
+- `PYTHONPATH=src python -m unittest tests.test_package_entrypoint`
+- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
 
-## Resilience Requirements
+Required final:
 
-- Port conflict preflight must block before mutation.
-- Dependency cycles must block workflow planning.
-- Missing health-check evidence must produce `blocked` or `failed_to_verify`, never success.
-- Resource-gated profiles must remain distinct from full runnable success.
-- Secrets must be represented by source names or external secret names, not values.
-- Evidence must stay redacted and under ignored `.tiny-swarm-world/**` paths.
+- `python3 tools/quality_gate.py test`
 
 ## Ordered Slices
 
-### Slice 01 - Architecture And Port Model Decision
+### Slice 01 - Status Proof And Workflow Evidence
 
 Purpose:
 
-- Record the exact port model before implementation: Traefik `80/443` remains the current public ingress baseline; high-numbered ports are direct/diagnostic/compatibility allocations unless an ADR explicitly changes ingress.
-
-Prerequisites:
-
-- Workflow branch active.
+- Record the repository-state proof for issues `#143` and `#151`.
 
 ```yaml
 slice_id: "01"
-profile: "FULL_PATH"
-owner: "Senior System Architect"
+profile: "NORMAL_PATH"
+owner: "Senior Workflow Architect"
 secondary_reviewers:
   - "Senior Requirement Engineer"
-  - "Senior Documentation Engineer"
+  - "Senior Tester"
 affected_files:
-  - "documentation/arc42/07_deployment_view.adoc"
-  - "documentation/arc42/08_concepts.adoc"
-  - "documentation/arc42/09_architecture_decisions.adoc"
-  - "documentation/architecture/adr-traefik-https-ingress-existing-ca.adoc"
+  - "documentation/workflow/workflow.md"
+  - "documentation/workflow/context-pack.md"
+  - "documentation/workflow/context-pack.json"
+  - ".codex/evidence/workflow-console-output-issue-151-20260621/status-check.md"
 affected_modules: []
 affected_contracts:
-  - "Traefik ingress baseline"
-  - "service-access setup profile"
+  - "workflow evidence"
 dependencies: []
-parallel_group: "architecture"
+parallel_group: "governance"
 file_locks:
-  - "documentation/arc42/**"
-  - "documentation/architecture/adr-traefik-https-ingress-existing-ca.adoc"
+  - "documentation/workflow/**"
+  - ".codex/evidence/workflow-console-output-issue-151-20260621/**"
 contract_locks:
-  - "public ingress port model"
+  - "issue status proof"
 architecture_locks:
-  - "Docker Swarm-first deployment"
-  - "LXC-native provider direction"
+  - "hexagonal boundaries unchanged"
 quality_gates:
   targeted:
     - "git diff --check"
   required:
-    - "python3 tools/quality_gate.py quality"
+    - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "Check and update deployment/concepts/ADR index if the port model changes."
-  adr: "Required only if replacing Traefik 80/443 public ingress with high-numbered public gateway ports."
+  arc42: "No arc42 change expected."
+  adr: "No ADR change expected."
 stop_conditions:
-  - "Stop if high-numbered ports would contradict accepted Traefik ingress without an ADR."
+  - "Stop if issue status cannot be proven from repository evidence."
 ```
 
-Done Criteria:
-
-- The workflow execution records whether the port registry governs direct ports, public ingress, or both.
-- arc42 remains aligned with the selected model.
-- ADR need is explicitly resolved.
-
-Verification Commands:
-
-- `git diff --check`
-
-### Slice 02 - Central Port Registry Contract
+### Slice 02 - Default Human Output And Explicit JSON Gate
 
 Purpose:
 
-- Add a central desired-state port registry under `infra/config` with range definitions, service mappings, external/internal semantics, exposure class, and ownership metadata.
-
-Prerequisites:
-
-- Slice 01 completed.
+- Remove default raw JSON emission from the CLI while preserving an explicit
+  machine-readable path.
 
 ```yaml
 slice_id: "02"
-profile: "FULL_PATH"
+profile: "NORMAL_PATH"
 owner: "Senior Python Automation Developer"
 secondary_reviewers:
-  - "Senior System Architect"
   - "Senior Tester"
+  - "Senior System Architect"
 affected_files:
-  - "infra/config/ports.yaml"
-  - "src/tiny_swarm_world/domain/preflight/setup_manifest.py"
-  - "src/tiny_swarm_world/domain/network/port_forwarding_plan.py"
-  - "tests/domain/preflight/test_preflight_result.py"
-  - "tests/domain/network/test_port_forwarding_plan.py"
+  - "src/tiny_swarm_world/__main__.py"
+  - "tests/test_package_entrypoint.py"
 affected_modules:
-  - "tiny_swarm_world.domain.preflight"
-  - "tiny_swarm_world.domain.network"
+  - "tiny_swarm_world.__main__"
 affected_contracts:
-  - "Port registry schema"
+  - "CLI stdout contract"
 dependencies:
   - "01"
-parallel_group: "backend"
+parallel_group: "implementation"
 file_locks:
-  - "infra/config/ports.yaml"
-  - "src/tiny_swarm_world/domain/**"
-  - "tests/domain/**"
+  - "src/tiny_swarm_world/__main__.py"
+  - "tests/test_package_entrypoint.py"
 contract_locks:
-  - "port registry schema"
+  - "default CLI output"
 architecture_locks:
-  - "domain parser-independent model"
+  - "console formatting remains outside domain/application"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result"
+    - "PYTHONPATH=src python -m unittest tests.test_package_entrypoint"
   required:
-    - "python3 tools/quality_gate.py quality"
+    - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "Concepts may need a port registry summary."
-  adr: "Not expected unless ingress baseline changes."
+  arc42: "N/A"
+  adr: "Existing installer console reporting ADR remains valid."
 stop_conditions:
-  - "Stop if the registry would contain host-specific IP addresses, secrets, or credential-bearing URLs."
-  - "Stop if domain code would parse YAML directly."
+  - "Stop if the fix requires application or domain changes."
+  - "Stop if raw JSON remains on default stdout after tests."
 ```
 
-Done Criteria:
-
-- Port ranges and service port entries are centrally declared.
-- Duplicate external ports are rejected by tests.
-- Internal container ports can remain service defaults while external mappings are governed.
-
-Verification Commands:
-
-- `PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan tests.domain.preflight.test_preflight_result`
-
-### Slice 03 - Port Registry Repository And Preflight Integration
+### Slice 03 - Final Verification And Consolidation Evidence
 
 Purpose:
 
-- Load the port registry through an application repository port and infrastructure YAML adapter, then integrate required host-port checks into setup preflight planning.
-
-Prerequisites:
-
-- Slice 02 completed.
+- Execute focused verification and prove the final state.
 
 ```yaml
 slice_id: "03"
-profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
-secondary_reviewers:
-  - "Senior Tester"
-  - "Senior DevOps Engineer"
-affected_files:
-  - "src/tiny_swarm_world/application/ports/repositories/port_port_registry_repository.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/port_registry_yaml_repository.py"
-  - "src/tiny_swarm_world/application/services/platform/preflight_service.py"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py"
-  - "tests/application/services/platform/test_preflight_service.py"
-affected_modules:
-  - "tiny_swarm_world.application.ports.repositories"
-  - "tiny_swarm_world.infrastructure.adapters.repositories"
-  - "tiny_swarm_world.application.services.platform"
-affected_contracts:
-  - "setup preflight port availability"
-dependencies:
-  - "02"
-parallel_group: "backend"
-file_locks:
-  - "src/tiny_swarm_world/application/ports/repositories/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/**"
-  - "src/tiny_swarm_world/application/services/platform/preflight_service.py"
-  - "src/tiny_swarm_world/infrastructure/composition.py"
-  - "tests/infrastructure/adapters/repositories/**"
-  - "tests/application/services/platform/test_preflight_service.py"
-contract_locks:
-  - "port registry repository contract"
-  - "preflight blocker semantics"
-architecture_locks:
-  - "application depends on ports, infrastructure implements adapters"
-quality_gates:
-  targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository tests.application.services.platform.test_preflight_service"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "Update concepts/building blocks if a new repository port is introduced."
-  adr: "Not expected."
-stop_conditions:
-  - "Stop if preflight executes live networking commands in default tests."
-  - "Stop if infrastructure repository details leak into domain or application models."
-```
-
-Done Criteria:
-
-- Registry YAML loads via infrastructure adapter.
-- Application preflight can report port conflicts as blockers.
-- Tests use fakes/mocks and no live socket mutation.
-
-Verification Commands:
-
-- `PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.repositories.test_port_registry_yaml_repository tests.application.services.platform.test_preflight_service`
-
-### Slice 04 - Installation Phase Registry And Dependency Graph
-
-Purpose:
-
-- Add a central phase plan for setup order and validate acyclic dependencies for preflight, platform, cluster, network/routing, secrets, artifacts, CI/CD, quality, messaging, observability, control, docs, and validation phases.
-
-Prerequisites:
-
-- Slice 01 completed.
-
-```yaml
-slice_id: "04"
-profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
-secondary_reviewers:
-  - "Senior Requirement Engineer"
-  - "Senior Tester"
-affected_files:
-  - "infra/config/installation-plan.yaml"
-  - "src/tiny_swarm_world/domain/preflight/setup_manifest.py"
-  - "src/tiny_swarm_world/application/services/setup/workflow.py"
-  - "tests/application/services/setup/test_setup_workflow.py"
-  - "tests/domain/preflight/test_preflight_result.py"
-affected_modules:
-  - "tiny_swarm_world.domain.preflight"
-  - "tiny_swarm_world.application.services.setup"
-affected_contracts:
-  - "installation phase registry"
-  - "setup phase sequencing"
-dependencies:
-  - "01"
-parallel_group: "backend"
-file_locks:
-  - "infra/config/installation-plan.yaml"
-  - "src/tiny_swarm_world/domain/preflight/**"
-  - "src/tiny_swarm_world/application/services/setup/**"
-  - "tests/application/services/setup/**"
-contract_locks:
-  - "setup workflow phase order"
-architecture_locks:
-  - "fail-closed setup orchestration"
-quality_gates:
-  targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.application.services.setup.test_setup_workflow tests.domain.preflight.test_preflight_result"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "Runtime/deployment view should summarize ordered setup phases."
-  adr: "Not expected."
-stop_conditions:
-  - "Stop if dependency cycles exist."
-  - "Stop if a missing phase verification path can still report success."
-```
-
-Done Criteria:
-
-- Installation phases are declared centrally.
-- Phase dependencies sort deterministically.
-- Cycle and missing-required-service cases fail closed.
-
-Verification Commands:
-
-- `PYTHONPATH=src python3 -m unittest tests.application.services.setup.test_setup_workflow tests.domain.preflight.test_preflight_result`
-
-### Slice 05 - Service Registry And Stack Alignment
-
-Purpose:
-
-- Align service stack contracts, desired inventory, compose stack metadata, and registry service names so each selected service has a phase, dependency, port classification, and readiness target.
-
-Prerequisites:
-
-- Slices 02 and 04 completed.
-
-```yaml
-slice_id: "05"
-profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
-secondary_reviewers:
-  - "Senior DevOps Engineer"
-  - "Senior Tester"
-affected_files:
-  - "infra/config/services.yml"
-  - "infra/config/inventory/desired_inventory.yaml"
-  - "infra/config/compose/**/docker-compose.yml"
-  - "src/tiny_swarm_world/domain/deployment/service_stack_contract.py"
-  - "src/tiny_swarm_world/application/services/deployment/service_stack_plan.py"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
-  - "tests/domain/deployment/test_service_stack_contract.py"
-  - "tests/application/services/deployment/test_service_stack_plan.py"
-  - "tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py"
-affected_modules:
-  - "tiny_swarm_world.domain.deployment"
-  - "tiny_swarm_world.application.services.deployment"
-  - "tiny_swarm_world.infrastructure.adapters.repositories"
-affected_contracts:
-  - "service stack contract"
-  - "compose published port extraction"
-  - "desired inventory selected stacks"
-dependencies:
-  - "02"
-  - "04"
-parallel_group: "runtime"
-file_locks:
-  - "infra/config/services.yml"
-  - "infra/config/inventory/desired_inventory.yaml"
-  - "infra/config/compose/**"
-  - "src/tiny_swarm_world/domain/deployment/**"
-  - "src/tiny_swarm_world/application/services/deployment/**"
-  - "src/tiny_swarm_world/infrastructure/adapters/repositories/compose_file_repository_yaml.py"
-contract_locks:
-  - "service stack registry"
-  - "compose stack port mapping"
-architecture_locks:
-  - "Deployment responsibility boundary"
-quality_gates:
-  targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.domain.deployment.test_service_stack_contract tests.application.services.deployment.test_service_stack_plan tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "Update deployment view when direct published ports change or are reclassified."
-  adr: "Required if service exposure model changes beyond documented Traefik/direct-port compatibility."
-stop_conditions:
-  - "Stop if Portainer becomes a bootstrap dependency for Portainer."
-  - "Stop if service readiness is claimed from static config alone."
-  - "Stop if RabbitMQ is added without service-stack contract, compose, tests, and docs."
-```
-
-Done Criteria:
-
-- Selected services map to registry entries and phases.
-- Compose published ports are either registry-backed, ingress-owned, or explicitly deferred.
-- Current Pulsar baseline and any RabbitMQ decision are explicit.
-
-Verification Commands:
-
-- `PYTHONPATH=src python3 -m unittest tests.domain.deployment.test_service_stack_contract tests.application.services.deployment.test_service_stack_plan tests.infrastructure.adapters.repositories.test_compose_file_repository_yaml`
-
-### Slice 06 - Health Check And Validation Plan Registry
-
-Purpose:
-
-- Add health-check and validation-plan declarations that distinguish static readiness plans from observed runtime evidence.
-
-Prerequisites:
-
-- Slices 04 and 05 completed.
-
-```yaml
-slice_id: "06"
-profile: "FULL_PATH"
-owner: "Senior Python Automation Developer"
-secondary_reviewers:
-  - "Senior Tester"
-  - "Senior DevOps Engineer"
-affected_files:
-  - "infra/config/health-checks.yaml"
-  - "infra/config/validation-plan.yaml"
-  - "src/tiny_swarm_world/application/services/deployment/verify_swarm_service_readiness.py"
-  - "src/tiny_swarm_world/application/services/deployment/workflows.py"
-  - "tests/application/services/deployment/test_verify_swarm_service_readiness.py"
-  - "tests/application/services/deployment/test_deployment_workflows.py"
-affected_modules:
-  - "tiny_swarm_world.application.services.deployment"
-affected_contracts:
-  - "health check registry"
-  - "greenpath validation plan"
-dependencies:
-  - "04"
-  - "05"
-parallel_group: "quality"
-file_locks:
-  - "infra/config/health-checks.yaml"
-  - "infra/config/validation-plan.yaml"
-  - "src/tiny_swarm_world/application/services/deployment/**"
-  - "tests/application/services/deployment/**"
-contract_locks:
-  - "service readiness evidence semantics"
-architecture_locks:
-  - "observed-state evidence remains local and redacted"
-quality_gates:
-  targeted:
-    - "PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_verify_swarm_service_readiness tests.application.services.deployment.test_deployment_workflows"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "Update quality requirements with validation-plan fail-closed behavior."
-  adr: "Not expected."
-stop_conditions:
-  - "Stop if HTTP checks are documented as live default quality gates."
-  - "Stop if missing observed evidence reports healthy."
-```
-
-Done Criteria:
-
-- Health checks and greenpath validation steps are centrally declared.
-- Runtime evidence remains separate from desired checks.
-- Tests prove missing evidence fails closed.
-
-Verification Commands:
-
-- `PYTHONPATH=src python3 -m unittest tests.application.services.deployment.test_verify_swarm_service_readiness tests.application.services.deployment.test_deployment_workflows`
-
-### Slice 07 - Operator Documentation And Arc42 Synchronization
-
-Purpose:
-
-- Update operator docs, arc42, and EPIC references to explain the installation phase model, port registry, current Traefik ingress baseline, and validation semantics.
-
-Prerequisites:
-
-- Slices 02 through 06 completed or explicitly skipped with evidence.
-
-```yaml
-slice_id: "07"
-profile: "FULL_PATH"
-owner: "Senior Documentation Engineer"
-secondary_reviewers:
-  - "Senior System Architect"
-  - "Senior Requirement Engineer"
-  - "Senior Tester"
-affected_files:
-  - "README.md"
-  - "documentation/deployment/system.adoc"
-  - "documentation/system/lxc-native-setup.adoc"
-  - "documentation/configuration/config-contract-inventory.md"
-  - "documentation/arc42/05_building_blocks.adoc"
-  - "documentation/arc42/06_runtime_view.adoc"
-  - "documentation/arc42/07_deployment_view.adoc"
-  - "documentation/arc42/08_concepts.adoc"
-  - "documentation/arc42/10_quality_requirements.adoc"
-  - "documentation/epics/autonomous-runnable-setup.md"
-affected_modules: []
-affected_contracts:
-  - "operator setup documentation"
-dependencies:
-  - "02"
-  - "03"
-  - "04"
-  - "05"
-  - "06"
-parallel_group: "documentation"
-file_locks:
-  - "README.md"
-  - "documentation/**"
-contract_locks:
-  - "documented setup behavior"
-architecture_locks:
-  - "arc42 deployment and concept consistency"
-quality_gates:
-  targeted:
-    - "git diff --check"
-  required:
-    - "python3 tools/quality_gate.py quality"
-documentation:
-  arc42: "Must be synchronized."
-  adr: "Only if execution changed accepted architecture decisions."
-stop_conditions:
-  - "Stop if docs would claim live installation or health without evidence."
-  - "Stop if docs use Windows-specific setup commands or paths."
-```
-
-Done Criteria:
-
-- Documentation describes implemented behavior only.
-- Planned services remain clearly marked as planned, optional, or deferred.
-- arc42 is consistent with registry and setup behavior.
-
-Verification Commands:
-
-- `git diff --check`
-
-### Slice 08 - Full Quality Gate And Execution Handoff
-
-Purpose:
-
-- Run final verification, classify any failures through repository quality rules, and prepare the workflow evidence for commit/push readiness if requested.
-
-Prerequisites:
-
-- Slices 01 through 07 completed or explicitly stopped with evidence.
-
-```yaml
-slice_id: "08"
-profile: "FULL_PATH"
+profile: "NORMAL_PATH"
 owner: "Senior Tester"
 secondary_reviewers:
-  - "Quality Gate Orchestrator"
   - "Senior Workflow Architect"
 affected_files:
-  - ".codex/evidence/workflow-install-order-and-port-allocation-20260620/**"
-  - "documentation/workflow/context-pack.md"
-  - "documentation/workflow/context-pack.json"
+  - ".codex/evidence/workflow-console-output-issue-151-20260621/slice-02-distribution.md"
+  - ".codex/evidence/workflow-console-output-issue-151-20260621/slice-02-consolidation.md"
 affected_modules: []
 affected_contracts:
-  - "quality gate evidence"
+  - "verification evidence"
 dependencies:
-  - "07"
-parallel_group: "quality"
+  - "02"
+parallel_group: "verification"
 file_locks:
-  - ".codex/evidence/workflow-install-order-and-port-allocation-20260620/**"
-  - "documentation/workflow/**"
+  - ".codex/evidence/workflow-console-output-issue-151-20260621/**"
 contract_locks:
-  - "workflow execute evidence"
+  - "verification proof"
 architecture_locks: []
 quality_gates:
   targeted:
-    - "git diff --check"
+    - "PYTHONPATH=src python -m unittest tests.test_package_entrypoint"
+    - "PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui"
   required:
-    - "python3 tools/quality_gate.py quality"
+    - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "Confirm synchronized."
-  adr: "Confirm no missing ADR remains."
+  arc42: "N/A"
+  adr: "N/A"
 stop_conditions:
-  - "Stop on failed or unverifiable required quality gate."
-  - "Stop if generated local artifacts, caches, logs, or secrets appear in git status."
+  - "Stop if the chosen Python executable cannot run the targeted tests."
 ```
-
-Done Criteria:
-
-- Required gates are run or explicitly justified if skipped.
-- Evidence records targeted and full gate outcomes.
-- No generated local state is staged.
-
-Verification Commands:
-
-- `python3 tools/quality_gate.py quality`
-
-## Slice Dependency Graph
-
-```text
-01
-|\
-| +-- 04
-|     \
-02 ----+-- 05 -- 06 -- 07 -- 08
-  \
-   +-- 03
-```
-
-Execution order:
-
-1. Slice 01
-2. Slice 02 and Slice 04 may run after Slice 01 if isolated worktrees are used and file locks are disjoint.
-3. Slice 03 may run after Slice 02.
-4. Slice 05 waits for Slices 02 and 04.
-5. Slice 06 waits for Slices 04 and 05.
-6. Slice 07 waits for implementation slices.
-7. Slice 08 runs last.
-
-## Parallel Execution
-
-- Can this workflow run in parallel? `limited`
-- Conflicting workflows: any workflow that touches `infra/config/**`, setup/deployment services, compose stack contracts, `documentation/arc42/**`, or service-access/Traefik ingress.
-- Shared files: `src/tiny_swarm_world/infrastructure/composition.py`, `src/tiny_swarm_world/domain/preflight/setup_manifest.py`, `src/tiny_swarm_world/domain/deployment/service_stack_contract.py`, `infra/config/compose/**`, `documentation/arc42/**`.
-- Shared infrastructure: LXC/LXD/Incus, Docker Swarm, compose stacks, Portainer, Nexus, Jenkins, SonarQube, Infisical, Pulsar, service-access, Traefik.
-- Requires isolated worktree: `yes`
-- Requires serialized live validation: `yes`
-- Merge-order constraints: architecture and registry contracts before consumers; documentation after behavior; final quality last.
-
-Parallelization Opportunities:
-
-- Slice 02 and Slice 04 may be split after Slice 01 if Three Amigos confirms disjoint files.
-- Slice 03 can run in parallel with Slice 04 after Slice 02 only if setup manifest files are not shared.
-- Documentation drafting for Slice 07 may begin read-only earlier, but writes wait until implementation behavior is known.
 
 ## Automatic Work Distribution Policy
 
-During `workflow execute`, Codex must analyze every slice for safe specialist stream decomposition before implementation.
-
-Stream map:
-
-- backend: Senior Python Automation Developer for domain, application, ports, repositories, and composition.
-- frontend: console/status UI skills for terminal/status output; browser React impact check is N/A unless a verified frontend module exists.
-- tests: Senior Tester and quality-gate skills.
-- runtime: Senior DevOps Engineer for compose, Docker Swarm, LXC exposure, and service-stack runtime contracts.
-- documentation: Senior Documentation Engineer.
-- quality: Quality Gate Orchestrator and Senior Tester.
-- architecture: Senior System Architect and arc42 governance.
-- security: security and secrets/configuration review where port exposure, credentials, or evidence are touched.
-
-`workflow execute` must use real Codex subagents where supported. If callable subagents are unavailable, the executor must perform explicit role-based fallback review in the main thread and record that fallback in `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-distribution.md`.
-
-Evidence governance:
-
-- Evidence files must never be written directly into `.codex/evidence/` using generic slice names.
-- Every workflow must write evidence into its dedicated workflow-specific subdirectory.
-- This workflow writes evidence only under `.codex/evidence/workflow-install-order-and-port-allocation-20260620/`.
-- Forbidden generic paths include `.codex/evidence/slice-01-distribution.md` and `.codex/evidence/slice-01-consolidation.md`.
-
-Evidence collision preflight guard:
-
-- Before writing evidence, check whether the target file already exists.
-- If the target file exists and belongs to another workflow, stop and report a blocker.
-- Do not overwrite, modify, truncate, rename, or delete evidence belonging to another workflow.
-- Existing generic evidence files for unrelated workflows must remain unchanged.
-
-Before implementation for each slice:
-
-- write `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-distribution.md`;
-- record whether the slice can be split into backend, frontend, tests, runtime, documentation, quality, architecture, or security streams;
-- record file locks, contract locks, and stop conditions.
-
-After implementation for each implemented slice:
-
-- write `.codex/evidence/workflow-install-order-and-port-allocation-20260620/slice-<number>-consolidation.md`;
-- record accepted stream changes, rejected changes, tests run, and remaining risk.
-
-Non-parallelization rules:
-
-- Do not parallelize overlapping files.
-- Do not parallelize unclear architecture boundaries.
-- Do not parallelize contradictory requirements.
-- Do not parallelize mandatory ordering.
-- Do not parallelize shared migrations or strict schema/config sequencing.
-- Do not parallelize generated-file conflicts.
-- Do not parallelize when Three Amigos marks the slice not safely parallelizable.
-- Do not parallelize unclear secrets handling.
-- Do not parallelize weakened safety guards.
-
-Codex remains final integration owner for consolidation, tests, evidence, PR readiness, and merge readiness.
-
-## Git Worktree Execution Rule
-
-Every executable stream must use an isolated worktree and stream branch when parallelized.
-
-Stream branch format:
-
-```text
-feature/workflow-installation-phases-port-registry-20260620-slice-<number>-<stream>
-```
-
-Rules:
-
-- Verify the stream branch belongs to this workflow before writing.
-- Do not implement on `main`, `master`, `develop`, or shared branches.
-- Stream workers must not merge directly into the main workflow branch.
-- Codex consolidates stream results into `feature/workflow-installation-phases-port-registry-20260620` after evidence and tests pass.
-- Live validation is serialized unless isolated disposable infrastructure is explicitly approved.
-
-## Role Ownership Map
-
-- Senior Workflow Architect: workflow dependency ordering and execution handoff.
-- Senior Requirement Engineer: requirement drift, EPIC fit, open assumptions.
-- Senior System Architect: architecture boundaries, Traefik/port model, ADR need.
-- Senior Python Automation Developer: domain, application, repositories, composition, tests.
-- Senior React Frontend Developer: mandatory impact check; no React scope approved.
-- Senior Tester: regression design and quality gate evidence.
-- Senior DevOps Engineer: compose, Swarm, LXC exposure, service-stack runtime contracts.
-- Senior Documentation Engineer: README, arc42, deployment/system docs.
-- Security reviewer: secrets, credential references, port exposure, evidence redaction.
-
-## Quality Gate Expectations
-
-Use commands from `QUALITY.md` only.
-
-Targeted gates:
-
-- `git diff --check` for documentation-only slices.
-- `PYTHONPATH=src python3 -m unittest <nearest test modules>` for implementation slices.
-
-Required final gate:
-
-```bash
-python3 tools/quality_gate.py quality
-```
-
-The default quality gate must not execute live infrastructure commands.
-
-## Documentation Synchronization Points
-
-- Slice 01: arc42 and ADR check for port model.
-- Slice 05: deployment view if compose published ports or service stack endpoint behavior changes.
-- Slice 06: quality requirements if validation evidence semantics change.
-- Slice 07: README, deployment docs, system docs, configuration docs, EPIC notes, and arc42 synchronization.
-
-## Stop Conditions
-
-Stop workflow execution if:
-
-- active branch is not the workflow branch or its approved stream branch;
-- a slice would touch files outside its allowed scope;
-- Traefik ingress would be replaced without ADR coverage;
-- live infrastructure commands would be required without explicit approval;
-- domain/application/infrastructure dependency direction would be violated;
-- service health would be claimed without observed-state or smoke evidence;
-- secrets, tokens, local IP addresses, local absolute paths, or raw command output would be committed or persisted as evidence;
-- RabbitMQ is added without explicit service-stack contract, compose, tests, and docs;
-- quality commands cannot be verified from `QUALITY.md`;
-- unrelated local changes appear and ownership is unclear.
-
-## Uncertainty Escalation Rules
-
-- Port model conflict: escalate to Senior System Architect and ADR steward.
-- Pulsar vs RabbitMQ service-selection conflict: escalate to Senior Requirement Engineer and Senior System Architect.
-- Secret-handling uncertainty: escalate to security and secrets/configuration review.
-- Quality gate uncertainty: escalate to Senior Tester and Quality Gate Orchestrator.
-- Branch or file-lock conflict: escalate to Senior Workflow Architect and conflict-resolution skill.
-
-## Commit And Push Plan
-
-- Do not commit or push during workflow creation unless explicitly requested.
-- During `workflow execute`, each slice commit must represent exactly one slice.
-- `push auto` is not implied by this workflow. If later requested, it must run the full guarded lifecycle described in root `AGENTS.md`.
+- Slice `02` is safe for parallel analysis only.
+- Real subagents are used for the initial issue-state proof.
+- Final code edits stay sequential because `src/tiny_swarm_world/__main__.py`
+  and `tests/test_package_entrypoint.py` are tightly coupled.
 
 ## Definition Of Done
 
-- `documentation/workflow/workflow.md` exists and validates against workflow-authoring structure.
-- `documentation/workflow/context-pack.md` and `documentation/workflow/context-pack.json` exist.
-- Branch evidence is recorded.
-- Slices include YAML metadata, dependencies, file locks, quality gates, documentation impact, and stop conditions.
-- arc42 check status is recorded.
-- `workflow execute` can start from this workflow without guessing scope.
+- Issue `#143` proven already implemented from repository evidence.
+- Issue `#151` default JSON emission removed from normal CLI output.
+- Explicit JSON mode available and covered by tests.
+- Evidence files written under the workflow evidence root.
 
 ## Handoff To Workflow Execute
 
-`workflow execute` may proceed after verifying:
-
-- active branch is `feature/workflow-installation-phases-port-registry-20260620`;
-- `documentation/workflow/context-pack.json` hashes still match governing files;
-- no unrelated or unclear local changes exist;
-- slice metadata is intact;
-- S3/S3D preflight confirms dependency order and file locks;
-- live infrastructure commands remain out of default gates unless explicitly approved.
-
-## arc42 Check Status
-
-Checked during workflow creation:
-
-- `documentation/arc42/05_building_blocks.adoc`
-- `documentation/arc42/07_deployment_view.adoc`
-- `documentation/arc42/08_concepts.adoc`
-- `documentation/arc42/09_architecture_decisions.adoc`
-- `documentation/arc42/10_quality_requirements.adoc`
-
-Result:
-
-- arc42 already documents the current Traefik `80/443` ingress baseline, desired/observed state separation, evidence redaction, and service-access profile boundaries.
-- No arc42 file was changed during workflow creation.
-- Slice 01 and Slice 07 are responsible for arc42 updates during execution if implementation changes behavior or documented contracts.
+- Execute slices in order `01 -> 02 -> 03`.
+- Do not invoke live infrastructure commands.

--- a/src/tiny_swarm_world/__main__.py
+++ b/src/tiny_swarm_world/__main__.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -128,6 +129,11 @@ def parse_args(argv: Sequence[str] | None = None) -> Namespace:
         ),
     )
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit structured JSON workflow results instead of the default human-readable summary.",
+    )
+    parser.add_argument(
         "--confirm",
         help="Exact confirmation phrase required by destructive workflows.",
     )
@@ -190,7 +196,7 @@ async def main(argv: Sequence[str] | None = None) -> None:
         return
 
     _enforce_workflow_confirmation(workflow, args.confirm)
-    _enforce_workflow_implementation(workflow)
+    _enforce_workflow_implementation(workflow, args)
     live_consent = _live_consent_for_workflow(workflow, args)
 
     logger.info("Running workflow: %s", workflow.name)
@@ -207,9 +213,7 @@ async def main(argv: Sequence[str] | None = None) -> None:
         service_profile=args.service_profile,
         node_provider_request=node_provider_request,
     )
-    if isinstance(result, SetupWorkflowResult):
-        _print_setup_installation_summary(result)
-    print(json.dumps(_workflow_result_to_dict(result), indent=2, sort_keys=True))
+    _emit_workflow_result(result, args)
     if _workflow_status_value(result) != PlatformWorkflowStatus.COMPLETED.value:
         raise SystemExit(1)
 
@@ -233,8 +237,10 @@ async def _run_preflight_command(args: Namespace) -> None:
     )
     live_consent = _live_consent_from_args(args) if args.live else None
     result = await preflight.run(live_consent)
-    print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
-    _print_preflight_summary(result, live=args.live)
+    if _should_emit_json(args):
+        _emit_json_payload(result.to_dict())
+    else:
+        _print_preflight_summary(result, live=args.live)
     if not result.passed:
         raise SystemExit(1)
 
@@ -254,16 +260,14 @@ def _enforce_workflow_confirmation(workflow: CliWorkflow, confirmation: str | No
     raise SystemExit(2)
 
 
-def _enforce_workflow_implementation(workflow: CliWorkflow) -> None:
+def _enforce_workflow_implementation(workflow: CliWorkflow, args: Namespace) -> None:
     if workflow.implemented:
         return
-    print(
-        json.dumps(
-            _blocked_workflow_result(workflow),
-            indent=2,
-            sort_keys=True,
-        )
-    )
+    payload = _blocked_workflow_result(workflow)
+    if _should_emit_json(args):
+        _emit_json_payload(payload)
+    else:
+        _print_blocked_workflow_summary(payload)
     raise SystemExit(1)
 
 
@@ -395,11 +399,31 @@ def _workflow_result_to_dict(result: WorkflowResult) -> dict[str, object]:
     return result.to_dict()
 
 
+def _emit_workflow_result(result: WorkflowResult, args: Namespace) -> None:
+    if _should_emit_json(args):
+        _emit_json_payload(_workflow_result_to_dict(result))
+        return
+    if isinstance(result, SetupWorkflowResult):
+        _print_setup_installation_summary(result)
+        return
+    _print_workflow_summary(result)
+
+
+def _emit_json_payload(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def _workflow_status_value(result: WorkflowResult) -> str:
     status = result.status
     if isinstance(status, Enum):
         return str(status.value)
     return str(status)
+
+
+def _should_emit_json(args: Namespace) -> bool:
+    if bool(args.json):
+        return True
+    return os.environ.get("TSW_DEBUG_JSON", "").strip().lower() == "true"
 
 
 def _blocked_workflow_result(workflow: CliWorkflow) -> dict[str, object]:
@@ -409,6 +433,35 @@ def _blocked_workflow_result(workflow: CliWorkflow) -> dict[str, object]:
         "status": "blocked",
         "workflow": workflow.name,
     }
+
+
+def _print_blocked_workflow_summary(payload: dict[str, object]) -> None:
+    print()
+    print(f"Workflow: {payload['workflow']}")
+    print(f"Status: {payload['status']}")
+    print(f"Message: {payload['message']}")
+
+
+def _print_workflow_summary(result: WorkflowResult) -> None:
+    print()
+    print(f"Workflow: {_workflow_name(result)}")
+    print(f"Status: {_workflow_status_value(result)}")
+    print(f"Executed: {'yes' if result.executed else 'no'}")
+    message = getattr(result, "message", "")
+    if message:
+        print(f"Message: {message}")
+    reason = getattr(result, "reason", "")
+    if reason:
+        print(f"Reason: {reason}")
+    verification_results = getattr(result, "verification_results", ())
+    if verification_results:
+        print("Verification summary:")
+        for verification in verification_results:
+            print(f"- {verification.target_id}: {verification.status.value}")
+
+
+def _workflow_name(result: WorkflowResult) -> str:
+    return getattr(result, "workflow_name", _workflow_result_to_dict(result).get("workflow", "workflow"))
 
 
 def _live_consent_from_args(args: Namespace) -> LiveConsent:

--- a/tests/test_package_entrypoint.py
+++ b/tests/test_package_entrypoint.py
@@ -90,6 +90,12 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ServiceStackProfile.SERVICE_ACCESS.value, args.service_profile)
         self.assertEqual(NodeProviderKind.LXC_NATIVE.value, args.node_provider)
         self.assertIsNone(args.lxc_backend)
+        self.assertFalse(args.json)
+
+    def test_json_flag_enables_machine_readable_output(self):
+        args = entrypoint.parse_args(["--json"])
+
+        self.assertTrue(args.json)
 
     def test_lxc_backend_option_is_forwarded_as_provider_preference(self):
         args = entrypoint.parse_args(["--lxc-backend", "incus"])
@@ -163,7 +169,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
                     await entrypoint.main(["platform", "init", "--live"])
 
         workflows.init.run.assert_awaited_once_with()
-        self.assertIn('"workflow": "platform init"', output.getvalue())
+        self.assertIn("Workflow: platform init", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_mutating_workflow_accepts_explicit_noninteractive_live_approval(self):
         services, workflows = _application_services_with_platform_workflows()
@@ -175,7 +182,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
                     await entrypoint.main(["platform", "init", "--live", "--approve-live"])
 
         workflows.init.run.assert_awaited_once_with()
-        self.assertIn('"workflow": "platform init"', output.getvalue())
+        self.assertIn("Workflow: platform init", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_mutating_workflow_refuses_noninteractive_eof(self):
         output = io.StringIO()
@@ -202,7 +210,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         workflows.init.run.assert_awaited_once_with()
         workflows.reconcile.run.assert_not_awaited()
         workflows.expose.run.assert_not_awaited()
-        self.assertIn('"workflow": "platform init"', output.getvalue())
+        self.assertIn("Workflow: platform init", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_platform_reconcile_cli_output_reports_converged_outcome(self):
         reconcile_result = PlatformWorkflowResult(
@@ -231,7 +240,7 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         with patch.object(entrypoint, "build_application_services", return_value=services):
             with redirect_stdout(output):
                 await entrypoint.main(
-                    ["platform", "reconcile", "--live", "--approve-live"]
+                    ["platform", "reconcile", "--live", "--approve-live", "--json"]
                 )
 
         workflows.reconcile.run.assert_awaited_once_with()
@@ -250,7 +259,7 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
             with patch.object(entrypoint, "build_application_services", return_value=services):
                 with redirect_stdout(output):
                     with self.assertRaises(SystemExit) as raised:
-                        await entrypoint.main(["platform", "init", "--live"])
+                        await entrypoint.main(["platform", "init", "--live", "--json"])
 
         self.assertEqual(1, raised.exception.code)
         services.platform.preflight.run.assert_not_awaited()
@@ -279,7 +288,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         )
         workflows.verify.run.assert_awaited_once_with()
         workflows.init.run.assert_not_awaited()
-        self.assertIn('"workflow": "platform verify"', output.getvalue())
+        self.assertIn("Workflow: platform verify", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_explicit_lxc_backend_override_builds_provider_request(self):
         services, workflows = _application_services_with_platform_workflows()
@@ -311,7 +321,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
 
         workflows.expose.run.assert_awaited_once_with()
         workflows.init.run.assert_not_awaited()
-        self.assertIn('"workflow": "platform expose"', output.getvalue())
+        self.assertIn("Workflow: platform expose", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_platform_repair_lxc_proxy_drift_requires_live_consent_and_dispatches(self):
         services, workflows = _application_services_with_platform_workflows()
@@ -324,7 +335,8 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
 
         workflows.repair_lxc_proxy_drift.run.assert_awaited_once_with()
         workflows.expose.run.assert_not_awaited()
-        self.assertIn('"workflow": "platform repair-lxc-proxy-drift"', output.getvalue())
+        self.assertIn("Workflow: platform repair-lxc-proxy-drift", output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
 
     async def test_reset_refuses_missing_confirmation_before_building_services(self):
         output = io.StringIO()
@@ -463,9 +475,9 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
                                 with self.assertRaises(SystemExit) as raised:
                                     if requires_live:
                                         with patch("builtins.input", return_value="y"):
-                                            await entrypoint.main(command)
+                                            await entrypoint.main([*command, "--json"])
                                     else:
-                                        await entrypoint.main(command)
+                                        await entrypoint.main([*command, "--json"])
 
                 self.assertEqual(1, raised.exception.code)
                 build_application_services.assert_not_called()
@@ -511,7 +523,7 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
                 ):
                     with redirect_stdout(output):
                         with self.assertRaises(SystemExit) as raised:
-                            await entrypoint.main(["setup", "run", "--live"])
+                            await entrypoint.main(["setup", "run", "--live", "--json"])
 
         self.assertEqual(1, raised.exception.code)
         run_setup.assert_awaited_once()
@@ -557,9 +569,21 @@ class TestPackageEntrypoint(unittest.IsolatedAsyncioTestCase):
         )
         build_services.assert_not_called()
         preflight.run.assert_awaited_once_with(None)
-        self.assertIn('"status": "PASSED"', output.getvalue())
+        self.assertNotIn('{\n', output.getvalue())
+        self.assertIn("Preflight summary: PASSED", output.getvalue())
         self.assertIn("Static checks passed", output.getvalue())
         self.assertIn("does not claim live provider readiness", output.getvalue())
+
+    async def test_preflight_json_mode_emits_structured_payload(self):
+        preflight = SimpleNamespace(run=AsyncMock(return_value=_FakePreflightResult(True)))
+        output = io.StringIO()
+
+        with patch.object(entrypoint, "build_preflight_service", return_value=preflight):
+            with redirect_stdout(output):
+                await entrypoint.main(["--preflight", "--json"])
+
+        payload = _json_payload_from_output(output.getvalue())
+        self.assertEqual("PASSED", payload["status"])
 
     async def test_failed_preflight_exits_nonzero(self):
         preflight = SimpleNamespace(run=AsyncMock(return_value=_FakePreflightResult(False)))


### PR DESCRIPTION
## Summary
- gate workflow and preflight JSON output behind explicit `--json` or `TSW_DEBUG_JSON`
- keep default CLI output human-readable and update entrypoint regression tests
- record workflow-execute evidence proving issue #143 was already implemented and issue #151 was remediated

## Verification
- `git diff --check`
- `PYTHONPATH=src .venv/Scripts/python.exe -m unittest tests.test_package_entrypoint tests.infrastructure.adapters.ui.test_progress_trace_ui`
- `./.venv/Scripts/python.exe tools/quality_gate.py test` *(fails on unrelated repo/host platform issues; not claimed green)*

## Notes
- `documentation/user-handbook.adoc` was reviewed and did not require changes for this scope.
- workflow evidence lives under `.codex/evidence/workflow-console-output-issue-151-20260621/`.