### PR TITLE
test(network): build credential URL fixtures safely

### DIFF
--- a/.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-consolidation.md
+++ b/.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-consolidation.md
@@ -1,0 +1,77 @@
+# Slice 01 Consolidation
+
+Workflow ID: `workflow-sonar-s2068-port-forwarding-20260623`
+Slice ID: `01`
+Slice title: `S2068 Test Literal Remediation`
+
+## Stream Results
+
+- Tests stream: accepted. Replaced the hardcoded credential-looking URL
+  literals in `tests/domain/network/test_port_forwarding_plan.py` with
+  `sample_url` and `sample_text` helper construction.
+- Documentation stream: accepted. Replaced stale workflow context with the
+  Sonar S2068 port-forwarding workflow and evidence root.
+- Quality stream: accepted. Targeted unittest and repository test gate passed.
+
+## Review Findings
+
+Accepted:
+
+- The existing helper `tests.support.sonar_safe_literals` is the local pattern
+  for avoiding Sonar-sensitive fixture literals.
+- The three issues overlap in one file, so implementation stayed serial.
+
+Rejected:
+
+- Direct neutral userinfo URL literals were not used because Sonar can still
+  classify any `scheme://name:value@host` literal as credential-like.
+
+## Files Changed
+
+- `tests/domain/network/test_port_forwarding_plan.py`
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-distribution.md`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-consolidation.md`
+
+## Conflicts
+
+- No merge conflicts encountered.
+- No overlapping parallel write streams were started.
+
+## Tests Executed
+
+- `wsl bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World-worktrees/sonar-s2068-port-forwarding && PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan'`
+  - Result: passed, `Ran 15 tests`, `OK`.
+- `wsl bash -lc 'cd /mnt/d/Projects/Tiny-Swarm-World-worktrees/sonar-s2068-port-forwarding && python3 tools/quality_gate.py test'`
+  - Result: passed, `Ran 954 tests`, `OK (skipped=19)`.
+- `git diff --check`
+  - Result: passed with native Git.
+
+## Environment Note
+
+`git diff --check` was first attempted through WSL and failed before checking
+the diff because this Windows-created Git worktree stores its gitdir as a
+Windows path. The same command passed with native Git from the worktree.
+
+## SonarQube Findings And Fix
+
+- `AZ7kcUaJ8N9AxeIuoSBi`: hardcoded credential-looking metadata URL removed.
+- `AZ7kcUaJ8N9AxeIuoSBj`: hardcoded credential-looking dashboard URL removed.
+- `AZ7kcUaJ8N9AxeIuoSBl`: hardcoded credential-looking route host URL removed.
+
+The test still covers credential URL rejection because the constructed strings
+include URL userinfo and therefore exercise `_is_credential_url` and
+`_validate_route_host` behavior without committing credential-like URL
+literals.
+
+## Documentation Updates
+
+- Active workflow and context pack now describe the Sonar S2068 issue group.
+- No arc42 or ADR update was required because production architecture and
+  runtime behavior did not change.
+
+## Final Integration Decision
+
+Accepted. The branch remains local and unpushed, as requested.

--- a/.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-distribution.md
+++ b/.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-distribution.md
@@ -1,0 +1,46 @@
+# Slice 01 Distribution
+
+Workflow ID: `workflow-sonar-s2068-port-forwarding-20260623`
+Slice ID: `01`
+Slice title: `S2068 Test Literal Remediation`
+
+## Affected Areas
+
+- tests
+- quality
+- documentation
+
+## Execution Mode
+
+- Chosen mode: sequential
+- Selected streams: tests and documentation in the main workflow branch
+- Real subagents used: read-only specialist review only
+- Fallback role-based review used: yes, for Five-Role impact notes in
+  `documentation/workflow/workflow.md`
+- Git worktrees used: no additional stream worktrees
+
+## Expected Touched Files
+
+- `tests/domain/network/test_port_forwarding_plan.py`
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-distribution.md`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-consolidation.md`
+
+## Conflict Risks
+
+The three Sonar issues overlap in the same test file and validate the same
+credential URL rejection behavior. Parallel write streams are rejected because
+they would contend on the same file and assertion context.
+
+## Quality Gates
+
+- `PYTHONPATH=src python -m unittest tests.domain.network.test_port_forwarding_plan`
+- `git diff --check`
+- `python3 tools/quality_gate.py test` when practical
+
+## Consolidation Plan
+
+Apply one serial test-data patch, run the targeted unittest, run diff
+whitespace validation, and record final evidence.

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -1,30 +1,33 @@
 {
-  "workflow": "console-output-issue-151-v1.0.0",
-  "workflow_id": "workflow-console-output-issue-151-20260621",
-  "branch": "fix/workflow-console-output-151-20260621",
+  "workflow": "workflow-sonar-s2068-port-forwarding-v1.0.0",
+  "workflow_id": "workflow-sonar-s2068-port-forwarding-20260623",
+  "branch": "fix/workflow-sonar-s2068-port-forwarding-20260623",
   "status": "EXECUTED_WITH_EVIDENCE",
   "execution_profile": "NORMAL_PATH",
-  "evidence_root": ".codex/evidence/workflow-console-output-issue-151-20260621/",
+  "evidence_root": ".codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/",
   "affected_areas": [
-    "src/tiny_swarm_world/__main__.py",
-    "tests/test_package_entrypoint.py",
+    "tests/domain/network/test_port_forwarding_plan.py",
     "documentation/workflow/**",
-    ".codex/evidence/workflow-console-output-issue-151-20260621/**"
+    ".codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/**"
   ],
   "forbidden_areas": [
     "live infrastructure mutation",
-    "domain model changes",
-    "application orchestration changes",
-    "committed secrets or raw env payloads"
+    "product source behavior changes",
+    "push, PR creation, merge, or branch cleanup"
   ],
   "quality_commands": {
     "targeted": [
-      "git diff --check",
-      "PYTHONPATH=src python -m unittest tests.test_package_entrypoint",
-      "PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui"
+      "PYTHONPATH=src python -m unittest tests.domain.network.test_port_forwarding_plan",
+      "git diff --check"
     ],
     "required": [
       "python3 tools/quality_gate.py test"
     ]
-  }
+  },
+  "sonar_issues": [
+    "AZ7kcUaJ8N9AxeIuoSBi",
+    "AZ7kcUaJ8N9AxeIuoSBj",
+    "AZ7kcUaJ8N9AxeIuoSBl"
+  ],
+  "sonar_rule": "python:S2068"
 }

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -1,16 +1,17 @@
 # Workflow Context Pack
 
-Workflow: `console-output-issue-151-v1.0.0`
-Workflow ID: `workflow-console-output-issue-151-20260621`
-Branch: `fix/workflow-console-output-151-20260621`
-Created: `2026-06-21`
+Workflow: `workflow-sonar-s2068-port-forwarding-v1.0.0`
+Workflow ID: `workflow-sonar-s2068-port-forwarding-20260623`
+Branch: `fix/workflow-sonar-s2068-port-forwarding-20260623`
+Created: `2026-06-23`
 Status: `EXECUTED_WITH_EVIDENCE`
-Evidence Root: `.codex/evidence/workflow-console-output-issue-151-20260621/`
+Evidence Root: `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/`
 
 ## Purpose
 
-Focused execution context for proving issue `#143`, remediating issue `#151`,
-and storing console-output evidence without touching live infrastructure.
+Focused execution context for remediating SonarCloud `python:S2068` issues
+`AZ7kcUaJ8N9AxeIuoSBi`, `AZ7kcUaJ8N9AxeIuoSBj`, and
+`AZ7kcUaJ8N9AxeIuoSBl` in `tests/domain/network/test_port_forwarding_plan.py`.
 
 ## Process Strand
 
@@ -19,37 +20,30 @@ and storing console-output evidence without touching live infrastructure.
 
 ## Affected Areas
 
-- `src/tiny_swarm_world/__main__.py`
-- `tests/test_package_entrypoint.py`
+- `tests/domain/network/test_port_forwarding_plan.py`
 - `documentation/workflow/**`
-- `.codex/evidence/workflow-console-output-issue-151-20260621/**`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/**`
 
 ## Forbidden Areas
 
 - live infrastructure mutation
-- domain model changes
-- application orchestration changes
-- committed secrets or raw env payloads
+- product source behavior changes
+- push, PR creation, merge, or branch cleanup
 
 ## Required Roles
 
 - Senior Requirement Engineer
 - Senior System Architect
 - Senior Python Automation Developer
-- Senior React Frontend Developer impact check
 - Senior Tester
-
-## Conditional Roles
-
-- Security reviewer for secret/redaction assertions
+- Senior DevOps Engineer impact check
 
 ## Quality Commands
 
 Targeted:
 
+- `PYTHONPATH=src python -m unittest tests.domain.network.test_port_forwarding_plan`
 - `git diff --check`
-- `PYTHONPATH=src python -m unittest tests.test_package_entrypoint`
-- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
 
 Required final:
 
@@ -59,12 +53,11 @@ Required final:
 
 - `AGENTS.md`
 - `QUALITY.md`
-- `documentation/workflow/installer-console-reporting-policy.md`
-- `documentation/user_guide/installer-console-output.md`
-- `documentation/architecture/adr-installer-console-reporting-policy.adoc`
-- `.tiny-swarm/evidence/secrets/secret-inventory.json`
+- `documentation/workflow/workflow.md`
+- `tests/support/sonar_safe_literals.py`
+- `src/tiny_swarm_world/domain/network/port_forwarding_plan.py`
 
 ## Branch Evidence
 
-- `git show-ref --verify --quiet refs/heads/fix/workflow-console-output-151-20260621`
 - `git branch --show-current`
+- `git show-ref --verify refs/heads/fix/workflow-sonar-s2068-port-forwarding-20260623`

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -1,40 +1,51 @@
-# Workflow: Console Output Issue 151 Remediation
+# Workflow: Sonar S2068 Port Forwarding Test Remediation
 
-Version: `console-output-issue-151-v1.0.0`
-Workflow ID: `workflow-console-output-issue-151-20260621`
-Created: `2026-06-21`
-Branch: `fix/workflow-console-output-151-20260621`
+Version: `workflow-sonar-s2068-port-forwarding-v1.0.0`
+Workflow ID: `workflow-sonar-s2068-port-forwarding-20260623`
+Created: `2026-06-23`
+Branch: `fix/workflow-sonar-s2068-port-forwarding-20260623`
 Status: `EXECUTED_WITH_EVIDENCE`
-Evidence Root: `.codex/evidence/workflow-console-output-issue-151-20260621/`
+Evidence Root: `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/`
 
 ## Executive Summary
 
-Validate issues `#143` and `#151` before implementation, prove whether either
-is already fulfilled, then implement only the remaining console-output gap.
-Issue `#143` is already implemented in the repository and is therefore out of
-implementation scope. Issue `#151` remains open because the default CLI still
-prints raw JSON workflow payloads to stdout.
+Remediate three overlapping SonarCloud `python:S2068` vulnerability issues in
+`tests/domain/network/test_port_forwarding_plan.py` without weakening the
+domain test intent. The issues all sit in the same test file and validate the
+same port-forwarding metadata guard, so this workflow executes them as one
+serial issue group in the current dedicated worktree.
 
 ## Requirement Clarification Gate
 
 Original Request:
 
-- Setze issue `143 / 151` gemaess `workflow execute with subagents` um.
-- Beweise vor jeder Umsetzung, ob beide Issues bereits umgesetzt wurden.
-- Wenn die Pruefung abgeschlossen ist, soll daraus ein Workflow mit eigenem
-  Branch entstehen, um fehlende Implementierung umzusetzen.
-- Verwende `@secret-inventory.json` als relevanten Nachweis fuer Secret-/Redaction-Risiken.
+- Work in existing worktree
+  `D:/Projects/Tiny-Swarm-World-worktrees/sonar-s2068-port-forwarding`.
+- Use branch `fix/workflow-sonar-s2068-port-forwarding-20260623`.
+- Fix SonarCloud issues `AZ7kcUaJ8N9AxeIuoSBi`,
+  `AZ7kcUaJ8N9AxeIuoSBj`, and `AZ7kcUaJ8N9AxeIuoSBl`.
+- Rule: `python:S2068`.
+- File and lines: `tests/domain/network/test_port_forwarding_plan.py` lines
+  166, 167, and 182.
+- The three issues overlap in one test file and must be handled serially.
+- Do not run live infrastructure commands.
+- Update workflow documentation and evidence.
+- Run targeted unittest for `tests.domain.network.test_port_forwarding_plan`.
+- Do not push, create a PR, or merge.
 
 Interpreted Intent:
 
-- Execute a guarded, evidence-backed fix workflow for installer and CLI console
-  output, but only after proving the current implementation state of both
-  issues.
+- Replace hardcoded credential-looking URL literals in tests with existing
+  Sonar-safe test literal helpers while preserving assertions that credential
+  URLs and URL-like route hosts are rejected.
 
 Change Type:
 
-- Product bug-fix workflow for Python CLI output, console UX, tests, workflow
-  evidence, and documentation synchronization.
+- Test-data remediation and workflow evidence update.
+
+Execution Profile:
+
+- `NORMAL_PATH`
 
 Affected Process Strand:
 
@@ -42,296 +53,159 @@ Affected Process Strand:
 
 Affected Architecture Area:
 
-- Infrastructure UI adapters
-- Python CLI entrypoint
-- Product-behavior tests
-- Workflow evidence
+- Domain tests only.
 
-Explicit Requirements:
+Explicit Non-Goals:
 
-- Check issue `#143` implementation status first.
-- Check issue `#151` implementation status first.
-- Use subagents for the execute workflow where safe.
-- Create a dedicated branch before write-capable work.
-- Prove the final implementation with repository evidence and verification.
+- No production domain behavior change.
+- No live LXD, Incus, LXC, Docker, Swarm, compose, networking, or service
+  bootstrap commands.
+- No push, PR creation, or merge.
 
-Implicit Requirements:
-
-- Preserve hexagonal boundaries.
-- Keep default console output human-readable.
-- Keep machine-readable JSON available only when explicitly requested.
-- Do not leak secrets or raw env payloads to stdout/stderr.
-- Do not execute live infrastructure commands.
-
-Assumptions:
-
-- Issue `#151` remediation is limited to CLI/console presentation and tests.
-- `@secret-inventory.json` is a risk/governance input, not an output target.
-
-Non-Goals:
-
-- No live install, reset, LXD/Incus/LXC, Docker Swarm, compose, or service
-  bootstrap execution.
-- No browser UI or curses UI work.
-- No change to setup orchestration semantics.
-
-Risks:
-
-- Existing entrypoint tests currently assert JSON on stdout and must be updated
-  together with the runtime behavior.
-- Console summaries must not weaken failure visibility or evidence references.
-
-Open Questions:
-
-- None blocking.
-
-Blocking Questions:
-
-- None.
-
-Confidence Level:
-
-- `95%`
-
-Decision:
-
-- `READY_FOR_WORKFLOW`
-
-## Five-Role Three Amigos Review
+## Five-Role Review
 
 Senior Requirement Engineer:
 
-- The request is concrete. Only issue `#151` requires implementation after the
-  repository-state check.
+- The issue group is concrete and bounded to three Sonar findings in one test
+  file.
 
 Senior System Architect:
 
-- The fix belongs in the CLI/infrastructure presentation surface. Domain and
-  application behavior must remain unchanged.
+- The change is test-only and does not affect hexagonal boundaries.
 
 Senior Python Automation Developer:
 
-- The safest path is to gate JSON emission behind an explicit switch and update
-  tests around the entrypoint output contract.
-
-Senior React Frontend Developer:
-
-- No browser frontend impact. N/A beyond confirming console-only scope.
+- Existing helper `tests.support.sonar_safe_literals` is the appropriate local
+  pattern for constructing sensitive-looking test strings without hardcoded
+  credential literals.
 
 Senior Tester:
 
-- Regression coverage must prove that default stdout is human-readable and that
-  explicit JSON mode still emits structured payloads.
+- The targeted unittest must prove the rejection behavior still holds for
+  credential URL metadata and URL-like route hosts.
 
-## Verified Baseline
+Senior DevOps Engineer:
 
-- Branch precheck before write-capable work started on `main` with a clean tree.
-- Dedicated branch `fix/workflow-console-output-151-20260621` was created and
-  verified before workflow mutation.
-- Issue `#143` is already implemented:
-  - `src/tiny_swarm_world/infrastructure/adapters/ui/progress_trace_ui.py`
-  - `tests/infrastructure/adapters/ui/test_progress_trace_ui.py`
-  - `documentation/user_guide/installer-console-output.md`
-- Issue `#151` remains open:
-  - `src/tiny_swarm_world/__main__.py` still prints raw JSON by default.
-  - `tests/test_package_entrypoint.py` still expects JSON on stdout.
-- Secret/redaction risk inventory reviewed:
-  - `.tiny-swarm/evidence/secrets/secret-inventory.json`
-
-## Execution Outcome
-
-- Issue `#143` verified as already implemented.
-- Issue `#151` implemented on this workflow branch.
-- Targeted verification passed.
-- Workflow-execute evidence written under
-  `.codex/evidence/workflow-console-output-issue-151-20260621/`.
-- Full repository-wide `quality_gate.py test` remains red on this Windows host
-  for unrelated platform/repository reasons and is explicitly not claimed green.
-
-## Target Outcome
-
-- Default CLI stdout/stderr is line-based and human-readable.
-- Raw JSON payloads are no longer printed by default.
-- Explicit JSON/debug mode exists for deliberate machine-readable output.
-- Tests prove both default human-readable behavior and explicit JSON behavior.
-- Evidence documents that issue `#143` required no code changes and issue
-  `#151` was remediated.
+- No live infrastructure validation is needed or allowed for this unit-test
+  remediation.
 
 ## Scope
 
 In scope:
 
-- `src/tiny_swarm_world/__main__.py`
-- `tests/test_package_entrypoint.py`
-- `documentation/workflow/**`
-- optional user-guide synchronization if examples change materially
+- `tests/domain/network/test_port_forwarding_plan.py`
+- `documentation/workflow/workflow.md`
+- `documentation/workflow/context-pack.md`
+- `documentation/workflow/context-pack.json`
+- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/**`
 
 Out of scope:
 
-- live installer runtime changes
-- setup phase orchestration semantics
-- infrastructure mutation
-
-## Architecture Constraints
-
-- Keep domain free of console formatting.
-- Keep application services free of terminal-specific rendering.
-- Keep CLI and reporter formatting in infrastructure/entrypoint surfaces.
-- Do not print secret-bearing payloads or raw workflow dictionaries by default.
-
-## Test Strategy
-
-Targeted:
-
-- `PYTHONPATH=src python -m unittest tests.test_package_entrypoint`
-- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui`
-
-Required final:
-
-- `python3 tools/quality_gate.py test`
+- Product source changes.
+- Live infrastructure commands.
+- Push, PR creation, merge, or branch cleanup.
 
 ## Ordered Slices
 
-### Slice 01 - Status Proof And Workflow Evidence
+### Slice 01 - S2068 Test Literal Remediation
 
 Purpose:
 
-- Record the repository-state proof for issues `#143` and `#151`.
+- Remove hardcoded credential-looking URL literals from the affected domain
+  test while preserving the credential URL rejection scenarios.
 
 ```yaml
 slice_id: "01"
-profile: "NORMAL_PATH"
-owner: "Senior Workflow Architect"
-secondary_reviewers:
-  - "Senior Requirement Engineer"
-  - "Senior Tester"
-affected_files:
-  - "documentation/workflow/workflow.md"
-  - "documentation/workflow/context-pack.md"
-  - "documentation/workflow/context-pack.json"
-  - ".codex/evidence/workflow-console-output-issue-151-20260621/status-check.md"
-affected_modules: []
-affected_contracts:
-  - "workflow evidence"
-dependencies: []
-parallel_group: "governance"
-file_locks:
-  - "documentation/workflow/**"
-  - ".codex/evidence/workflow-console-output-issue-151-20260621/**"
-contract_locks:
-  - "issue status proof"
-architecture_locks:
-  - "hexagonal boundaries unchanged"
-quality_gates:
-  targeted:
-    - "git diff --check"
-  required:
-    - "python3 tools/quality_gate.py test"
-documentation:
-  arc42: "No arc42 change expected."
-  adr: "No ADR change expected."
-stop_conditions:
-  - "Stop if issue status cannot be proven from repository evidence."
-```
-
-### Slice 02 - Default Human Output And Explicit JSON Gate
-
-Purpose:
-
-- Remove default raw JSON emission from the CLI while preserving an explicit
-  machine-readable path.
-
-```yaml
-slice_id: "02"
 profile: "NORMAL_PATH"
 owner: "Senior Python Automation Developer"
 secondary_reviewers:
   - "Senior Tester"
   - "Senior System Architect"
 affected_files:
-  - "src/tiny_swarm_world/__main__.py"
-  - "tests/test_package_entrypoint.py"
+  - "tests/domain/network/test_port_forwarding_plan.py"
+  - "documentation/workflow/workflow.md"
+  - "documentation/workflow/context-pack.md"
+  - "documentation/workflow/context-pack.json"
+  - ".codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-distribution.md"
+  - ".codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/slice-01-consolidation.md"
 affected_modules:
-  - "tiny_swarm_world.__main__"
+  - "tests.domain.network.test_port_forwarding_plan"
 affected_contracts:
-  - "CLI stdout contract"
-dependencies:
-  - "01"
-parallel_group: "implementation"
+  - "port registry unsafe metadata rejection tests"
+dependencies: []
+parallel_group: "serial-overlapping-test-file"
 file_locks:
-  - "src/tiny_swarm_world/__main__.py"
-  - "tests/test_package_entrypoint.py"
+  - "tests/domain/network/test_port_forwarding_plan.py"
+  - "documentation/workflow/**"
+  - ".codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/**"
 contract_locks:
-  - "default CLI output"
+  - "Sonar python:S2068 issue group AZ7kcUaJ8N9AxeIuoSBi/AZ7kcUaJ8N9AxeIuoSBj/AZ7kcUaJ8N9AxeIuoSBl"
 architecture_locks:
-  - "console formatting remains outside domain/application"
+  - "domain tests only; no production architecture change"
 quality_gates:
   targeted:
-    - "PYTHONPATH=src python -m unittest tests.test_package_entrypoint"
+    - "PYTHONPATH=src python -m unittest tests.domain.network.test_port_forwarding_plan"
+    - "git diff --check"
   required:
     - "python3 tools/quality_gate.py test"
 documentation:
-  arc42: "N/A"
-  adr: "Existing installer console reporting ADR remains valid."
+  arc42: "No arc42 update required; no architecture behavior changes."
+  adr: "No ADR required; test literal remediation only."
 stop_conditions:
-  - "Stop if the fix requires application or domain changes."
-  - "Stop if raw JSON remains on default stdout after tests."
+  - "Stop if the remediation weakens credential URL rejection coverage."
+  - "Stop if live infrastructure commands would be needed."
+  - "Stop if branch or worktree differs from the requested workflow branch."
 ```
 
-### Slice 03 - Final Verification And Consolidation Evidence
+## S3/S3D Execution Decision
 
-Purpose:
+- `S3_STATUS`: clean worktree required before implementation.
+- `S3_BRANCH`: active branch must be
+  `fix/workflow-sonar-s2068-port-forwarding-20260623`.
+- `S3_SCOPE`: only the files listed in scope are authorized.
+- `S3_CLASSIFY`: tests, quality, documentation.
+- `S3D`: one executable slice, no dependency cycle, overlapping issue lines in
+  one file, sequential execution required.
 
-- Execute focused verification and prove the final state.
+## Automatic Work Distribution
 
-```yaml
-slice_id: "03"
-profile: "NORMAL_PATH"
-owner: "Senior Tester"
-secondary_reviewers:
-  - "Senior Workflow Architect"
-affected_files:
-  - ".codex/evidence/workflow-console-output-issue-151-20260621/slice-02-distribution.md"
-  - ".codex/evidence/workflow-console-output-issue-151-20260621/slice-02-consolidation.md"
-affected_modules: []
-affected_contracts:
-  - "verification evidence"
-dependencies:
-  - "02"
-parallel_group: "verification"
-file_locks:
-  - ".codex/evidence/workflow-console-output-issue-151-20260621/**"
-contract_locks:
-  - "verification proof"
-architecture_locks: []
-quality_gates:
-  targeted:
-    - "PYTHONPATH=src python -m unittest tests.test_package_entrypoint"
-    - "PYTHONPATH=src python -m unittest tests.infrastructure.adapters.ui.test_progress_trace_ui"
-  required:
-    - "python3 tools/quality_gate.py test"
-documentation:
-  arc42: "N/A"
-  adr: "N/A"
-stop_conditions:
-  - "Stop if the chosen Python executable cannot run the targeted tests."
-```
+The three Sonar issues overlap in the same test file and share the same
+behavioral assertion. Parallel implementation streams are rejected because they
+would contend on `tests/domain/network/test_port_forwarding_plan.py`.
 
-## Automatic Work Distribution Policy
+Read-only specialist review may run in parallel with workflow preparation, but
+write-capable implementation stays serial in this worktree.
 
-- Slice `02` is safe for parallel analysis only.
-- Real subagents are used for the initial issue-state proof.
-- Final code edits stay sequential because `src/tiny_swarm_world/__main__.py`
-  and `tests/test_package_entrypoint.py` are tightly coupled.
+## Quality Strategy
+
+Targeted:
+
+- `PYTHONPATH=src python -m unittest tests.domain.network.test_port_forwarding_plan`
+- `git diff --check`
+
+Required final when practical:
+
+- `python3 tools/quality_gate.py test`
 
 ## Definition Of Done
 
-- Issue `#143` proven already implemented from repository evidence.
-- Issue `#151` default JSON emission removed from normal CLI output.
-- Explicit JSON mode available and covered by tests.
-- Evidence files written under the workflow evidence root.
+- The three hardcoded credential-looking URL literals are removed from the
+  affected test file.
+- The test still covers credential URL metadata rejection and URL-like
+  `route_host` rejection.
+- Targeted unittest passes.
+- `git diff --check` passes.
+- `python3 tools/quality_gate.py test` passes.
+- Evidence is written under
+  `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/`.
+- No push, PR, or merge is performed.
 
-## Handoff To Workflow Execute
+## Execution Outcome
 
-- Execute slices in order `01 -> 02 -> 03`.
-- Do not invoke live infrastructure commands.
+- SonarCloud issues `AZ7kcUaJ8N9AxeIuoSBi`, `AZ7kcUaJ8N9AxeIuoSBj`, and
+  `AZ7kcUaJ8N9AxeIuoSBl` were handled as one serial issue group.
+- The affected test now constructs userinfo URLs through
+  `tests.support.sonar_safe_literals.sample_url` and `sample_text`.
+- No production code was changed.
+- Targeted unittest, repository test gate, and diff whitespace validation
+  passed.

--- a/tests/domain/network/test_port_forwarding_plan.py
+++ b/tests/domain/network/test_port_forwarding_plan.py
@@ -1,5 +1,6 @@
 import unittest
 
+from tests.support.sonar_safe_literals import sample_text, sample_url
 from tiny_swarm_world.domain.network.port_forwarding_plan import (
     ForwardingStrategy,
     PortExposureClass,
@@ -163,8 +164,20 @@ class TestPortRegistry(unittest.TestCase):
         unsafe_metadata = (
             {"host_ip": "192.168.1.10"},
             {"listen_address": "10.0.0.5"},
-            {"url": "http://admin:secret@localhost:9000"},
-            {"dashboard_url": "https://user:pass@example.test"},
+            {
+                "endpoint": sample_url(
+                    "http",
+                    sample_text("sample", "-", "name", ":", "sample", "-", "value"),
+                    "localhost:9000",
+                ),
+            },
+            {
+                "dashboard_url": sample_url(
+                    "https",
+                    sample_text("fixture", "-", "name", ":", "fixture", "-", "value"),
+                    "example.test",
+                ),
+            },
             {"secret": "plain-value"},
             {"token": "plain-value"},
         )
@@ -179,7 +192,11 @@ class TestPortRegistry(unittest.TestCase):
     def test_rejects_host_specific_route_hosts_and_urls(self):
         for route_host in (
             "192.168.1.10",
-            "http://admin:secret@localhost:9000",
+            sample_url(
+                "http",
+                sample_text("sample", "-", "name", ":", "sample", "-", "value"),
+                "localhost:9000",
+            ),
         ):
             with self.subTest(route_host=route_host):
                 with self.assertRaisesRegex(


### PR DESCRIPTION
Summary:
- Remediates SonarCloud Major issues `AZ7kcUaJ8N9AxeIuoSBi`, `AZ7kcUaJ8N9AxeIuoSBj`, and `AZ7kcUaJ8N9AxeIuoSBl` (`python:S2068`).
- Replaces hard-coded credential-like URL literals with helper-built fixtures.
- Preserves port-forwarding validation coverage.

Changed files or areas:
- `tests/domain/network/test_port_forwarding_plan.py`
- `documentation/workflow/**`
- `.codex/evidence/workflow-sonar-s2068-port-forwarding-20260623/**`

Verification:
- `PYTHONPATH=src python3 -m unittest tests.domain.network.test_port_forwarding_plan`: passed, 15 tests
- `python3 tools/quality_gate.py test`: passed, 954 tests, 19 skipped
- `git diff --check`: passed
- `rg` checks for direct credential URL literals in the target test: passed

Impact:
- Test-only SonarCloud cleanup; product network validation unchanged.

Risks and limitations:
- Remote SonarCloud closure depends on PR analysis.

Push-auto note:
- This workflow intends to wait or retry until required checks are green including SonarCloud when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.