### PR TITLE
fix(service-access): keep nginx pid writable

### DIFF
--- a/infra/config/compose/service-access/dashboard/Dockerfile
+++ b/infra/config/compose/service-access/dashboard/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:mainline-alpine
 
 RUN apk add --no-cache libcap \
+    && sed -i 's#pid[[:space:]]\+/run/nginx.pid;#pid /tmp/nginx.pid;#' /etc/nginx/nginx.conf \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && chown -R nginx:nginx /var/cache/nginx /var/run /var/log/nginx /usr/share/nginx/html
 

--- a/infra/config/compose/service-access/nginx/Dockerfile
+++ b/infra/config/compose/service-access/nginx/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:mainline-alpine
 
 RUN apk add --no-cache libcap openssl \
+    && sed -i 's#pid[[:space:]]\+/run/nginx.pid;#pid /tmp/nginx.pid;#' /etc/nginx/nginx.conf \
     && setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx \
     && mkdir -p /etc/nginx/tls \
     && chown -R nginx:nginx /var/cache/nginx /var/run /var/log/nginx /etc/nginx/conf.d /etc/nginx/tls

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -889,6 +889,7 @@ services:
                 self.assertIn(base_image_line, dockerfile)
                 self.assertIn(copy_line, dockerfile)
                 self.assertIn("USER nginx", dockerfile)
+                self.assertIn("pid /tmp/nginx.pid", dockerfile)
                 self.assertIn("setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx", dockerfile)
                 if service_name == "service-access-nginx":
                     self.assertIn("apk add --no-cache libcap openssl", dockerfile)


### PR DESCRIPTION
## Summary
- Move Service Access dashboard and proxy NGINX pid files to `/tmp/nginx.pid` during image build.
- Preserve non-root NGINX execution and existing bind-service capability setup.
- Add a repository packaging regression assertion for the writable pid path.

## Root Cause
Service Access containers run as non-root NGINX images. During live setup, NGINX attempted to write `/run/nginx.pid`, causing the dashboard and proxy tasks to exit with `Permission denied` and blocking deployment readiness.

## Verification
- `./install.sh --headless --confirm-reset --non-interactive-live-approval`: passed; final setup status completed.
- `python3 tools/quality_gate.py quality`: passed; lint, arch-lint, arch-tests, mypy, and 963 tests passed.
- SonarQube status endpoint `http://localhost:12000/api/system/status`: `UP`.
- Service Access dashboard `http://localhost:10000`: reachable.

## Impact
- Fixes live installation deployment readiness for Service Access.
- No API, schema, architecture boundary, or documentation contract changes.

## Push Auto
This `push auto` flow will wait for required checks, including SonarQube/SonarCloud when configured, merge the PR only after verification, delete the merged remote head branch, and run local cleanup after merge verification.