### PR TITLE
fix(platform): preserve backend timeout evidence

### DIFF
--- a/src/tiny_swarm_world/application/services/platform/node_provider_selection.py
+++ b/src/tiny_swarm_world/application/services/platform/node_provider_selection.py
@@ -341,6 +341,16 @@ def _blocked_backend_selection(readiness: ProviderReadiness) -> ManagedLxcBacken
         return backend_selection
 
     evidence = {"readiness_status": readiness.status.value}
+    remediation = readiness.remediation
+    if backend_selection is not None:
+        evidence.update(backend_selection.evidence)
+        remediation = _merge_remediation(backend_selection.remediation, remediation)
+        return ManagedLxcBackendSelection(
+            status=ManagedLxcBackendSelectionStatus.UNSUPPORTED,
+            candidates=backend_selection.candidates,
+            remediation=remediation,
+            evidence=evidence,
+        )
     if readiness.status == ProviderReadinessStatus.BACKEND_MISSING:
         return ManagedLxcBackendSelection.missing(
             remediation=readiness.remediation,

--- a/tests/application/services/platform/test_node_provider_selection.py
+++ b/tests/application/services/platform/test_node_provider_selection.py
@@ -192,6 +192,38 @@ class TestNodeProviderSelectionService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(NodeProviderKind.LXC_NATIVE, selection.selected_provider)
         self.assertEqual(ManagedLxcBackendSelectionStatus.UNSUPPORTED, selection.backend_selection.status)
 
+    async def test_failed_backend_probe_preserves_candidate_and_failure_evidence(self):
+        readiness = _ReadinessProbe(
+            ProviderReadiness(
+                provider=NodeProviderKind.LXC_NATIVE,
+                status=ProviderReadinessStatus.TIMEOUT,
+                backend_selection=ManagedLxcBackendSelection.for_backend(
+                    ManagedLxcBackend.INCUS,
+                    remediation=("Verify the incus daemon responds to read-only commands.",),
+                    evidence={
+                        "backend": "incus",
+                        "classification": "timeout",
+                        "classification_source": "timeout",
+                        "probe": "info",
+                    },
+                ),
+                remediation=("Verify the incus daemon responds to read-only commands.",),
+            )
+        )
+
+        result = await NodeProviderSelectionService(readiness).verify_provider_selection()
+
+        self.assertEqual(VerificationStatus.BLOCKED, result.status)
+        self.assertEqual("provider_selection_blocked", result.evidence["reason"])
+        self.assertEqual("timeout", result.evidence["readiness_status"])
+        self.assertEqual("unsupported", result.evidence["backend_status"])
+        self.assertEqual("1", result.evidence["backend_candidate_count"])
+        self.assertEqual("incus", result.evidence["backend_candidates"])
+        self.assertEqual("incus", result.evidence["backend"])
+        self.assertEqual("timeout", result.evidence["classification"])
+        self.assertEqual("timeout", result.evidence["classification_source"])
+        self.assertEqual("1", result.evidence["remediation_count"])
+
     async def test_unsupported_provider_request_blocks_selection(self):
         readiness = _ReadinessProbe(
             ProviderReadiness(


### PR DESCRIPTION
## Summary

Preserve LXC backend timeout evidence when platform provider selection blocks during fresh-install reset or platform reset pre-apply checks.

## Changed Areas

- `src/tiny_swarm_world/application/services/platform/node_provider_selection.py`
- `tests/application/services/platform/test_node_provider_selection.py`

## Verification

- PASS: `PYTHONPATH=src python3 -m unittest tests.application.services.platform.test_node_provider_selection`
- PASS: `python3 tools/quality_gate.py quality`
- PASS: `git diff --check`

## Impact

- Improves blocked reset/install diagnostics by retaining backend candidate, backend name, timeout classification, and remediation evidence.
- Does not change live infrastructure mutation behavior.

## Risks And Limitations

- This does not repair an unhealthy Incus/LXD daemon; it only makes the blocked evidence actionable.

## Push Auto

This `push auto` workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.