### PR TITLE
fix(deps): update requests pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
   "pydantic==2.10.6",
   "PyYAML==6.0.1",
-  "requests==2.32.0",
+  "requests==2.34.2",
   "ruamel.yaml==0.17.21",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 
 pydantic==2.10.6
 PyYAML==6.0.1
-requests==2.32.0
+requests==2.34.2
 ruamel.yaml==0.17.21


### PR DESCRIPTION
## Summary
- Update the pinned runtime dependency `requests` from `2.32.0` to `2.34.2`.
- Keep `requirements.txt` and `pyproject.toml` aligned.

## Changed Files
- `requirements.txt`: replaces the yanked `requests==2.32.0` pin.
- `pyproject.toml`: mirrors the runtime dependency pin for package metadata.

## Verification
- `PYTHONPATH=src python -m unittest tests.infrastructure.adapters.clients.test_nexus_http_client tests.infrastructure.adapters.clients.test_sonarqube_http_client tests.infrastructure.adapters.clients.test_infisical_cli_client tests.infrastructure.adapters.clients.test_lxc_swarm_runtime` - PASS, 55 tests.
- `python3 tools/quality_gate.py test` - PASS, 964 tests, 19 skipped.
- `python3 tools/quality_gate.py quality` - PASS, lint, arch-lint, arch-tests, typecheck, and 971 tests with 19 skipped.

## Impact
- Runtime dependency resolution no longer selects the yanked `requests 2.32.0` release.
- No Python source, service configuration, architecture rule, or public interface changes.

## Risks And Limitations
- Low dependency-update risk; request APIs used by the project are unchanged by this diff.
- No live infrastructure commands were run.

## Push Auto
This `push auto` workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the pull request, delete the merged remote head branch, and run clean after merge verification.
