### PR TITLE
chore: align environment with ruff lint gate

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - flake8
+  - ruff
   - pip
   - ruamel.yaml
   - pip:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -3,6 +3,8 @@ import tomllib
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -41,6 +43,15 @@ class TestPackageMetadata(unittest.TestCase):
         pyproject = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
         self.assertEqual(requirements, pyproject["project"]["dependencies"])
+
+    def test_environment_declares_ruff_quality_tool(self):
+        environment = yaml.safe_load((REPOSITORY_ROOT / "environment.yml").read_text(encoding="utf-8"))
+        conda_dependencies = [
+            dependency for dependency in environment["dependencies"] if isinstance(dependency, str)
+        ]
+
+        self.assertIn("ruff", conda_dependencies)
+        self.assertNotIn("flake8", conda_dependencies)
 
     def test_package_versions_are_aligned(self):
         pyproject = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))


### PR DESCRIPTION
## What
- Replace the legacy flake8 conda environment entry with ruff.
- Add metadata coverage that verifies environment.yml declares ruff and no longer declares flake8.

## Why
- The local quality gate runs Ruff for linting, so the developer environment should install the same tool.

## Testing
- PYTHONPATH=src .venv/bin/python -m unittest tests.test_package_metadata
- .venv/bin/python tools/quality_gate.py quality