### PR TITLE
agent(workflow): guard workflow create publication

### DIFF
--- a/.agents/orchestrator/swarm-orchestrator.md
+++ b/.agents/orchestrator/swarm-orchestrator.md
@@ -45,10 +45,15 @@ Coordinate small implementation slices across roles while preserving architectur
   checkpoint push.
 
 The strands must not be mixed. Slice checkpoint push is not `push auto`.
-`push auto` may publish and merge any task-scoped repository change, including
-Python product code and Python product-behavior tests, only through the guarded
-commit, pull request, green required-checks, SonarQube when configured, merge
-and cleanup lifecycle.
+Workflow-create publication is not `push auto`; it commits and pushes the
+workflow branch without automatic PR merge, branch deletion or cleanup.
+`push auto` may publish and merge task-scoped implementation changes,
+including Python product code and Python product-behavior tests, only through
+the guarded commit, pull request, green required-checks, SonarQube when
+configured, merge and cleanup lifecycle. For workflow-create-only branches,
+`push auto` stops unless the user explicitly confirms a
+workflow-documentation-only PR merge after the workflow-create guard is
+reported.
 
 ## Execution Profile Routing
 

--- a/.agents/prompts/slice-execute.md
+++ b/.agents/prompts/slice-execute.md
@@ -43,8 +43,11 @@ git show-ref --verify --quiet refs/heads/<workflow-branch>
    explicitly declared as a D8 requirement.
 
 The slice checkpoint push is not `push auto`. It must not create or merge a PR, clean up branches, force-push or push to `main`.
-A later explicit `push auto` may publish any task-scoped repository change
-from a slice only through the guarded commit, pull request, green
+Workflow-create publication is also not `push auto` and stays limited to the
+workflow branch push unless the user explicitly confirms a
+workflow-documentation-only PR merge after the workflow-create guard is
+reported. A later explicit `push auto` may publish task-scoped implementation
+changes from a slice only through the guarded commit, pull request, green
 required-checks, SonarQube when configured, merge and cleanup lifecycle.
 Each checkpoint commit must contain exactly one slice.
 

--- a/.agents/prompts/workflow-create.md
+++ b/.agents/prompts/workflow-create.md
@@ -89,7 +89,14 @@ git branch --show-current
     automatically analyzes every slice for safe specialist streams, requires
     evidence, uses real subagents where supported, and uses fallback
     role-based review where subagents are unavailable.
-20. Validate that `documentation/workflow/workflow.md` and checked or updated `documentation/arc42/**` documentation exist before releasing `workflow execute`.
+20. Commit the completed workflow-authoring artifacts and push only
+    `HEAD` to `origin/<workflow-branch>` as guarded workflow-create
+    publication.
+21. Do not run `push auto` for workflow-create-only output. Stop before PR
+    merge, remote branch deletion or local cleanup unless the user explicitly
+    confirms a workflow-documentation-only PR merge after the
+    workflow-create guard is reported.
+22. Validate that `documentation/workflow/workflow.md` and checked or updated `documentation/arc42/**` documentation exist before releasing `workflow execute`.
 
 For microservice migration workflows, record the Three Amigos decision before
 workflow authoring continues. The decision must include scope, non-scope,
@@ -119,6 +126,8 @@ Stop when:
 - the workflow branch cannot be checked out;
 - the workflow branch ref cannot be verified after creation or checkout;
 - the active branch after checkout does not match the expected workflow branch;
+- workflow-create publication would push anywhere other than `origin/<workflow-branch>`;
+- workflow-create publication would create or merge a PR, delete branches, run cleanup, force-push or push to `main`;
 - workflow rules conflict and cannot be resolved from repository sources;
 - creating or modifying workflow artifacts would happen on `main`, `master`, `develop`, or another shared branch.
 - blocking requirement questions remain;

--- a/.agents/prompts/workflow-execute.md
+++ b/.agents/prompts/workflow-execute.md
@@ -89,5 +89,8 @@ Stop when:
 - slice checkpoint push would include files outside the current slice;
 - slice checkpoint push would push to `main`, create or merge a PR, run `push auto`, run branch cleanup or force-push.
 - a slice checkpoint commit would contain multiple slice IDs or no active workflow version.
+- `push auto` is requested for workflow-create-only output without explicit
+  confirmation to override the workflow-create guard for a
+  workflow-documentation-only PR merge.
 - `push auto` is requested but commit, pull request, green required-checks,
   SonarQube when configured, merge or cleanup verification cannot be completed.

--- a/.agents/skills/git-commit-preparation/SKILL.md
+++ b/.agents/skills/git-commit-preparation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-preparation
-description: Use when preparing, reviewing, validating, repairing, committing, pushing, creating a PR, running workflow-execute slice checkpoint pushes, or running `push auto` for task-scoped repository changes including Python product code. This skill is the commit-readiness workflow and enforces AGENTS.md, QUALITY.md, git diff inspection, task-scope validation, quality-gate verification, blocker routing, git-commit-message-preparation, PR creation on explicit `push`, and commit, PR, green required-checks, SonarQube when configured, merge plus branch cleanup on explicit `push auto`.
+description: Use when preparing, reviewing, validating, repairing, committing, pushing, creating a PR, running workflow-execute slice checkpoint pushes, handling workflow-create branch publication, or running `push auto` for eligible task-scoped implementation changes including Python product code. This skill is the commit-readiness workflow and enforces AGENTS.md, QUALITY.md, git diff inspection, task-scope validation, quality-gate verification, blocker routing, git-commit-message-preparation, PR creation on explicit `push`, workflow-create publication without automatic merge, and commit, PR, green required-checks, SonarQube when configured, merge plus branch cleanup on eligible explicit `push auto`.
 ---
 
 # Commit Preparation Skill
@@ -339,6 +339,33 @@ For workflow-execute checkpoint commits:
 - record the actual commit hash after `CP_COMMIT` succeeds;
 - stop when staged files or the commit message would mix multiple slices.
 
+### Workflow Create Publication Guard
+
+When the active strand is `workflow create`, successful authoring grants
+permission only for the workflow-authoring publication path:
+
+1. stage only workflow-authoring files and directly required governance
+   synchronization files;
+2. create the reviewed workflow-authoring commit;
+3. push `HEAD` only to `origin/<workflow-branch>`;
+4. create or update a GitHub pull request only when the user entered exact
+   `push` or explicitly requested PR creation for the workflow documentation;
+5. stop before PR merge, remote branch deletion, local branch deletion or
+   `git-clean`.
+
+If the user enters exact `push auto` while the current branch contains only a
+completed `workflow create` result and no implementation changes produced by
+`workflow execute`, do not run Phase 13. Treat the request as a guarded
+workflow-authoring publication request instead: commit and push the workflow
+branch if needed, or report that the branch is already pushed. Do not merge the
+pull request automatically, do not delete the remote branch and do not clean up
+the local workflow branch.
+
+`push auto` becomes eligible again only after a task-scoped implementation
+change exists beyond the workflow-authoring baseline, or after the user
+explicitly confirms that they want to override the workflow-create publication
+guard for a workflow-documentation-only PR merge.
+
 ### Phase 12: Push Command And GitHub Pull Request
 
 When the user enters exactly `push`, treat it as explicit permission to:
@@ -381,7 +408,7 @@ If an open pull request already exists for the current branch against `main`, re
 
 ### Phase 13: Push Auto Check Loop, Merge, Branch Deletion, And Cleanup
 
-When the user enters exactly `push auto`, treat it as explicit permission to run the normal `push` workflow and then automatically finish the GitHub pull request lifecycle for the active task-scoped change, including Python product code and Python product-behavior tests.
+When the user enters exactly `push auto`, treat it as explicit permission to run the normal `push` workflow and then automatically finish the GitHub pull request lifecycle for the active task-scoped implementation change, including Python product code and Python product-behavior tests. This does not apply to workflow-create-only output; that case is governed by the Workflow Create Publication Guard.
 
 `push auto` must not publish unrelated changes, sensitive files, generated local artifacts, credentials, or files that cannot be classified as part of the active task.
 

--- a/.agents/skills/release-branch-governance/push-rules.md
+++ b/.agents/skills/release-branch-governance/push-rules.md
@@ -21,7 +21,7 @@ workflow explicitly declares it as a D8 requirement.
 
 ## Publication Modes
 
-There are three separate publication modes:
+There are four separate publication modes:
 
 1. Slice checkpoint push
    - belongs to `workflow execute`;
@@ -31,16 +31,29 @@ There are three separate publication modes:
    - does not create or merge a PR;
    - does not run branch cleanup;
    - is not `push auto`.
-2. `push`
+2. Workflow create publication
+   - belongs to `workflow create`;
+   - commits the completed workflow-authoring artifacts;
+   - pushes the workflow branch to `origin/<workflow-branch>`;
+   - keeps the branch available for workflow execution and parallel worktrees;
+   - may create or update a PR only on exact `push` or explicit PR request;
+   - does not automatically merge a PR;
+   - does not delete remote or local branches;
+   - is not `push auto`.
+3. `push`
    - normal publication after explicit user approval;
    - pushes the branch and creates or updates a PR;
    - does not automatically merge.
-3. `push auto`
-   - applies to any task-scoped repository change, including Python product
+4. `push auto`
+   - applies to task-scoped implementation changes, including Python product
      code and Python product-behavior tests;
    - runs a guarded commit, PR, check-loop, merge and cleanup lifecycle;
    - may merge the PR and clean up only after required checks are green,
      including SonarQube when configured.
+   - is blocked for branches that contain only completed `workflow create`
+     output and no task-scoped implementation changes, unless the user
+     explicitly confirms a workflow-documentation-only PR merge after the
+     workflow-create guard is reported.
 
 ## Parallel Workflow Publication
 
@@ -66,6 +79,13 @@ documented, and workflow status is updated.
 - Do not push unrelated local changes.
 - Create PRs only when workflow or user request allows it.
 - For slice checkpoint push, stage only current-slice files and push only to `origin/<workflow-branch>`.
+- For workflow create publication, stage only workflow-authoring and directly
+  required governance synchronization files, then push only to
+  `origin/<workflow-branch>`.
+- If exact `push auto` is requested immediately after `workflow create` and
+  the branch contains only workflow-authoring output, downgrade the action to
+  workflow create publication and stop before PR merge, remote branch deletion
+  or cleanup.
 - For `push auto`, stop unless the active change is task-scoped and free of
   unrelated, sensitive, generated local or unclassified files.
 - `push auto` must create or reuse a pull request, wait or retry until required
@@ -90,6 +110,11 @@ Stop when:
 - workflow does not allow push.
 - slice checkpoint push would include files outside the current slice;
 - slice checkpoint push would push to `main`, create or merge a PR, run `push auto`, run branch cleanup or force-push;
+- workflow create publication would include files outside workflow-authoring or
+  directly required governance synchronization scope;
+- exact `push auto` is requested for a workflow-create-only branch without
+  explicit confirmation to override the workflow-create guard for a
+  workflow-documentation-only PR merge;
 - `push auto` would publish unrelated, sensitive, generated local,
   unclassified or out-of-task files;
 - required checks, SonarQube status when configured, mergeability, merge

--- a/.agents/skills/workflow-authoring/SKILL.md
+++ b/.agents/skills/workflow-authoring/SKILL.md
@@ -91,6 +91,39 @@ git branch --show-current
 
 Do not rely on generated workflow notes as proof that a branch exists.
 
+## Workflow Authoring Publication Rule
+
+`workflow create` is a planning and governance publication step, not an
+implementation release step. When workflow authoring completes successfully,
+the workflow branch must be committed and pushed to `origin/<workflow-branch>`
+as the default publication action so other agents, worktrees and parallel
+development streams can see the same workflow baseline.
+
+The workflow authoring publication action must:
+
+1. stage only workflow-authoring files and directly required governance
+   synchronization files;
+2. create a workflow-authoring commit after the reviewed diff and required
+   governance checks pass;
+3. push only `HEAD` to `origin/<workflow-branch>`;
+4. record the branch name, commit SHA, push target and verification result in
+   the workflow handoff;
+5. stop if the branch is `main`, if unrelated files are present, if the remote
+   target is unclear, or if the workflow branch cannot be pushed.
+
+This default publication is equivalent to a guarded `push`, not `push auto`.
+It must not create, merge or clean up a pull request, must not delete local or
+remote branches, must not force-push and must not push to `main`.
+
+After a completed `workflow create`, an immediate user request for `push auto`
+against the same workflow-authoring branch must be treated as a request to keep
+the workflow branch published only. The operator must run or reuse the normal
+`push` publication path and must stop before PR merge, remote branch deletion
+or branch cleanup unless a later task produces implementation changes through
+`workflow execute` or the user explicitly requests a workflow-documentation PR
+merge after acknowledging that `push auto` is blocked for workflow-authoring
+only output.
+
 ## Required Inputs
 
 Read before authoring or regenerating a workflow:

--- a/.agents/skills/workflow-executor/SKILL.md
+++ b/.agents/skills/workflow-executor/SKILL.md
@@ -417,8 +417,16 @@ For each slice:
     the workflow explicitly permits carrying a documented blocker without a
     commit.
 
-Slice checkpoint push is not `push auto`. It must not create or merge a PR, run branch cleanup, force-push or push to `main`.
-A later explicit `push auto` may publish any task-scoped repository change
+Slice checkpoint push is not `push auto`. It must not create or merge a PR, run
+branch cleanup, force-push or push to `main`.
+
+Workflow-authoring publication is also not `push auto`. A branch that contains
+only the result of `workflow create` must remain in the normal branch-push
+state until implementation slices are executed or the user explicitly requests
+a workflow-documentation pull request merge after acknowledging the
+workflow-create guard.
+
+A later explicit `push auto` may publish task-scoped repository changes
 produced by workflow execution only through the guarded commit, pull request,
 green required-checks, SonarQube when configured, merge and cleanup lifecycle.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,9 +287,14 @@ authoritative skill entrypoints.
 - Classify failures through the Typed Error Router before retries.
 - Slice checkpoint push is not `push auto` and must not create or merge a pull
   request.
+- Workflow-create publication is not `push auto`; after `workflow create`, the
+  default publication action is a guarded commit and branch push to
+  `origin/<workflow-branch>` without PR merge, branch deletion, or cleanup.
 - Exact `push auto` may publish and automatically merge any task-scoped
-  repository change, including Python product code and Python
-  product-behavior tests.
+  implementation change, including Python product code and Python
+  product-behavior tests. It is blocked for workflow-create-only branches
+  unless the user explicitly confirms a workflow-documentation-only PR merge
+  after the workflow-create guard is reported.
 - `push auto` must run the full guarded lifecycle: create the commit, push the
   branch, create or reuse a pull request, wait or retry until required checks
   are green including SonarQube when configured, merge the pull request, delete

--- a/documentation/process/branch-governance.md
+++ b/documentation/process/branch-governance.md
@@ -13,9 +13,14 @@ Tiny Swarm World.
 - Preserve existing user changes when switching branches.
 - Check local and remote branch-name collisions before creating a branch.
 - Prefer clear, task-specific branch names over generic work branches.
-- `push auto` may automatically merge any task-scoped repository change,
+- Workflow-create publication commits and pushes the workflow branch to
+  `origin/<workflow-branch>` as a guarded branch publication. It must not merge
+  a PR, delete branches, or run cleanup.
+- `push auto` may automatically merge task-scoped implementation changes,
   including product feature or bug-fix branches, Python product code, and
-  Python product-behavior tests.
+  Python product-behavior tests. It is blocked for workflow-create-only
+  branches unless the user explicitly confirms a workflow-documentation-only
+  PR merge after the workflow-create guard is reported.
 - `push auto` must create or reuse a pull request, wait or retry until required
   checks are green including SonarQube when configured, merge only after green
   checks, delete the merged remote head branch, and clean up the local branch.

--- a/documentation/process/workflow-create.md
+++ b/documentation/process/workflow-create.md
@@ -28,8 +28,14 @@ Use this process when the user requests `workflow create`.
 8. Add the required `## Git Worktree Execution Rule` section to every
    executable workflow so parallel stream work uses isolated worktrees and
    branches named `<workflow-branch>-slice-<number>-<stream>`.
-9. Verify that `documentation/workflow/workflow.md` and relevant `documentation/arc42` updates exist before releasing `workflow execute`.
+9. Commit the completed workflow-authoring artifacts and push only `HEAD` to
+   `origin/<workflow-branch>` as guarded workflow-create publication.
+10. Do not run `push auto` for workflow-create-only output. Stop before PR
+    merge, remote branch deletion or local cleanup unless the user explicitly
+    confirms a workflow-documentation-only PR merge after the workflow-create
+    guard is reported.
+11. Verify that `documentation/workflow/workflow.md` and relevant `documentation/arc42` updates exist before releasing `workflow execute`.
 
 ## Stop Conditions
 
-Stop when requirement ownership, branch safety, architecture impact, quality commands, or workflow artifact paths cannot be verified.
+Stop when requirement ownership, branch safety, architecture impact, quality commands, workflow artifact paths, or guarded workflow-create publication cannot be verified.

--- a/documentation/process/workflow-execute.md
+++ b/documentation/process/workflow-execute.md
@@ -51,10 +51,13 @@ Use this process when the user requests `workflow execute`.
     real blocker occurs.
 20. When the active workflow requires checkpoint pushes, stage only current-slice files, commit, push the workflow branch, and record the result.
 
-Slice checkpoint push is not `push auto`. A later explicit `push auto` may
-publish any task-scoped repository change produced by workflow execution only
-through the guarded commit, pull request, green required-checks, SonarQube when
-configured, merge and cleanup lifecycle.
+Slice checkpoint push is not `push auto`. Workflow-create publication is also
+not `push auto`; workflow-create-only branches stay at guarded branch
+publication unless the user explicitly confirms a workflow-documentation-only
+PR merge after the workflow-create guard is reported. A later explicit
+`push auto` may publish task-scoped implementation changes produced by workflow
+execution only through the guarded commit, pull request, green required-checks,
+SonarQube when configured, merge and cleanup lifecycle.
 
 ## Automatic Work Distribution Policy
 


### PR DESCRIPTION
Summary:
- Define workflow-create publication as a guarded branch push to origin/<workflow-branch>.
- Block push auto for workflow-create-only output unless explicitly confirmed for a workflow-documentation-only PR merge.
- Synchronize AGENTS.md, workflow prompts, skills, orchestrator and process docs.

Changed areas:
- Agent governance and workflow prompts
- Workflow authoring/executor skills
- Branch and workflow process documentation

Verification:
- git diff --check: pass
- Python quality gate: not run, governance-only documentation and skill instruction change

Impact:
- Governance only; no product runtime or test behavior changed.

Risks and limitations:
- Requires future workflow-create and push-auto handling to follow the updated guard.

Push auto lifecycle:
- This PR is intended to wait for required checks including SonarCloud when configured, merge after green checks, delete the merged head branch, and clean up locally.