### PR TITLE
fix(messaging): remove legacy messaging references

### DIFF
--- a/documentation/arc42/08_concepts.adoc
+++ b/documentation/arc42/08_concepts.adoc
@@ -99,7 +99,7 @@ allocations and must not be silently interpreted as public ingress.
 phases, service-stack contracts, port-registry IDs, readiness targets, and
 explicit compatibility published ports. Runtime deployment selection still
 uses `ServiceStackContract` domain contracts. Current Apache Pulsar remains
-the messaging baseline; RabbitMQ is not part of the selected service registry.
+the messaging baseline in the selected service registry.
 
 === Health And Validation Evidence
 

--- a/documentation/arc42/11_risks_and_debt.adoc
+++ b/documentation/arc42/11_risks_and_debt.adoc
@@ -61,8 +61,8 @@ Remaining debt:
 * Portainer, Nexus, Jenkins, Apache Pulsar, SonarQube, and Swagger/NGINX service
   readiness must not be claimed until verified through tests or explicit live
   smoke evidence;
-* Apache Pulsar has a higher local resource footprint than RabbitMQ and may
-  require tighter memory/CPU guidance after live smoke validation;
+* Apache Pulsar may require tighter memory/CPU guidance after live smoke
+  validation;
 * Pulsar standalone mode is sufficient for local greenpath validation, but it
   is not equivalent to a production Pulsar cluster;
 * Pulsar Admin API uses internal port `8080`, so host exposure must continue to

--- a/documentation/architecture/adr-autonomous-setup-safety.adoc
+++ b/documentation/architecture/adr-autonomous-setup-safety.adoc
@@ -23,8 +23,8 @@ local Linux/WSL Docker Swarm-first environment into a runnable state after
 explicit operator consent.
 
 The setup can affect local managed nodes, networking, Docker Engine, Docker
-Swarm, Portainer, Nexus, Jenkins, RabbitMQ, SonarQube, Swagger/NGINX, image
-build and push behavior, service stacks, credentials, and local evidence
+Swarm, Portainer, Nexus, Jenkins, Apache Pulsar, SonarQube, Swagger/NGINX,
+image build and push behavior, service stacks, credentials, and local evidence
 files. These are live infrastructure surfaces and must not be changed silently.
 
 The repository already has these constraints:
@@ -54,8 +54,8 @@ The canonical setup path must preserve these rules:
 ** `y` at the short interactive live-infrastructure confirmation prompt
 * Missing live consent must be refused before LXD, Incus, LXC container
   lifecycle, Docker Swarm, netplan, socat, compose, Portainer, Nexus, Jenkins,
-  RabbitMQ, SonarQube, Swagger/NGINX, image build, image push, stack upload,
-  service bootstrap, or removed-provider commands can run.
+  Apache Pulsar, SonarQube, Swagger/NGINX, image build, image push, stack
+  upload, service bootstrap, or removed-provider commands can run.
 * After live consent is accepted, host-runtime readiness checks may run
   non-mutating probes. LXD/Incus readiness must distinguish executable
   presence from daemon, socket, permission, backend selection, and profile

--- a/documentation/architecture/adr-separate-platform-artifacts-deployment.adoc
+++ b/documentation/architecture/adr-separate-platform-artifacts-deployment.adoc
@@ -37,7 +37,8 @@ environment on Linux/WSL. The repository currently combines multiple concerns:
 * Dockerfile generation, image build/tag/push, Nexus Docker registry setup,
   Nexus Maven repository setup, and artifact publication.
 * Compose stack definitions, Portainer stack upload, and deployment of services
-  such as Portainer, Nexus, Jenkins, RabbitMQ, SonarQube, and Swagger/NGINX.
+  such as Portainer, Nexus, Jenkins, Apache Pulsar, SonarQube, and
+  Swagger/NGINX.
 * Shared command execution, YAML handling, file/path handling, logging, and
   dependency wiring.
 
@@ -121,8 +122,8 @@ steps. Empty marker directories are not required for the current state.
 * Compose stack definitions
 * Compose file repository behavior
 * Portainer stack create/update/upload
-* Service stack lifecycle for Portainer, Nexus, Jenkins, RabbitMQ, SonarQube,
-  Swagger/NGINX, and future stacks
+* Service stack lifecycle for Portainer, Nexus, Jenkins, Apache Pulsar,
+  SonarQube, Swagger/NGINX, and future stacks
 
 `shared` owns reusable infrastructure:
 

--- a/documentation/architecture/adr-service-access-dashboard-vaultwarden.adoc
+++ b/documentation/architecture/adr-service-access-dashboard-vaultwarden.adoc
@@ -43,9 +43,9 @@ Not implemented or not verified:
 
 Tiny Swarm World is a Linux/WSL-only Python automation project for a local
 Docker Swarm target environment. Existing service stacks such as Portainer,
-Nexus, Jenkins, RabbitMQ, SonarQube and Swagger/NGINX are governed through
-Deployment responsibility boundaries, compose assets, explicit verification
-contracts and live-infrastructure consent rules.
+Nexus, Jenkins, Apache Pulsar, SonarQube and Swagger/NGINX are governed
+through Deployment responsibility boundaries, compose assets, explicit
+verification contracts and live-infrastructure consent rules.
 
 The requested capability adds a service-access GUI and a Vaultwarden
 credential store. The user requirement includes password visibility for
@@ -103,7 +103,7 @@ The baseline rules are:
   is intended to serve the management overview at `http://localhost` after a
   verified provider-specific live deployment.
 * The service-access NGINX manages stable central paths for Jenkins, Nexus,
-  Portainer, RabbitMQ, SonarQube, Swagger and Vaultwarden.
+  Portainer, Apache Pulsar, SonarQube, Swagger and Vaultwarden.
 * Swagger/NGINX moves to published port `8084`.
 * Wider shared ingress is deferred until a later ADR defines route ownership,
   tests and rollback.

--- a/documentation/architecture/agent-split-plan.md
+++ b/documentation/architecture/agent-split-plan.md
@@ -24,7 +24,7 @@ accepted.
   - socat forwarding
   - Nexus bootstrap against a real service
   - Portainer bootstrap against a real service
-  - Jenkins/RabbitMQ/SonarQube live setup
+  - Jenkins/Apache Pulsar/SonarQube live setup
 - Preserve hexagonal imports.
 - Run only safe unit, static, architecture, and quality-gate checks.
 
@@ -267,7 +267,7 @@ Scope:
 - Stack definitions.
 - Portainer stack upload.
 - Service deployment lifecycle.
-- Jenkins, RabbitMQ, SonarQube, Swagger/NGINX, Nexus, and Portainer stack
+- Jenkins, Apache Pulsar, SonarQube, Swagger/NGINX, Nexus, and Portainer stack
   metadata.
 
 Allowed files after architecture approval:

--- a/documentation/deployment/system.adoc
+++ b/documentation/deployment/system.adoc
@@ -96,8 +96,7 @@ documentation. Runtime stack selection still comes from
 installation phase, service-stack contract, readiness target, port-registry
 IDs, and any compatibility published ports. Portainer remains outside the
 Portainer-managed deployment plan to avoid a bootstrap cycle. Apache Pulsar
-remains the selected messaging stack; RabbitMQ is not part of the selected
-baseline.
+remains the selected messaging stack.
 
 Setup preflight is idempotent for an already running Tiny Swarm World
 environment. Required ports pass when they are either free or already serve the

--- a/documentation/workflow/context-pack.json
+++ b/documentation/workflow/context-pack.json
@@ -20,7 +20,7 @@
   ],
   "forbidden_areas": [
     "live-infrastructure-without-explicit-opt-in",
-    "rabbitmq",
+    "unsupported-legacy-messaging-routes",
     "kubernetes-first-behavior",
     "react-frontend",
     "committed-runtime-evidence",

--- a/documentation/workflow/context-pack.md
+++ b/documentation/workflow/context-pack.md
@@ -34,7 +34,6 @@ the active workflow remain authoritative.
 
 - Live LXC, Incus, LXD, Docker, Swarm, Traefik, DNS, hosts-file or browser
   mutation without explicit live opt-in.
-- RabbitMQ metadata or routes.
 - Kubernetes-first behavior.
 - React frontend implementation.
 - Committed `.tiny-swarm-world/evidence/**` runtime evidence.

--- a/documentation/workflow/workflow.md
+++ b/documentation/workflow/workflow.md
@@ -77,7 +77,6 @@ Explicit Requirements:
 - Host-based routes must use service internal target ports behind Traefik.
 - `exposedByDefault=false` is required and `--api.insecure=true` is forbidden.
 - Pulsar broker TCP must not become an HTTP route.
-- RabbitMQ must not be generated.
 - Default tests must stay static or mocked.
 - Live Selenium/browser validation must be opt-in and redacted.
 
@@ -108,7 +107,6 @@ Non-Goals:
 - No LXC/Incus installation change.
 - No Docker installation or Swarm bootstrap behavior change.
 - No Kubernetes support.
-- No RabbitMQ metadata or routes.
 - No automatic Windows hosts-file management.
 - No Linux `/etc/hosts` or DNS resolver mutation.
 - No automatic TLS or CA lifecycle implementation.
@@ -191,7 +189,6 @@ Implemented and verified by the first execution:
   Portainer, Jenkins, SonarQube, Nexus, Swagger, Infisical, Service Access,
   Pulsar Manager GUI and optional Pulsar Admin/API.
 - Pulsar broker TCP is not modelled as a normal HTTP route.
-- RabbitMQ routes and metadata are not generated.
 - Service Access keeps credential display safety; password values are not
   rendered or committed.
 - Default quality gate passes without live infrastructure.
@@ -795,7 +792,6 @@ documentation:
   adr: "No ADR change expected."
 stop_conditions:
   - "Stop if tests require live infrastructure by default."
-  - "Stop if RabbitMQ route metadata appears."
   - "Stop if Pulsar broker TCP is treated as HTTP."
 ```
 
@@ -1086,7 +1082,6 @@ Stop and report if:
 - Live browser or infrastructure checks would run by default.
 - DNS or hosts-file mutation would be required.
 - Pulsar broker TCP is treated as HTTP.
-- RabbitMQ metadata or routes are introduced.
 - Documentation would claim live success without opt-in evidence.
 - Any quality failure cannot be safely classified.
 

--- a/infra/config/ports.yaml
+++ b/infra/config/ports.yaml
@@ -3,7 +3,6 @@ metadata:
   ingress_baseline: "traefik"
   public_ingress_policy: "Traefik owns public ingress ports 80 and 443."
   direct_port_policy: "High-numbered ports are direct, diagnostic, compatibility, or preflight allocations unless a later ADR changes public ingress."
-  unsupported_routes: "rabbitmq"
 ranges:
   - id: public-ingress
     start: 80

--- a/tests/domain/ingress/test_desired_state.py
+++ b/tests/domain/ingress/test_desired_state.py
@@ -112,12 +112,23 @@ class TestDesiredHttpsIngress(unittest.TestCase):
             evidence["health_check_targets"],
         )
         self.assertIn(
-            {"reason": "service_not_supported", "service": "rabbitmq"},
-            evidence["skipped_routes"],
-        )
-        self.assertIn(
             {"reason": "service_not_enabled", "service": "prometheus"},
             evidence["skipped_routes"],
+        )
+
+    def test_unsupported_route_metadata_is_reported_without_route_generation(self):
+        desired = desired_https_ingress_for_profile(
+            ServiceStackProfile.SERVICE_ACCESS,
+            port_registry=PortRegistry(
+                ranges=_committed_port_registry().ranges,
+                mappings=_committed_port_registry().mappings,
+                metadata={"unsupported_routes": "legacy-broker"},
+            ),
+        )
+
+        self.assertIn(
+            {"reason": "service_not_supported", "service": "legacy-broker"},
+            desired.to_dict()["skipped_routes"],
         )
 
     def test_route_hosts_and_diagnostic_fallbacks_can_come_from_port_registry(self):

--- a/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
+++ b/tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py
@@ -336,7 +336,20 @@ services:
         selected_stacks = expected_stacks
         self.assertEqual(set(), set(service_entries) - set(expected_stacks))
         self.assertEqual(set(selected_stacks), set(contract_by_stack))
-        self.assertNotIn("rabbitmq", service_entries)
+        self.assertEqual(
+            {
+                "infisical",
+                "jenkins",
+                "nexus",
+                "portainer",
+                "pulsar",
+                "service-access",
+                "sonarqube",
+                "swagger",
+                "traefik",
+            },
+            set(service_entries),
+        )
 
         for stack_name in selected_stacks:
             entry = service_entries[stack_name]

--- a/tests/integration/test_service_access_routing.py
+++ b/tests/integration/test_service_access_routing.py
@@ -53,10 +53,6 @@ class TestServiceAccessRouting(unittest.TestCase):
             evidence["diagnostic_fallback_ports"],
         )
         self.assertEqual("traefik_host_route", evidence["service_access_preferred_url_source"])
-        self.assertIn(
-            {"reason": "service_not_supported", "service": "rabbitmq"},
-            evidence["skipped_routes"],
-        )
         assert_evidence_safe(self, evidence)
 
 


### PR DESCRIPTION
## Summary

- Remove unsupported legacy messaging references from ADRs, arc42, deployment docs, workflow artifacts, and port-registry metadata.
- Keep Apache Pulsar as the documented messaging baseline.
- Replace narrow negative tests with positive supported-service registry expectations and neutral unsupported-route test data.
- Clean active issue text for #156, #157, and #202 so the removed messaging stack is no longer presented as planned, supported, or present behavior.

## Changed Areas

- `documentation/arc42/**`
- `documentation/architecture/**`
- `documentation/deployment/system.adoc`
- `documentation/workflow/**`
- `infra/config/ports.yaml`
- `tests/domain/ingress/test_desired_state.py`
- `tests/infrastructure/adapters/repositories/test_compose_file_repository_yaml.py`
- `tests/integration/test_service_access_routing.py`

## Verification

- `git diff --cached --check` passed.
- `rg -n -i "rabbitmq|rabbit|amqp" .` returned no matches.
- `rg --files | rg -i "rabbitmq|rabbit|amqp"` returned no matches.
- `python3 tools/quality_gate.py test` passed, 1034 tests, 28 skipped.
- `python3 tools/quality_gate.py quality` passed.
- Direct REST checks for active issues #154, #156, #157, and #202 found no searched terms in title/body after updates.

## Impact

- Documentation, workflow metadata, configuration metadata, and tests no longer keep the removed messaging stack discoverable.
- Runtime behavior is unchanged except for removing stale unsupported-route metadata from `infra/config/ports.yaml`.

## Risks and Limitations

- GitHub issue search can lag after body updates because of indexing, so direct title/body checks were used for final confirmation.
- No live infrastructure validation was run; this cleanup is static/test-backed only.

## Push Auto

This PR is part of a `push auto` flow. The workflow will verify required checks, including SonarQube/SonarCloud if configured, merge only after checks are green or no required checks are configured, delete the merged remote head branch, and run local cleanup after merge verification.