### PR TITLE
agent(governance): enforce issue completion gates

### DIFF
--- a/.agents/orchestrator/routing-rules.md
+++ b/.agents/orchestrator/routing-rules.md
@@ -9,6 +9,10 @@ Use these rules to select roles for a slice. Prefer the smallest set that covers
 - Exact `skills update` routes to the skills-agents strand, Skill Registry Conflict Auditor, Senior Documentation Engineer as Organigramm Maintainer, and Senior Workflow Architect as Process Governance Maintainer.
 - Exact `workflow create` routes to workflow create.
 - Exact `workflow execute` routes to workflow execute.
+- Issue completion, DONE readiness, acceptance coverage, branch completion
+  audit, or "is this issue fully done" routes to
+  `skills/issue-completion-auditor/SKILL.md` after implementation evidence is
+  available.
 
 Before assigning specialist roles, route every `workflow create` and
 `workflow execute` request through
@@ -33,6 +37,11 @@ gates. Unclear impact defaults to `FULL_PATH`.
 - Production microservice migration safety, rollback, strangler strategy or multi-service risk gates route to `skills/microservice-migration-safety-gate/SKILL.md`.
 - Microservice runtime independence, healthcheck, observability or container-readiness evidence routes to `skills/microservice-runtime-readiness-expert/SKILL.md`.
 - Test strategy, regression coverage, Python architecture checks or quality-gate design routes to `roles/senior-tester.md`.
+- Requirement matrix, acceptance verification, evidence completeness or
+  no-silent-scope-reduction concerns route through
+  `documentation/process/issue-completion-discipline.md`,
+  `skills/three-amigos-requirement-gatekeeper/SKILL.md` and
+  `skills/issue-completion-auditor/SKILL.md` by phase.
 - Quality or validation failures in `workflow execute` route through the Typed Error Router before any retry:
   - `ARCH_VIOLATION` routes to Root Architect escalation, `roles/senior-system-architect.md` and `skills/architecture-hexagonal/SKILL.md`.
   - `BUILD_FAILURE` routes to the responsible Python automation or frontend owner plus `roles/senior-devops.md`; Python quality-gate failures also route to `skills/quality-gate/SKILL.md`.

--- a/.agents/skills/acceptance-checks/SKILL.md
+++ b/.agents/skills/acceptance-checks/SKILL.md
@@ -20,12 +20,15 @@ automation changes.
 
 - User request, workflow slice and requirement notes.
 - Root `AGENTS.md`, `QUALITY.md` and relevant docs.
+- `documentation/process/issue-completion-discipline.md` for issue-driven
+  work.
 - Current changed files.
 
 ## Outputs
 
 - Acceptance checklist and verification command list.
 - Residual risk and blocker notes.
+- Requirement-to-verification mapping for each acceptance criterion.
 
 ## Boundaries
 
@@ -36,6 +39,8 @@ automation changes.
 ## STOP conditions
 
 - Acceptance criteria cannot be verified from repository evidence.
+- A requirement from the matrix has no implementation evidence or verification
+  evidence.
 - A check would require forbidden live infrastructure execution.
 - The changed file set escapes the active slice.
 

--- a/.agents/skills/engineering-governance/SKILL.md
+++ b/.agents/skills/engineering-governance/SKILL.md
@@ -18,6 +18,7 @@ Inspect the relevant subset of:
 - user request
 - `AGENTS.md`
 - `QUALITY.md`
+- `documentation/process/issue-completion-discipline.md`
 - `documentation/epics`
 - `documentation/arc42`
 - `documentation/adr`
@@ -63,6 +64,7 @@ Run governance checks:
 - before adding resilience behavior
 - before changing quality-gate expectations
 - before aligning existing skills or roles
+- before marking issue-driven work complete
 - before commit readiness review
 
 ## Architecture Rules
@@ -125,6 +127,19 @@ Require:
 - Minimum and full local quality gates recorded when relevant.
 - `git diff --check` run before commit readiness.
 
+### Issue Completion Consistency
+
+- `documentation/process/issue-completion-discipline.md` reviewed for
+  issue-driven work.
+- Requirement matrix exists before implementation.
+- Every requirement maps to implementation evidence and verification evidence.
+- Required `.tiny-swarm/evidence/<workflow-or-issue-id>/` files exist before
+  `DONE`.
+- `issue-completion-auditor` review is recorded before a final completion
+  claim.
+- Open or unverified requirements force `INCOMPLETE`, `BLOCKED` or `FAILED`,
+  never `DONE`.
+
 ## Stop Conditions
 
 Stop and report if:
@@ -135,6 +150,8 @@ Stop and report if:
 - service ownership is ambiguous
 - resilience expectations are unclear
 - quality-gate authority is unclear
+- issue requirements, requirement matrix, evidence path or completion authority
+  are unclear
 - a governance decision would require guessing
 
 ## Expected Outputs

--- a/.agents/skills/issue-completion-auditor/SKILL.md
+++ b/.agents/skills/issue-completion-auditor/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: issue-completion-auditor
+description: "Use after issue or workflow implementation to audit whether the branch fully satisfies the issue requirements, acceptance criteria, tests, evidence, documentation and completion discipline before any DONE claim."
+---
+
+# Skill: Issue Completion Auditor
+
+## Mission
+
+Verify whether a branch fully satisfies a GitHub issue, workflow issue or
+issue-driven implementation request.
+
+This skill is an audit gate. It does not implement code, repair tests or
+approve its own implementation work.
+
+## Required References
+
+Read before auditing:
+
+1. Root `AGENTS.md`.
+2. Root `QUALITY.md`.
+3. `documentation/process/issue-completion-discipline.md`.
+4. The complete issue, workflow slice or user request under audit.
+5. The requirement matrix for the issue or slice.
+6. Changed files in the branch.
+7. Test and quality-gate evidence.
+8. Documentation and evidence files referenced by the issue.
+
+## Audit Inputs
+
+Compare:
+
+- issue requirements and acceptance criteria;
+- requirement matrix;
+- changed files;
+- tests and checks;
+- evidence under `.tiny-swarm/evidence/<workflow-or-issue-id>/`;
+- workflow evidence under `.codex/evidence/**` when applicable;
+- documentation updates;
+- architecture and safety rules from `AGENTS.md`;
+- quality commands and failure policy from `QUALITY.md`.
+
+## Audit Procedure
+
+1. Confirm the branch is not `main`, `master`, `develop` or another shared
+   branch for write-capable completion work.
+2. Read the complete issue or workflow slice.
+3. Verify that every explicit and implicit issue requirement is present in the
+   requirement matrix.
+4. Map every requirement to changed code, config, documentation or declared
+   non-code evidence.
+5. Map every requirement to a test, check, static validation, config diff,
+   evidence file or manual verification result.
+6. Verify that required evidence files exist:
+   - `requirement_matrix.md`
+   - `implementation_summary.md`
+   - `changed_files.md`
+   - `test_results.md`
+   - `remaining_risks.md`
+   - `acceptance_checklist.md`
+7. Check for TODO-as-implementation, scaffolding-only completion, hidden scope
+   reduction and unrelated behavior changes.
+8. Verify that local validation was executed or that a documented blocker
+   explains why it could not run.
+9. Produce a final audit decision.
+
+## Definition of Done
+
+The audit may return `PASS` only when:
+
+1. All requirements from the issue or workflow slice were explicitly
+   extracted.
+2. Every requirement has implementation evidence.
+3. Every requirement has at least one relevant test, check or evidence
+   artifact.
+4. No acceptance criterion is open, silently ignored or partially implemented.
+5. The change was locally validated with the relevant `QUALITY.md` gate or an
+   explicitly justified narrower command.
+6. Required evidence exists under the intended workflow or issue evidence path.
+7. Non-implemented or unverifiable points are reported as blockers.
+
+If any requirement is open or unverified, the audit result must not be `PASS`.
+
+## No Silent Scope Reduction
+
+Fail the audit when the branch:
+
+- implements only the easy parts;
+- leaves TODOs, placeholders or stubs as substitutes for required behavior;
+- claims success with scaffolding only;
+- skips tests or evidence without a recorded blocker;
+- ignores acceptance criteria;
+- changes unrelated behavior to make checks pass;
+- bypasses architecture, safety or quality gates.
+
+## Three Amigos Completion Review
+
+Before a `PASS` decision, confirm the evidence includes three perspectives:
+
+| Perspective | Required confirmation |
+|---|---|
+| Requirement Lead | Every issue requirement is captured and no hidden requirement was ignored. |
+| System Architect Reviewer | The solution fits hexagonal architecture, provider model, reconciliation and workflow design without shortcuts or local hacks. |
+| Test / Evidence Reviewer | Every requirement has test or evidence and quality gates were not bypassed. |
+
+If one perspective fails or is missing without a justified blocker, return
+`INCOMPLETE` or `BLOCKED`.
+
+## Decision Contract
+
+Return exactly one:
+
+```text
+PASS
+INCOMPLETE
+BLOCKED
+REJECTED
+```
+
+Use `PASS` only for fully complete, verified and evidenced work.
+
+Use `INCOMPLETE` when implementation exists but any requirement, test,
+documentation update, validation command or evidence file is missing.
+
+Use `BLOCKED` when external information, environment, permissions or an
+architecture decision prevents completion and the blocker is explicit.
+
+Use `REJECTED` when the branch silently reduced scope, used TODOs or
+scaffolding as completion, changed unrelated behavior, bypassed gates, or
+cannot map acceptance criteria to implementation.
+
+## Stop Conditions
+
+Stop and return `BLOCKED` when:
+
+- the issue, workflow slice or acceptance criteria cannot be read completely;
+- the requirement matrix is missing;
+- the evidence path is unclear;
+- changed files cannot be inspected;
+- quality-gate authority is unclear;
+- architecture ownership or source of truth would require guessing;
+- the audit would require running live infrastructure commands without
+  explicit approval.
+
+## Required Final Report
+
+```md
+## Issue Completion Audit
+
+Decision: PASS | INCOMPLETE | BLOCKED | REJECTED
+
+Issue:
+- <issue id/title>
+
+Requirement matrix:
+- REQ-001: ...
+- REQ-002: ...
+
+Implemented requirements:
+- REQ-001: ...
+
+Verified requirements:
+- REQ-001: verified by ...
+
+Open requirements:
+- none
+
+Rejected or unrelated changes:
+- none
+
+Changed files:
+- ...
+
+Tests / checks reviewed:
+- command: ...
+  result: PASS/FAIL/NOT RUN
+
+Evidence reviewed:
+- .tiny-swarm/evidence/.../requirement_matrix.md
+- .tiny-swarm/evidence/.../test_results.md
+
+Risks:
+- ...
+
+Final decision:
+- ...
+```
+
+If `Open requirements` is not empty, `Decision` must not be `PASS`.

--- a/.agents/skills/skill-registry-conflict-auditor/SKILL.md
+++ b/.agents/skills/skill-registry-conflict-auditor/SKILL.md
@@ -18,6 +18,10 @@ This skill is a governance reviewer. It does not implement product code, write b
 - Identify duplicated ownership, missing owners, incompatible STOP rules and conflicting quality or architecture expectations.
 - Classify conflicts as `BLOCKING` or `NON_BLOCKING`.
 - Verify that every new skill defines mission, responsibilities, forbidden scope, inputs, outputs, collaboration rules and STOP rules.
+- Verify that every new or changed issue-driven skill applies
+  `documentation/process/issue-completion-discipline.md` through requirement
+  extraction, verification evidence, final status rules or a documented N/A
+  rationale.
 - Preserve the distinction between reusable `.codex` assets and project-specific `.agents` or documentation assets.
 - Reuse a previous registry result only when the recorded governance hashes still match the repository files and no governing path changed.
 - Escalate unresolved architecture, security, quality, API, data ownership or release conflicts to the owning specialist skill or role.
@@ -35,6 +39,8 @@ The Skill Registry & Conflict Auditor may:
 
 - Do not invent missing skills, roles or agent names.
 - Do not allow implementation to bypass the Three Amigos Requirement Gatekeeper for new or changed requirements.
+- Do not allow issue-driven work to bypass the requirement matrix,
+  issue-completion evidence or `issue-completion-auditor` completion decision.
 - Do not allow commit or push without required quality gate evidence.
 - Do not weaken `AGENTS.md`, `QUALITY.md`, ADRs or microservice boundary rules.
 - Do not treat `.codex` reusable templates as the place for project-specific governance unless portability is verified.
@@ -44,6 +50,7 @@ The Skill Registry & Conflict Auditor may:
 
 - Root `AGENTS.md`
 - Root `QUALITY.md`
+- `documentation/process/issue-completion-discipline.md`
 - Active `documentation/workflow/**`
 - Existing `docs/workplan/**` when referenced by migration or historical context
 - `documentation/adr/**`
@@ -66,6 +73,7 @@ The Skill Registry & Conflict Auditor may:
 - Missing-owner report
 - Required specialist review list
 - Updated or validated persistent skill registry matrix
+- Issue-completion discipline coverage findings
 - Registry reuse decision: `REUSE_ALLOWED`, `MANUAL_REVIEW_REQUIRED` or `BLOCKED`
 - `READY_FOR_WORKFLOW` or blocking governance findings when used in a requirement gate
 
@@ -86,6 +94,8 @@ Stop and report when:
 - a skill permits shared Java implementation modules between microservices;
 - a skill permits direct cross-service database access;
 - a skill permits implementation without requirement gate approval;
+- a skill permits issue-driven completion without requirement matrix,
+  verification evidence or auditor review;
 - a skill permits commit or push without required quality gates;
 - several skills own the same output but apply incompatible rules;
 - a workflow references a skill, role, prompt or agent that cannot be verified;

--- a/.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md
+++ b/.agents/skills/three-amigos-requirement-gatekeeper/SKILL.md
@@ -44,6 +44,7 @@ Inspect the relevant subset of:
 - user requirement and acceptance criteria
 - root `AGENTS.md`
 - root `QUALITY.md`
+- `documentation/process/issue-completion-discipline.md`
 - `documentation/epics`
 - `documentation/arc42`
 - `documentation/adr`
@@ -94,6 +95,32 @@ Always ask:
 ```text
 Does the implementation still match the EPIC?
 ```
+
+## Required Requirement Matrix Gate
+
+Before implementation can be approved, the gatekeeper must require a
+requirement matrix that follows
+`documentation/process/issue-completion-discipline.md`.
+
+The matrix must include every explicit and implicit behavior requirement,
+mentioned file, service, port, command, workflow and evidence path from the
+issue. Ambiguous requirements must be marked `BLOCKED`; they must not be
+silently omitted or deferred.
+
+## Completion Perspectives
+
+Before any later `DONE` claim, the Three Amigos evidence must cover these
+perspectives:
+
+- Requirement Lead: every issue requirement is captured and no hidden
+  requirement was ignored.
+- System Architect Reviewer: the solution fits hexagonal architecture,
+  provider model, reconciliation and workflow design without shortcuts or
+  local hacks.
+- Test / Evidence Reviewer: every requirement has test or evidence and quality
+  gates were not bypassed.
+
+If one perspective fails, the issue is `INCOMPLETE` or `BLOCKED`.
 
 For microservice migration requests, require a Three Amigos Decision Record with:
 
@@ -196,6 +223,7 @@ Stop with `REQUIRES_REFINEMENT` when:
 - affected services, APIs, storage, data ownership or deployment impact are unclear;
 - microservice service boundary, contract impact, test impact, risk level or forbidden changes are unclear;
 - acceptance criteria are missing or not testable;
+- the requirement matrix is missing or omits issue requirements;
 - API contracts or message semantics are unclear;
 - architecture boundaries, testability, data ownership, service boundaries, APIs, contracts, runtime behavior or scope are unclear;
 - rollback strategy is missing when the change affects deployable behavior or persisted state;

--- a/.agents/skills/workflow-authoring/SKILL.md
+++ b/.agents/skills/workflow-authoring/SKILL.md
@@ -131,11 +131,12 @@ Read before authoring or regenerating a workflow:
 1. User request.
 2. Root `AGENTS.md`.
 3. Root `QUALITY.md`.
-4. Existing `documentation/workflow` if present.
-5. Relevant EPIC files under `documentation/epics` if present.
-6. Relevant `documentation/arc42` and `documentation/adr` files.
-7. Relevant `.agents/skills` and `.agents/roles` files.
-8. Python tooling or CI files only when quality-gate behavior is affected.
+4. `documentation/process/issue-completion-discipline.md`.
+5. Existing `documentation/workflow` if present.
+6. Relevant EPIC files under `documentation/epics` if present.
+7. Relevant `documentation/arc42` and `documentation/adr` files.
+8. Relevant `.agents/skills` and `.agents/roles` files.
+9. Python tooling or CI files only when quality-gate behavior is affected.
 
 ## Workflow Regeneration Rule
 
@@ -211,6 +212,9 @@ Every workflow should include:
 - Git Worktree Execution Rule
 - parallelization opportunities
 - role or subagent ownership map
+- requirement matrix expectations for issue-driven workflows
+- issue-completion evidence expectations
+- issue-completion-auditor handoff
 - quality-gate expectations from `QUALITY.md`
 - documentation synchronization points
 - stop conditions
@@ -274,6 +278,8 @@ For each slice define:
 - file, contract and architecture locks
 - parallelization status
 - done criteria
+- issue-completion evidence path
+- requirement-to-verification mapping
 - verification commands
 - stop conditions
 
@@ -304,6 +310,24 @@ stop_conditions: []
 Use empty arrays for none. Dependencies must be concrete slice IDs, not ranges
 or prose. Missing metadata blocks future `workflow execute` until the workflow
 is corrected.
+
+Every issue-driven executable workflow must include this section:
+
+```markdown
+## Issue Completion Discipline
+
+- Requirement matrix path:
+- Required evidence path:
+- Required evidence files:
+- Requirement Lead review:
+- System Architect Reviewer review:
+- Test / Evidence Reviewer review:
+- Issue Completion Auditor review:
+- DONE blocking rule:
+```
+
+The `DONE` blocking rule must state that open or unverified requirements force
+`INCOMPLETE`, `BLOCKED` or `FAILED`.
 
 Every executable workflow must include this section:
 
@@ -397,6 +421,8 @@ Stop and report if:
 - quality-gate authority is unclear
 - planned file paths cannot be verified
 - blocking requirement questions remain
+- requirement matrix expectations or issue-completion evidence expectations
+  are unclear for issue-driven workflows
 - `documentation/workflow/workflow.md` cannot be validated
 - arc42 documentation cannot be checked or updated
 - continuing would require guessing governance decisions

--- a/.agents/skills/workflow-executor/SKILL.md
+++ b/.agents/skills/workflow-executor/SKILL.md
@@ -35,11 +35,12 @@ Read these files before implementation:
 
 1. Root `AGENTS.md`.
 2. Root `QUALITY.md`.
-3. Active workflow under `documentation/workflow`.
-4. `.agents/orchestrator/routing-rules.md`.
-5. `.agents/orchestrator/swarm-orchestrator.md`.
-6. Relevant `.agents/roles` files for the slice.
-7. Relevant `.agents/skills` files for the slice.
+3. `documentation/process/issue-completion-discipline.md`.
+4. Active workflow under `documentation/workflow`.
+5. `.agents/orchestrator/routing-rules.md`.
+6. `.agents/orchestrator/swarm-orchestrator.md`.
+7. Relevant `.agents/roles` files for the slice.
+8. Relevant `.agents/skills` files for the slice.
 
 When `documentation/workflow/context-pack.md` or
 `documentation/workflow/context-pack.json` exists, read it first for orientation and
@@ -307,6 +308,32 @@ Never implement a workflow slice directly before the relevant subagent or role h
 
 The `workflow execute` command authorizes the configured subagent workflow for that workflow only. Keep unrelated tasks under the normal repository subagent authorization rules.
 
+## Issue Completion Discipline
+
+For every issue-driven workflow slice, apply
+`documentation/process/issue-completion-discipline.md` as a hard execution
+gate.
+
+Before implementation:
+
+- create or verify `.tiny-swarm/evidence/<workflow-or-issue-id>/requirement_matrix.md`;
+- extract every explicit and implicit issue requirement into stable requirement
+  IDs;
+- map each requirement to planned code, config, documentation, test and
+  evidence changes;
+- mark ambiguous requirements `BLOCKED` instead of guessing silently.
+
+Before `DONE`:
+
+- verify every requirement against implementation evidence and test or check
+  evidence;
+- create all required `.tiny-swarm/evidence/<workflow-or-issue-id>/` files;
+- run the Three Amigos completion perspectives for requirement, architecture
+  and test/evidence coverage;
+- run or record `issue-completion-auditor` review;
+- report `INCOMPLETE`, `BLOCKED` or `FAILED` when any requirement is open or
+  unverified.
+
 ## Required Default Roles
 
 Use at least these roles when relevant to the slice:
@@ -372,47 +399,52 @@ For each slice:
 
 1. Read `documentation/workflow/workflow.md`.
 2. Read root `AGENTS.md` and relevant skill definitions.
-3. Run the Three Amigos or specialist review gate for the slice.
-4. Run S3D dependency, topological-order and conflict-lock checks.
-5. Create `.codex/evidence/slice-<number>-distribution.md` with the automatic
+3. Read `documentation/process/issue-completion-discipline.md`.
+4. Create or verify the requirement matrix before implementation.
+5. Run the Three Amigos or specialist review gate for the slice.
+6. Run S3D dependency, topological-order and conflict-lock checks.
+7. Create `.codex/evidence/slice-<number>-distribution.md` with the automatic
    work distribution decision.
-6. Select sequential or parallel execution.
-7. If parallel, create isolated Git worktrees per selected stream, execute
+8. Select sequential or parallel execution.
+9. If parallel, create isolated Git worktrees per selected stream, execute
    stream-specific work, collect stream evidence, and consolidate into the main
    workflow branch only after the Git Worktree Execution Rule is satisfied.
-8. If sequential, document why sequential execution was chosen and execute the
+10. If sequential, document why sequential execution was chosen and execute the
    slice in the main workflow branch.
-9. Apply only the changes authorized by the slice.
-10. Run targeted tests first.
-11. Run the required quality checks from `QUALITY.md` or the workflow.
-12. Fix quality-gate, test and SonarQube findings that are inside the active
+11. Apply only the changes authorized by the slice.
+12. Run targeted tests first.
+13. Run the required quality checks from `QUALITY.md` or the workflow.
+14. Fix quality-gate, test and SonarQube findings that are inside the active
    workflow branch and slice scope. Stop only when the fix would be unsafe,
    out of scope, unverifiable or would weaken gates.
-13. Treat the required quality decision as `D8`. Failed build, failed tests,
+15. Treat the required quality decision as `D8`. Failed build, failed tests,
    architecture violation, missing required documentation, missing workflow
    version or failed required quality gate blocks commit, checkpoint push and
    release readiness.
-14. Inspect `git diff` and `git diff --check`.
-15. Create or update `.codex/evidence/slice-<number>-consolidation.md` with
+16. Inspect `git diff` and `git diff --check`.
+17. Create or update `.codex/evidence/slice-<number>-consolidation.md` with
     stream results, accepted and rejected findings, conflicts, tests,
     SonarQube fixes, documentation updates and final integration decision.
-16. Document the result in the workflow quality log or the workflow-designated location.
-17. When the slice quality gate passed, stage only files changed by the current slice.
-18. Run `git diff --cached --check`.
-19. Create the slice-scoped checkpoint commit. Each commit must represent
+18. Create or update `.tiny-swarm/evidence/<workflow-or-issue-id>/` issue
+    completion evidence when the slice is issue-driven.
+19. Run or record `issue-completion-auditor` review before any `DONE` claim.
+20. Document the result in the workflow quality log or the workflow-designated location.
+21. When the slice quality gate passed, stage only files changed by the current slice.
+22. Run `git diff --cached --check`.
+23. Create the slice-scoped checkpoint commit. Each commit must represent
     exactly one slice; multi-slice commits are forbidden.
-20. Push the current workflow branch to `origin`.
-21. Create or update the pull request when the workflow or publication command
+24. Push the current workflow branch to `origin`.
+25. Create or update the pull request when the workflow or publication command
     requires it. Merge only after required gates pass, including SonarQube when
     configured.
-22. Record the workflow version, slice ID, slice title, responsible agent,
+26. Record the workflow version, slice ID, slice title, responsible agent,
     changed files, quality-gate commands, quality-gate result, commit SHA,
     rollback reference, arc42 update status, ADR update status and push result
     in the execution report.
-23. Route asynchronous execution-report notes through `Q11`; Q11 is
+27. Route asynchronous execution-report notes through `Q11`; Q11 is
     non-blocking by default unless the active workflow explicitly declares a
     regulatory or compliance report as a D8 requirement.
-24. Continue with the next slice or next workflow issue only when the current
+28. Continue with the next slice or next workflow issue only when the current
     slice is clean, the checkpoint push or required PR lifecycle succeeded, or
     the workflow explicitly permits carrying a documented blocker without a
     commit.
@@ -457,6 +489,9 @@ Stop and report if:
 - S3D cannot verify required slice metadata, a dependency graph, topological order or disjoint locks
 - S3D detects a file, contract, module or architecture-boundary lock conflict
 - the distribution decision evidence cannot be created before implementation
+- the requirement matrix is missing before implementation
+- issue-completion evidence is missing before a `DONE` claim
+- `issue-completion-auditor` review is required but missing before completion
 - parallel workflow worktrees cannot be created or are dirty before execution
 - two parallel workflows unexpectedly modify the same file, test, governance
   artifact, skill file, agent file, package structure or architecture decision

--- a/.agents/skills/workflow-slice-execution/SKILL.md
+++ b/.agents/skills/workflow-slice-execution/SKILL.md
@@ -12,18 +12,41 @@ Execute small, traceable implementation increments.
 ## Practices
 
 1. Read-only verification.
-2. Slice plan with affected files and quality checks.
-3. Verify that the active branch belongs to the current workflow and is not `main`, `master`, `develop`, or another shared branch.
-4. Minimal implementation.
-5. Targeted tests.
-6. Applicable quality gate from `QUALITY.md`.
-7. Documentation update when public behavior changes.
-8. Clear final summary with commands executed.
+2. Read `documentation/process/issue-completion-discipline.md` for
+   issue-driven slices.
+3. Create or verify the requirement matrix before implementation.
+4. Slice plan with affected files and quality checks.
+5. Verify that the active branch belongs to the current workflow and is not `main`, `master`, `develop`, or another shared branch.
+6. Minimal complete implementation for every mapped requirement.
+7. Targeted tests.
+8. Applicable quality gate from `QUALITY.md`.
+9. Documentation update when public behavior changes.
+10. Required evidence under `.tiny-swarm/evidence/<workflow-or-issue-id>/`
+    for issue-driven work.
+11. `issue-completion-auditor` review before any `DONE` claim.
+12. Clear final summary with commands executed, requirement status, evidence
+    paths and open risks.
+
+## Definition of Done
+
+Use `DONE` only when every requirement from the slice or issue has
+implementation evidence, verification evidence, local validation and required
+evidence files. If any requirement is open or unverified, report `INCOMPLETE`
+or `BLOCKED`.
+
+## No Silent Scope Reduction
+
+Do not implement only the easy parts, replace behavior with TODOs, claim
+scaffolding as completion, skip evidence, or change unrelated behavior to make
+checks pass.
 
 ## Stop Conditions
 
 - Required symbols, tasks, files or contracts cannot be verified.
+- The requirement matrix is missing or incomplete before implementation.
 - Documentation and source disagree in a behavior-relevant way.
 - The active branch is not the expected workflow branch.
 - The slice would modify files on `main`, `master`, `develop`, or another shared branch.
+- Required evidence or `issue-completion-auditor` review is missing before a
+  `DONE` claim.
 - Continuing would require fabricating evidence or guessing semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,9 @@ Root agent: `tiny-swarm-world-lead-architect`.
 This is the repository governance identity for Tiny Swarm World agent and skill
 work. It is not a new callable role file. It applies root `AGENTS.md`,
 `QUALITY.md`, the active workflow, and the owner map before specialist routing.
+Issue-driven work also applies
+`documentation/process/issue-completion-discipline.md` as the completion
+authority for requirement extraction, evidence, verification and final status.
 
 Tiny Swarm World is currently Docker Swarm first. Tiny Swarm World must remain
 Kubernetes-aware but not Kubernetes-first.
@@ -210,6 +213,7 @@ Owner mapping:
   `documentation-sync`, `requirement-engineering`,
   `arc42-architecture-governance`, `adr-steward`,
   `skill-registry-conflict-auditor`,
+  `issue-completion-auditor`,
   `audit-evidence-manager`, `qms-light-governance-expert`,
   `traceability-engineer`, `documentation-audience-architect`,
   `release-baseline-governance-expert`, and
@@ -256,6 +260,14 @@ authoritative skill entrypoints.
 ### Workflow Execution Rules
 
 - Exact `workflow execute` uses `.agents/skills/workflow-executor/SKILL.md`.
+- Issue-driven work must follow
+  `documentation/process/issue-completion-discipline.md`: extract a
+  requirement matrix before implementation, map every requirement to
+  implementation and verification evidence, and block `DONE` when any
+  requirement is open or unverified.
+- Completion of issue-driven work requires `issue-completion-auditor` review.
+  The implementer must not be the only authority deciding that an issue is
+  done.
 - Verify the active workflow, branch, slice metadata, locks, and quality gates
   before any write-capable work.
 - Use S3/S3D preflight for workflow execution.

--- a/documentation/process/issue-completion-discipline.md
+++ b/documentation/process/issue-completion-discipline.md
@@ -1,0 +1,222 @@
+# Issue Completion Discipline
+
+Tiny Swarm World skills are execution gates, not advisory expert personas. A
+skill may contribute implementation work, review work or governance decisions,
+but an issue is complete only when every requirement is implemented, verified
+and evidenced.
+
+This discipline applies to issue-driven work, `workflow execute`, slice
+execution, implementation skills, reviewer skills and completion audits.
+
+## Mandatory Completion Loop
+
+```text
+Issue
+  -> Requirement Lead extracts a requirement matrix
+  -> System Architect Reviewer validates architecture fit
+  -> Implementation Agent implements the complete mapped scope
+  -> Test / Evidence Reviewer verifies every requirement
+  -> Issue Completion Auditor decides PASS, INCOMPLETE, BLOCKED or REJECTED
+```
+
+The implementer does not decide alone that the issue is done. The final
+completion decision must be made from the requirement matrix, changed files,
+tests, evidence and documented risks.
+
+## Required First Step: Issue Decomposition
+
+Before implementation, create a requirement matrix:
+
+| ID | Requirement from issue | Type | Files likely affected | Implementation evidence | Test evidence | Status |
+|----|------------------------|------|------------------------|--------------------------|---------------|--------|
+
+Rules:
+
+- Every sentence that describes expected behavior must become a requirement.
+- Every bullet point in the issue must become at least one requirement.
+- Every mentioned file, service, port, command, workflow or evidence path must
+  be considered.
+- If a requirement is ambiguous, mark it `BLOCKED` instead of guessing
+  silently.
+- Implementation may not start before the matrix exists.
+- Requirement IDs must be stable for the branch or workflow slice.
+
+## Definition of Done
+
+An issue, workflow slice or skill task may be marked `DONE` only when:
+
+1. All requirements from the issue or slice were explicitly extracted.
+2. Every requirement has implementation evidence.
+3. Every requirement has at least one test, check or evidence artifact.
+4. No acceptance criterion is open, implicitly ignored or partially
+   implemented.
+5. The change was locally validated with the relevant `QUALITY.md` command or
+   a documented narrower gate.
+6. Evidence was created under the intended workflow or issue evidence path.
+7. Non-implemented or unverifiable points are reported as blockers, not hidden.
+
+If any requirement is open or unverified, the status must not be `DONE`.
+
+## No Silent Scope Reduction
+
+The scope must not be reduced silently.
+
+If a requirement cannot be implemented because information is missing, existing
+architecture is unclear, tests fail, dependencies are unavailable, the change
+would be too large, or the issue conflicts with existing code, stop and report
+`BLOCKED` with exact reasons.
+
+Do not:
+
+- implement only the easy parts;
+- leave TODOs as a substitute for implementation;
+- claim success when only scaffolding was added;
+- skip tests because they are inconvenient;
+- ignore evidence requirements;
+- change unrelated behavior to make checks pass.
+
+## Evidence Requirements
+
+For every completed issue or workflow slice, create evidence under:
+
+```text
+.tiny-swarm/evidence/<workflow-or-issue-id>/
+```
+
+Required files:
+
+- `requirement_matrix.md`
+- `implementation_summary.md`
+- `changed_files.md`
+- `test_results.md`
+- `remaining_risks.md`
+- `acceptance_checklist.md`
+
+The issue is not `DONE` unless all required evidence files exist and are
+consistent with the implemented changes. If no evidence was created, the
+implementation status is `FAILED` even if code was changed.
+
+For workflow slices that already require `.codex/evidence/**`, keep that slice
+evidence and also maintain the issue-level `.tiny-swarm/evidence/**` package
+when the work is issue-driven.
+
+## Acceptance Verification
+
+For each requirement, provide one of:
+
+- automated test name;
+- command output;
+- static validation;
+- config diff;
+- created evidence file;
+- manual verification step with result.
+
+A requirement without verification remains `OPEN`. A workflow with `OPEN`
+requirements must not be marked `DONE`.
+
+## Three Amigos Completion Gate
+
+Before `DONE`, the implementation must pass three independent perspectives:
+
+| Perspective | Required decision |
+|---|---|
+| Requirement Lead | Confirms every issue requirement is captured and no hidden requirement was ignored. |
+| System Architect Reviewer | Confirms the solution fits hexagonal architecture, provider model, reconciliation and workflow design without local hacks. |
+| Test / Evidence Reviewer | Confirms every requirement has test or evidence and quality gates were not bypassed. |
+
+If one perspective fails, the issue is `INCOMPLETE` or `BLOCKED`, not `DONE`.
+
+## Stop Conditions
+
+Stop and report `BLOCKED` when:
+
+- issue requirements contradict current architecture;
+- required files or modules are missing;
+- existing tests fail before the change and impact cannot be isolated;
+- required runtime checks cannot be executed;
+- the evidence path is unclear;
+- the issue needs a design decision not present in the issue;
+- implementation would require disabling guards or validations.
+
+Do not stop for ordinary implementation errors. Fix compile errors, test
+failures and lint findings inside the branch when the fix is in scope and does
+not weaken guards.
+
+## No Scaffolding-Only Completion
+
+Creating interfaces, empty classes, TODOs, placeholder implementations, config
+stubs or documentation is not sufficient.
+
+If scaffolding is created, it must be connected to executable behavior and
+verified by tests or evidence. A branch that only prepares structure without
+implementing behavior is `INCOMPLETE` unless the issue explicitly asks only for
+scaffolding.
+
+## Status Rules
+
+Use `DONE` only if all requirements are implemented and verified.
+
+Use `INCOMPLETE` if implementation exists but one or more requirements are
+missing or unverified.
+
+Use `BLOCKED` if external information, environment, permissions or architecture
+decisions prevent completion.
+
+Use `FAILED` if attempted changes break existing behavior or validation.
+
+The `issue-completion-auditor` skill maps these implementation statuses to
+audit outcomes:
+
+- `PASS` for fully complete, verified work;
+- `INCOMPLETE` for missing implementation, missing verification or open
+  requirements;
+- `BLOCKED` for true external, architectural or requirement blockers;
+- `REJECTED` for scope reduction, TODO-as-implementation, scaffolding-only
+  completion, unrelated behavior changes or bypassed gates.
+
+## Final Completion Report
+
+Every issue-driven skill result must include:
+
+```md
+## Final Completion Report
+
+Status: DONE | INCOMPLETE | BLOCKED | FAILED
+
+Issue:
+- <issue id/title>
+
+Requirement matrix:
+- REQ-001: ...
+- REQ-002: ...
+
+Implemented requirements:
+- REQ-001: ...
+- REQ-002: ...
+
+Verified requirements:
+- REQ-001: verified by ...
+- REQ-002: verified by ...
+
+Open requirements:
+- none
+
+Changed files:
+- ...
+
+Tests / checks executed:
+- command: ...
+  result: PASS/FAIL
+
+Evidence:
+- .tiny-swarm/evidence/.../requirement_matrix.md
+- .tiny-swarm/evidence/.../test_results.md
+
+Risks:
+- ...
+
+Decision:
+- The issue is fully complete because ...
+```
+
+If `Open requirements` is not empty, `Status` must not be `DONE`.

--- a/documentation/process/skills-update.md
+++ b/documentation/process/skills-update.md
@@ -5,7 +5,8 @@ or workflow governance.
 
 ## Process
 
-1. Read `AGENTS.md` and `QUALITY.md`.
+1. Read `AGENTS.md`, `QUALITY.md`, and
+   `documentation/process/issue-completion-discipline.md`.
 2. Read `documentation/skill-audit/skill-registry.md`,
    `documentation/skill-audit/skill-registry.json`,
    `documentation/skill-audit/organigramm.md`, and
@@ -14,22 +15,26 @@ or workflow governance.
 4. Keep root project rules authoritative over reusable templates.
 5. Preserve Python automation as the primary architecture for Tiny Swarm World.
 6. Keep project skills discoverable as `.agents/skills/<name>/SKILL.md`.
-7. Route console/status UI work to terminal-oriented skills, not browser React
+7. Ensure issue-driven skills either apply the completion discipline
+   requirement matrix, evidence, verification and status rules or document why
+   they are review-only and N/A.
+8. Route console/status UI work to terminal-oriented skills, not browser React
    roles.
-8. Route service-boundary concerns by exact need: decomposition, runtime
+9. Route service-boundary concerns by exact need: decomposition, runtime
    readiness, migration safety, contract governance, or Senior System Architect
    escalation.
-9. Stop if Python product code, Python product-behavior tests, or other
+10. Stop if Python product code, Python product-behavior tests, or other
     product implementation files would be changed.
-10. Prepare optional `push auto` only when explicitly requested and only
+11. Prepare optional `push auto` only when explicitly requested and only
     through the full commit, pull request, green required-checks, SonarQube
     when configured, merge and cleanup lifecycle.
-11. Run `git diff --check` and the quality gate required by `QUALITY.md` when practical.
+12. Run `git diff --check` and the quality gate required by `QUALITY.md` when practical.
 
 ## Stop Conditions
 
-Stop when ownership, routing, quality authority, registry paths, organigramm
-paths, or project-specific overrides are unclear.
+Stop when ownership, routing, quality authority, completion-discipline
+authority, registry paths, organigramm paths, or project-specific overrides are
+unclear.
 
 Stop when a change would classify Tiny Swarm World as forensic analytics, a
 Spring Boot application, a React frontend project, or Kubernetes-first without a

--- a/documentation/process/workflow-create.md
+++ b/documentation/process/workflow-create.md
@@ -6,6 +6,7 @@ Use this process when the user requests `workflow create`.
 
 - `AGENTS.md`
 - `QUALITY.md`
+- `documentation/process/issue-completion-discipline.md`
 - `.agents/prompts/workflow-create.md`
 - `.agents/skills/workflow-authoring/SKILL.md`
 - `.agents/orchestrator/routing-rules.md`
@@ -16,26 +17,36 @@ Use this process when the user requests `workflow create`.
 1. Clarify the requirement until it is ready for workflow authoring or clearly blocked.
 2. Verify repository status and branch safety before creating workflow artifacts.
 3. Create or verify the dedicated workflow branch.
-4. Generate or regenerate `documentation/workflow`.
-5. Define slices with owners, dependencies, allowed write scopes, stop conditions, and quality gates from `QUALITY.md`.
-6. Add the required `## Parallel Execution` section to every executable workflow, including parallel eligibility, conflicting workflows, shared files, shared infrastructure, isolated worktree requirement, serialized live validation requirement, and merge-order constraints.
-7. Add the required `## Automatic Work Distribution Policy` section to every
+4. Create a requirement matrix for issue-driven workflows before defining
+   executable slices.
+5. Generate or regenerate `documentation/workflow`.
+6. Define slices with owners, dependencies, allowed write scopes, stop conditions, quality gates from `QUALITY.md`, and required issue-completion evidence.
+7. Add the required `## Parallel Execution` section to every executable workflow, including parallel eligibility, conflicting workflows, shared files, shared infrastructure, isolated worktree requirement, serialized live validation requirement, and merge-order constraints.
+8. Add the required `## Automatic Work Distribution Policy` section to every
    executable workflow so `workflow execute` automatically analyzes each slice
    for backend, frontend, tests, runtime, documentation, quality, architecture
    and security streams, uses real subagents where supported, falls back to
    explicit role-based review where needed, and records distribution plus
    consolidation evidence.
-8. Add the required `## Git Worktree Execution Rule` section to every
+9. Add the required `## Git Worktree Execution Rule` section to every
    executable workflow so parallel stream work uses isolated worktrees and
    branches named `<workflow-branch>-slice-<number>-<stream>`.
-9. Commit the completed workflow-authoring artifacts and push only `HEAD` to
+10. Add the required `## Issue Completion Discipline` section to every
+    issue-driven executable workflow so `DONE` is blocked until all
+    requirements are implemented, verified and evidenced.
+11. Commit the completed workflow-authoring artifacts and push only `HEAD` to
    `origin/<workflow-branch>` as guarded workflow-create publication.
-10. Do not run `push auto` for workflow-create-only output. Stop before PR
+12. Do not run `push auto` for workflow-create-only output. Stop before PR
     merge, remote branch deletion or local cleanup unless the user explicitly
     confirms a workflow-documentation-only PR merge after the workflow-create
     guard is reported.
-11. Verify that `documentation/workflow/workflow.md` and relevant `documentation/arc42` updates exist before releasing `workflow execute`.
+13. Verify that `documentation/workflow/workflow.md`, relevant
+    `documentation/arc42` updates and requirement-matrix expectations exist
+    before releasing `workflow execute`.
 
 ## Stop Conditions
 
-Stop when requirement ownership, branch safety, architecture impact, quality commands, workflow artifact paths, or guarded workflow-create publication cannot be verified.
+Stop when requirement ownership, requirement-matrix completeness, branch
+safety, architecture impact, quality commands, workflow artifact paths,
+completion evidence expectations, or guarded workflow-create publication cannot
+be verified.

--- a/documentation/process/workflow-execute.md
+++ b/documentation/process/workflow-execute.md
@@ -6,6 +6,7 @@ Use this process when the user requests `workflow execute`.
 
 - `AGENTS.md`
 - `QUALITY.md`
+- `documentation/process/issue-completion-discipline.md`
 - `.agents/prompts/workflow-execute.md`
 - `.agents/skills/workflow-executor/SKILL.md`
 - `.agents/orchestrator/routing-rules.md`
@@ -27,29 +28,34 @@ Use this process when the user requests `workflow execute`.
    - verify file, contract, module and architecture locks;
    - choose serial execution when locks overlap.
 4. Classify the next slice and route it to the smallest suitable role set.
-5. Run the Three Amigos or specialist review gate for the slice.
-6. Create the automatic distribution decision for the slice.
-7. Select sequential or parallel execution.
-8. If parallel, create isolated Git worktrees per stream, execute
+5. Create or verify the requirement matrix before implementation.
+6. Run the Three Amigos or specialist review gate for the slice.
+7. Create the automatic distribution decision for the slice.
+8. Select sequential or parallel execution.
+9. If parallel, create isolated Git worktrees per stream, execute
    stream-specific work, collect stream evidence and consolidate into the main
    workflow branch.
-9. If sequential, document why sequential execution was chosen and execute the
+10. If sequential, document why sequential execution was chosen and execute the
    slice in the main workflow branch.
-10. Implement only the slice's allowed write scope.
-11. Run targeted checks first, then required gates from `QUALITY.md`.
-12. Classify failures through the Typed Error Router before retries.
-13. Fix in-scope test, quality-gate and SonarQube findings without weakening
+11. Implement only the slice's allowed write scope.
+12. Run targeted checks first, then required gates from `QUALITY.md`.
+13. Classify failures through the Typed Error Router before retries.
+14. Fix in-scope test, quality-gate and SonarQube findings without weakening
     gates. Stop only when the repair would be unsafe, out of scope,
     unverifiable or would bypass quality authority.
-14. Inspect `git diff` and `git diff --check`.
-15. Create or update consolidation evidence for the slice.
-16. Commit exactly one slice. Multi-slice commits are forbidden.
-17. Create or update the PR when the active workflow or publication command
+15. Inspect `git diff` and `git diff --check`.
+16. Create or update consolidation evidence for the slice.
+17. Create or update issue-completion evidence under
+    `.tiny-swarm/evidence/<workflow-or-issue-id>/` when the slice is
+    issue-driven.
+18. Run or record `issue-completion-auditor` review before any `DONE` claim.
+19. Commit exactly one slice. Multi-slice commits are forbidden.
+20. Create or update the PR when the active workflow or publication command
     requires it.
-18. Merge only after required gates pass, including SonarQube when configured.
-19. Continue with the next workflow or issue after successful merge unless a
+21. Merge only after required gates pass, including SonarQube when configured.
+22. Continue with the next workflow or issue after successful merge unless a
     real blocker occurs.
-20. When the active workflow requires checkpoint pushes, stage only current-slice files, commit, push the workflow branch, and record the result.
+23. When the active workflow requires checkpoint pushes, stage only current-slice files, commit, push the workflow branch, and record the result.
 
 Slice checkpoint push is not `push auto`. Workflow-create publication is also
 not `push auto`; workflow-create-only branches stay at guarded branch
@@ -137,6 +143,11 @@ accepts the changes.
 ## Validation Checklist
 
 - `workflow execute` does not depend on the user saying "with subagents".
+- Requirement matrix exists before implementation.
+- Every requirement maps to implementation evidence and verification evidence.
+- Required `.tiny-swarm/evidence/<workflow-or-issue-id>/` files exist for
+  issue-driven work before `DONE`.
+- `issue-completion-auditor` review is recorded before any final `DONE` claim.
 - Every slice has distribution evidence before implementation.
 - Sequential execution records why parallelization was rejected.
 - Parallel execution uses isolated stream worktrees and stream branches.
@@ -152,5 +163,6 @@ accepts the changes.
 
 Stop when the branch, slice metadata, dependency graph, locks, ownership,
 quality gate, write scope, failure route, distribution evidence,
-consolidation evidence, stream worktree isolation, PR readiness, merge
-readiness, or checkpoint target cannot be verified.
+consolidation evidence, requirement matrix, issue-completion evidence,
+auditor review, stream worktree isolation, PR readiness, merge readiness, or
+checkpoint target cannot be verified.

--- a/documentation/skill-audit/organigramm.md
+++ b/documentation/skill-audit/organigramm.md
@@ -3,13 +3,15 @@
 ## Status
 
 ```text
-CURRENT_AFTER_AUDIT_DERIVED_GOVERNANCE_SKILLS
+CURRENT_WITH_ISSUE_COMPLETION_GATES
 ```
 
 ## Root
 
 The Tiny Swarm World lead authority is the project governance defined in root
-`AGENTS.md`, with root `QUALITY.md` as quality authority.
+`AGENTS.md`, with root `QUALITY.md` as quality authority and
+`documentation/process/issue-completion-discipline.md` as the authority for
+issue-driven completion status.
 
 ## Primary Routing
 
@@ -21,6 +23,8 @@ The Tiny Swarm World lead authority is the project governance defined in root
   orchestration.
 - Documentation and registry: `senior-documentation-engineer` and
   `skill-registry-conflict-auditor`.
+- Issue completion: `issue-completion-auditor`, Requirement Lead, System
+  Architect Reviewer and Test / Evidence Reviewer.
 - Quality: `senior-tester`, `platform-quality-gates` and `quality-gate`.
 - Console/status UI: `frontend-developer`, `console-status-ui-developer` and
   `terminal-status-dashboard`.

--- a/documentation/skill-audit/owner-map.md
+++ b/documentation/skill-audit/owner-map.md
@@ -3,13 +3,14 @@
 ## Status
 
 ```text
-CURRENT_AFTER_AUDIT_DERIVED_GOVERNANCE_SKILLS
+CURRENT_WITH_ISSUE_COMPLETION_GATES
 ```
 
 | Concept | Owner | Review And Escalation |
 | --- | --- | --- |
 | Organigramm Maintainer | Senior Documentation Engineer | Skill Registry Conflict Auditor, Senior Workflow Architect, Senior System Architect when hierarchy changes affect architecture governance. |
 | Process Governance Maintainer | Senior Workflow Architect | Senior Requirement Engineer for drift, Senior Tester for quality authority, Engineering Governance skill for consistency. |
+| Issue Completion Discipline | Senior Requirement Engineer | Use `issue-completion-auditor` for final PASS/INCOMPLETE/BLOCKED/REJECTED decisions; Senior System Architect reviews architecture fit, Senior Tester reviews test and evidence coverage. |
 | Root Architect | Senior System Architect | Escalate to requirement, security, DevOps, data, contract, release or quality owners when those concerns are primary. |
 | Typed Error Router | Workflow Executor / Senior Workflow Architect | Senior Execution Orchestrator owns lock-conflict routing; Senior Tester and Quality Gate Orchestrator own quality failure classification. |
 | Service Boundary Governance | Senior System Architect | Use `service-decomposition-bounded-context`, `microservice-runtime-readiness-expert`, `microservice-migration-safety-gate`, and `contract-governance-expert` by concern. |

--- a/documentation/skill-audit/skill-registry.json
+++ b/documentation/skill-audit/skill-registry.json
@@ -1,5 +1,5 @@
 {
-  "status": "CURRENT_AFTER_AUDIT_DERIVED_GOVERNANCE_SKILLS",
+  "status": "CURRENT_WITH_ISSUE_COMPLETION_GATES",
   "canonical_paths": {
     "skill_registry_markdown": "documentation/skill-audit/skill-registry.md",
     "skill_registry_json": "documentation/skill-audit/skill-registry.json",
@@ -10,23 +10,25 @@
   "counts": {
     "project_skill_entrypoints": 132,
     "codex_skill_entrypoints": 6,
-    "required_tiny_swarm_world_skills": 47,
+    "required_tiny_swarm_world_skills": 48,
     "removed_stale_microservice_artifacts": 4
   },
   "governing_hashes": {
-    "AGENTS.md": "F0FA2387DFA023B968A0F474971BACDA12EBF05FEA4A03B5D6D098F1701D4601",
-    "QUALITY.md": "D327E4060FF1729F17FFDE844B1A2D6208FE203E149AE9D1AF185BEF0AED2155",
-    "README.md": "31C6AA7F2907D2C773C4ADD14F31235AB620F3A11B3D9DB913004A69D8650A24",
-    "documentation/arc42/08_concepts.adoc": "6736AFC526995312EE33D64D7B9E1853CD5AE509293DF5EB518AF1F200EEA857",
-    "documentation/skill-audit/skill-registry.md": "E231255A840818A92D3AC49692636FB0BE2F46651E370080AF3196EB529BD3FA",
-    "documentation/skill-audit/organigramm.md": "542F1E8FC0E9311DEF5B0D456D31F7F19B09B8A17F621CF4F26006CD81CA7190",
-    "documentation/skill-audit/owner-map.md": "19E2AE03E5A120E8244A7904A59BB78C53EDA42959428220E101F4CCFAFE1A46"
+    "AGENTS.md": "BC4DB4B3806EB345353DE0A3FA95153378CCDDF8D6B86F16FD45E77B0C1503A8",
+    "QUALITY.md": "458E5F4D8FBDEDEA1C413E1FF135EC91392A4BB5A5AEA20300DCAC8E209414B6",
+    "README.md": "75565CD5F73BD223C30FFB62ACF7950E9F4DB438B7C124F22F7CE0D43970C931",
+    "documentation/arc42/08_concepts.adoc": "E5BCC7B971A63935F8D5AFD2703693C9624215708BADD291D4BA4450100323BC",
+    "documentation/process/issue-completion-discipline.md": "81876F6DCA479A1D63A80F765BAF949A951EFF2E0EEAFDE6BAC72AD750508904",
+    "documentation/skill-audit/skill-registry.md": "C75C670AD4FBC1D623A5174D2E3973630676A77076F9B0791D781DE316A1A965",
+    "documentation/skill-audit/organigramm.md": "87C9E8FDF29AAE7038B283EDA39B15B7FDE1FB02CD74E8B7C80A0F18E38E338B",
+    "documentation/skill-audit/owner-map.md": "6E20656042FE3F0651AC96E3527CB37A4CC4E24A82C3EFB3CFD9E5CDE198B335"
   },
   "required_tiny_swarm_world_skills": [
     "tdd-expert",
     "bdd-expert",
     "platform-quality-gates",
     "acceptance-checks",
+    "issue-completion-auditor",
     "hexagonal-architecture-expert",
     "mapping-dsl-expert",
     "strangler-command-adapter-pattern",
@@ -73,6 +75,7 @@
   "source_of_truth": [
     "AGENTS.md",
     "QUALITY.md",
+    "documentation/process/issue-completion-discipline.md",
     ".agents/skills",
     ".agents/roles",
     ".agents/orchestrator",
@@ -85,6 +88,19 @@
     "Governing hashes require refresh after audit-derived governance skill changes."
   ],
   "audit_derived_governance_skills": [
+    {
+      "name": "issue-completion-auditor",
+      "group": "Governance and quality",
+      "owner_role": "Senior Requirement Engineer",
+      "primary_paths": [
+        ".agents/skills/issue-completion-auditor/SKILL.md",
+        "documentation/process/issue-completion-discipline.md",
+        ".tiny-swarm/evidence/"
+      ],
+      "supported_workflows": ["issue completion discipline"],
+      "related_issues": [],
+      "conflict_notes": "Audits completion after implementation; does not implement code or replace quality gates."
+    },
     {
       "name": "audit-evidence-manager",
       "group": "Audit and quality",

--- a/documentation/skill-audit/skill-registry.md
+++ b/documentation/skill-audit/skill-registry.md
@@ -3,7 +3,7 @@
 ## Status
 
 ```text
-CURRENT_AFTER_AUDIT_DERIVED_GOVERNANCE_SKILLS
+CURRENT_WITH_ISSUE_COMPLETION_GATES
 ```
 
 This is the canonical Tiny Swarm World skill registry path. Repository files
@@ -13,6 +13,8 @@ remain the source of truth; this registry is an audit and navigation artifact.
 
 - Root engineering authority: `AGENTS.md`.
 - Quality authority: `QUALITY.md`.
+- Issue completion authority:
+  `documentation/process/issue-completion-discipline.md`.
 - Project-specific skills: `.agents/skills/<skill-name>/SKILL.md`.
 - Reusable Codex skills: `.codex/skills/<skill-name>/SKILL.md`.
 - Owner map: `documentation/skill-audit/owner-map.md`.
@@ -35,19 +37,20 @@ remain the source of truth; this registry is an audit and navigation artifact.
 
 - Project-specific discoverable skills: 132.
 - Reusable `.codex` skills: 6.
-- Canonical required Tiny Swarm World skills: 47.
+- Canonical required Tiny Swarm World skills: 48.
 - Removed stale microservice-specific artifacts: 4.
 
 ## Audit-Derived Governance Skills
 
-These skills were added for audit remediation workflows #121 through #130. No
-existing skill was removed or renamed; the new skills narrow ownership for audit
-evidence, QMS-light, ISMS-light, traceability, live evidence, ASVS mapping,
-supply chain security, branch/CI governance, documentation audiences, and
-release baselines.
+These skills were added for audit remediation workflows #121 through #130 and
+local completion-discipline hardening. No existing skill was removed or
+renamed; the new skills narrow ownership for issue completion, audit evidence,
+QMS-light, ISMS-light, traceability, live evidence, ASVS mapping, supply chain
+security, branch/CI governance, documentation audiences, and release baselines.
 
 | Skill | Group | Owner Role | Primary Paths | Related Issues |
 | --- | --- | --- | --- | --- |
+| `issue-completion-auditor` | Governance and quality | Senior Requirement Engineer | `.agents/skills/issue-completion-auditor/SKILL.md`, `documentation/process/issue-completion-discipline.md`, `.tiny-swarm/evidence/` | local governance hardening |
 | `audit-evidence-manager` | Audit and quality | Senior Documentation Engineer | `documentation/audit/` | #121 |
 | `qms-light-governance-expert` | Audit and quality | Senior Tester | `documentation/qms/`, `QUALITY.md`, `AGENTS.md` | #122 |
 | `traceability-engineer` | Audit and quality | Senior Requirement Engineer | `documentation/traceability/` | #124 |


### PR DESCRIPTION
## Summary

- Add a central issue completion discipline that makes DONE dependent on extracted requirements, implementation evidence, verification evidence and local validation.
- Add an `issue-completion-auditor` skill with PASS, INCOMPLETE, BLOCKED and REJECTED outcomes.
- Wire workflow create/execute, workflow authoring, Three Amigos, acceptance checks, routing, owner map, organigramm and registry governance to the new completion gate.

## Changed files / areas

- Root governance: `AGENTS.md`
- Skill governance: `.agents/skills/**`, `.agents/orchestrator/routing-rules.md`
- Process documentation: `documentation/process/**`
- Skill audit registry and ownership: `documentation/skill-audit/**`

## Verification

- `python3 -m json.tool documentation/skill-audit/skill-registry.json`: PASS
- `git diff --check`: PASS
- `python3 tools/quality_gate.py test`: PASS
- `python3 tools/quality_gate.py quality`: PASS

## Impact

- Governance and workflow behavior now require a requirement matrix, per-requirement verification evidence, local evidence files and auditor review before issue-driven DONE claims.
- Product runtime behavior: none.

## Risks and limitations

- `.tiny-swarm/evidence/...` remains local ignored evidence by repository policy and is not committed.
- This change centralizes completion discipline instead of duplicating identical boilerplate into every existing skill file.

## Push auto note

This PR is created for `push auto`. The workflow intends to wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run clean after merge verification.
