### PR TITLE
fix(service-access): verify dashboard asset deployment order

### DIFF
--- a/documentation/user-handbook.adoc
+++ b/documentation/user-handbook.adoc
@@ -215,6 +215,20 @@ deployment, use the Service Access landing page as the operator start page:
 https://service-access.tsw.local
 ----
 
+During `service-access` deployment, the LXC stack runtime renders the Service
+Access dashboard from the effective access model before applying the stack. It
+writes that generated HTML to the remote stack root path consumed by the
+compose config:
+
+[source,text]
+----
+${TSW_REMOTE_STACK_ROOT:-/var/lib/tiny-swarm-world/stacks}/service-access/dashboard/index.html
+----
+
+That file is the `service_access_dashboard_index` config source for the
+deployed dashboard, so the live stack consumes the freshly generated dashboard
+content rather than a stale checkout file.
+
 Common preferred local service routes are:
 
 [options="header"]

--- a/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
+++ b/tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py
@@ -57,6 +57,32 @@ class TestLxcSwarmRuntime(unittest.TestCase):
         self.assertFalse(any(script.startswith("docker service inspect") for script in scripts))
         self.assertFalse(any(script.startswith("docker service update") for script in scripts))
 
+    def test_deploy_stack_writes_generated_service_access_dashboard_before_stack_deploy(self):
+        generated_dashboard = "<!doctype html>\n<html><body>generated-dashboard</body></html>\n"
+        runtime = LxcSwarmRuntime(
+            backend=ManagedLxcBackend.LXD,
+            remote_stack_root="/custom/stacks",
+            service_access_dashboard_renderer=lambda: generated_dashboard,
+        )
+
+        with patch.object(runtime, "_run_manager_shell") as run_manager_shell:
+            runtime.deploy_stack(
+                StackDefinition(name="service-access", compose_content="services: {}")
+            )
+
+        scripts = [call.args[0] for call in run_manager_shell.call_args_list]
+        self.assertEqual(3, len(scripts))
+        self.assertIn("cat > /custom/stacks/service-access/docker-compose.yml", scripts[0])
+        self.assertIn(
+            "cat > /custom/stacks/service-access/dashboard/index.html",
+            scripts[1],
+        )
+        self.assertIn("docker stack deploy", scripts[2])
+        self.assertEqual(
+            generated_dashboard,
+            run_manager_shell.call_args_list[1].kwargs["input_text"],
+        )
+
     def test_default_remote_stack_root_matches_committed_compose_fallback(self):
         runtime = LxcSwarmRuntime(backend=ManagedLxcBackend.LXD)
 


### PR DESCRIPTION
Summary
- Document the generated Service Access dashboard deployment file path in the user handbook.
- Add a regression test proving generated dashboard HTML is written before docker stack deploy.

Changed files
- documentation/user-handbook.adoc
- tests/infrastructure/adapters/clients/test_lxc_swarm_runtime.py

Verification
- Runtime unittest for test_lxc_swarm_runtime: PASS, 47 tests.
- Composition unittest for test_composition: PASS, 84 tests.
- Compose repository unittest: PASS, 41 tests.
- Full quality gate with .venv/bin/python tools/quality_gate.py quality: PASS, lint, arch-lint, arch-tests, typecheck, 1243 tests.

Impact
- Clarifies service-access deployment behavior for operators.
- Extends mocked LXC Swarm runtime regression coverage.
- No live infrastructure mutation was performed.

Risks and limitations
- No live Incus, Docker Swarm, or Service Access deployment was run.

Push auto lifecycle
- This PR is intended for push auto: wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run clean after merge verification.
