### PR TITLE
feat(wsl): require prepared Windows bridge before install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ pydevd_attach_to_process/
 ### Tiny Swarm World local runtime artifacts ###
 /.tiny-swarm-world/
 /.tiny-swarm/
+/tools/windows/.tws-wsl-bridge.state.json
 .env
 .env.local
 

--- a/documentation/system/network.adoc
+++ b/documentation/system/network.adoc
@@ -68,34 +68,61 @@ raw provider command output.
 
 == WSL2 NAT Portproxy
 
-For WSL2, Tiny Swarm World uses controlled Windows localhost forwarding:
+For WSL2, Tiny Swarm World uses a Windows-side bridge prepared before live
+installation:
 
 [source,text]
 ----
 Windows Browser
--> http://127.0.0.1:<service-port>
+-> http://127.0.0.1:<service-port> or http://*.tws.local
 -> Windows portproxy
 -> current WSL eth0 IPv4
 -> Incus/LXC/Docker/Services
 ----
 
-Windows portproxy and firewall changes are not made by `install.sh` and are
-not made implicitly from Linux. Diagnose them from elevated PowerShell:
+Windows portproxy, Firewall and hosts-file changes are not made by
+`install.sh` and are not made implicitly from Linux. Prepare them from
+elevated PowerShell before starting a WSL2 live installation:
+
+[source,powershell]
+----
+Set-ExecutionPolicy -Scope Process Bypass
+.\tools\windows\tws-wsl-bridge.ps1 -Action install
+----
+
+The bridge writes `tools/windows/.tws-wsl-bridge.state.json`. The file is
+local runtime state and ignored by Git. During WSL2 live preflight,
+Tiny Swarm World requires this state to be present, recent, matched to the
+current WSL IP, and to contain every external TCP port from
+`infra/config/ports.yaml`. If the state is missing or stale, setup stops
+before platform mutation with a `WINDOWS-WSL-BRIDGE` preflight failure.
+
+After `wsl --shutdown` or another WSL restart, refresh the bridge from Windows
+or WSL:
+
+[source,powershell]
+----
+Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
+----
+
+[source,bash]
+----
+powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"
+----
+
+The bridge reads TCP ports and route hostnames from `infra/config/ports.yaml`.
+`tools/windows/tws-wsl-bridge.config.json` is limited to Windows-side
+settings such as distro selection, listen address, hosts address, and
+additional hostname aliases. Do not maintain a separate Windows port list.
+
+Use the older portproxy scripts only for focused Windows-side diagnosis or
+manual repair:
 
 [source,powershell]
 ----
 powershell.exe -ExecutionPolicy Bypass -File .\tools\windows\doctor-portproxy.ps1
-----
-
-Repair them only through the explicit elevated script:
-
-[source,powershell]
-----
 powershell.exe -ExecutionPolicy Bypass -File .\tools\windows\repair-wsl-portproxy.ps1
 ----
-
-Both scripts read `infra/config/ports.yaml`; do not maintain a separate
-Windows port list.
 
 == Targeted Network Repair
 

--- a/documentation/user_guide/troubleshooting.adoc
+++ b/documentation/user_guide/troubleshooting.adoc
@@ -174,6 +174,42 @@ This repair mode is intentionally limited to the installer execute bit and the
 local secret-file mode. Ownership mismatches are reported with a review command
 instead of being changed automatically.
 
+== WSL2 Setup Stops At WINDOWS-WSL-BRIDGE
+
+When WSL2 live setup requires Windows browser access, Tiny Swarm World checks
+the Windows-side bridge before platform mutation. A failed
+`WINDOWS-WSL-BRIDGE` preflight check means the Windows portproxy, Firewall,
+hosts-file and Scheduled Task bridge has not been prepared, is stale, or no
+longer matches the current WSL IP.
+
+Prepare or repair it from elevated Windows PowerShell:
+
+[source,powershell]
+----
+cd D:\Projects\Tiny-Swarm-World
+Set-ExecutionPolicy -Scope Process Bypass
+.\tools\windows\tws-wsl-bridge.ps1 -Action install
+----
+
+After `wsl --shutdown`, refresh the existing bridge:
+
+[source,powershell]
+----
+Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
+----
+
+From WSL, the same refresh can be triggered without changing Linux network
+state:
+
+[source,bash]
+----
+powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"
+----
+
+The installer does not set Windows portproxy, Firewall, hosts-file or
+Scheduled Task state by itself. To run WSL2 without Windows localhost
+exposure, set `TSW_WINDOWS_EXPOSURE=disabled` explicitly before setup.
+
 == Setup Preflight Reports Occupied Ports
 
 `setup run --live` is intentionally re-runnable. During preflight, an occupied

--- a/infra/config/ports.yaml
+++ b/infra/config/ports.yaml
@@ -99,6 +99,15 @@ ports:
       route_enabled_by_default: "true"
       upstream_service: service-access-dashboard
       no_login_note: "Dashboard does not require a login"
+  - id: service-access-legacy-http
+    service_id: service-access
+    internal_port: 8086
+    external_port: 8086
+    exposure: compatibility
+    protocol: tcp
+    required_for_preflight: false
+    metadata:
+      route_name: none
   - id: api-gateway-http
     service_id: api-gateway
     internal_port: 80

--- a/src/tiny_swarm_world/application/ports/preflight/port_host_preflight_probe.py
+++ b/src/tiny_swarm_world/application/ports/preflight/port_host_preflight_probe.py
@@ -7,6 +7,7 @@ from tiny_swarm_world.domain.preflight import (
     HostEnvironmentKind,
     HostEnvironmentReport,
     SetupPath,
+    WindowsWslBridgeStatus,
 )
 
 
@@ -28,6 +29,18 @@ class PortHostPreflightProbe(ABC):
             setup_path=SetupPath.UNSUPPORTED,
             remediation=("Run Tiny Swarm World from Linux or WSL2.",),
             evidence={"classification": "legacy_boolean_unsupported"},
+        )
+
+    def windows_wsl_bridge_status(
+        self,
+        expected_ports: Sequence[int],
+    ) -> WindowsWslBridgeStatus:
+        return WindowsWslBridgeStatus(
+            prepared=False,
+            reason="unsupported_probe",
+            state_path="tools/windows/.tws-wsl-bridge.state.json",
+            expected_ports=tuple(expected_ports),
+            missing_ports=tuple(expected_ports),
         )
 
     @abstractmethod

--- a/src/tiny_swarm_world/application/services/platform/preflight_service.py
+++ b/src/tiny_swarm_world/application/services/platform/preflight_service.py
@@ -10,6 +10,7 @@ from tiny_swarm_world.domain.configuration import ConfigurationFinding
 from tiny_swarm_world.domain.network import PortRegistry
 from tiny_swarm_world.domain.preflight import (
     HostEnvironmentReport,
+    HostEnvironmentKind,
     LiveConsent,
     PreflightCategory,
     PreflightCheck,
@@ -53,6 +54,7 @@ class PreflightService:
             and host_environment.allows_live_setup
         ):
             checks.extend(self._runtime_checks())
+            checks.extend(self._windows_wsl_bridge_checks(host_environment))
         secret_checks = (
             self._secret_checks()
             if self.configuration_validation is None
@@ -221,6 +223,56 @@ class PreflightService:
             )
         return tuple(checks)
 
+    def _windows_wsl_bridge_checks(
+        self,
+        host_environment: HostEnvironmentReport,
+    ) -> tuple[PreflightCheck, ...]:
+        if host_environment.environment is not HostEnvironmentKind.WSL2:
+            return ()
+        if not self.configuration.windows_wsl_bridge_required:
+            return (
+                _passed(
+                    "WINDOWS-WSL-BRIDGE",
+                    PreflightCategory.WINDOWS_EXPOSURE,
+                    "Windows exposure is disabled by operator configuration.",
+                    {"required": "false"},
+                ),
+            )
+
+        expected_ports = self._windows_bridge_expected_ports()
+        status = self.host_probe.windows_wsl_bridge_status(expected_ports)
+        evidence = {
+            "state_path": status.state_path,
+            "reason": status.reason,
+            "current_wsl_ip": status.current_wsl_ip,
+            "state_wsl_ip": status.state_wsl_ip,
+            "generated_at": status.generated_at,
+            "listen_address": status.listen_address,
+            "expected_ports": _csv_ints(status.expected_ports),
+            "mapped_ports": _csv_ints(status.mapped_ports),
+            "missing_ports": _csv_ints(status.missing_ports),
+        }
+        if status.state_age_seconds is not None:
+            evidence["state_age_seconds"] = str(status.state_age_seconds)
+        if status.prepared:
+            return (
+                _passed(
+                    "WINDOWS-WSL-BRIDGE",
+                    PreflightCategory.WINDOWS_EXPOSURE,
+                    "Windows <-> WSL bridge is prepared.",
+                    evidence,
+                ),
+            )
+        return (
+            _failed(
+                "WINDOWS-WSL-BRIDGE",
+                PreflightCategory.WINDOWS_EXPOSURE,
+                "Windows <-> WSL bridge is not prepared.",
+                _windows_wsl_bridge_remediation(status.reason),
+                evidence,
+            ),
+        )
+
     def _cpu_check(self) -> PreflightCheck:
         actual = self.host_probe.cpu_count()
         expected = self.configuration.resources.minimum_cpu_count
@@ -366,6 +418,19 @@ class PreflightService:
             RequiredPort(mapping.external_port, mapping.port_id)
             for mapping in self.port_registry.preflight_ports
             if mapping.external_port is not None
+        )
+
+    def _windows_bridge_expected_ports(self) -> tuple[int, ...]:
+        if self.port_registry is None:
+            return tuple(required_port.port for required_port in self.configuration.required_ports)
+        return tuple(
+            sorted(
+                {
+                    mapping.external_port
+                    for mapping in self.port_registry.mappings
+                    if mapping.external_port is not None and mapping.protocol == "tcp"
+                }
+            )
         )
 
     def _secret_checks(self) -> tuple[PreflightCheck, ...]:
@@ -581,10 +646,29 @@ def _bool_text(value: bool) -> str:
     return "true" if value else "false"
 
 
+def _csv_ints(values: tuple[int, ...]) -> str:
+    return ",".join(str(value) for value in values)
+
+
 def _host_environment_remediation(host_environment: HostEnvironmentReport) -> str:
     if host_environment.remediation:
         return " ".join(host_environment.remediation)
     return "Run Tiny Swarm World from supported native Linux or WSL2."
+
+
+def _windows_wsl_bridge_remediation(reason: str) -> str:
+    install = (
+        "Run PowerShell as Administrator: "
+        "tools/windows/tws-wsl-bridge.ps1 -Action install."
+    )
+    refresh = (
+        "After WSL IP changes, run: "
+        "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge."
+    )
+    disable = "Set TSW_WINDOWS_EXPOSURE=disabled only when Windows localhost exposure is not required."
+    if reason in {"wsl_ip_changed", "state_stale_by_age"}:
+        return f"{refresh} If the task is missing, {install} {disable}"
+    return f"{install} {disable}"
 
 
 def _port_remediation(service: str) -> str:

--- a/src/tiny_swarm_world/application/services/platform/workflow/runtime.py
+++ b/src/tiny_swarm_world/application/services/platform/workflow/runtime.py
@@ -164,6 +164,13 @@ def _pre_apply_guard_verification(result: object) -> VerificationResult | None:
                     if check.category.value == "RUNTIME"
                 )
             ),
+            "windows_exposure_failure_count": str(
+                sum(
+                    1
+                    for check in result.failed_checks
+                    if check.category.value == "WINDOWS_EXPOSURE"
+                )
+            ),
         },
     )
 

--- a/src/tiny_swarm_world/domain/preflight/__init__.py
+++ b/src/tiny_swarm_world/domain/preflight/__init__.py
@@ -15,6 +15,7 @@ from tiny_swarm_world.domain.preflight.host_environment import (
     HostEnvironmentReport,
     SetupPath,
 )
+from tiny_swarm_world.domain.preflight.windows_wsl_bridge import WindowsWslBridgeStatus
 from tiny_swarm_world.domain.preflight.preflight_check import (
     PreflightCategory,
     PreflightCheck,
@@ -81,6 +82,7 @@ __all__ = [
     "SetupProfile",
     "SetupSecretRequirement",
     "SetupServiceRequirement",
+    "WindowsWslBridgeStatus",
     "default_preflight_configuration",
     "default_installation_plan",
     "default_setup_manifest",

--- a/src/tiny_swarm_world/domain/preflight/preflight_check.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_check.py
@@ -21,6 +21,7 @@ class PreflightCategory(str, Enum):
     LIVE_CONSENT = "LIVE_CONSENT"
     IGNORE_POLICY = "IGNORE_POLICY"
     CONFIGURATION = "CONFIGURATION"
+    WINDOWS_EXPOSURE = "WINDOWS_EXPOSURE"
 
 
 class PreflightSeverity(str, Enum):

--- a/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
+++ b/src/tiny_swarm_world/domain/preflight/preflight_configuration.py
@@ -83,6 +83,7 @@ class PreflightConfiguration:
     required_ignored_paths: tuple[str, ...]
     resources: ResourceThresholds
     minimum_python_version: tuple[int, int]
+    windows_wsl_bridge_required: bool = True
     provider_metadata: ProviderPreflightMetadata = field(
         default_factory=lambda: ProviderPreflightMetadata(
             provider="generic",

--- a/src/tiny_swarm_world/domain/preflight/windows_wsl_bridge.py
+++ b/src/tiny_swarm_world/domain/preflight/windows_wsl_bridge.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WindowsWslBridgeStatus:
+    prepared: bool
+    reason: str
+    state_path: str
+    current_wsl_ip: str = ""
+    state_wsl_ip: str = ""
+    generated_at: str = ""
+    listen_address: str = ""
+    expected_ports: tuple[int, ...] = ()
+    mapped_ports: tuple[int, ...] = ()
+    missing_ports: tuple[int, ...] = ()
+    state_age_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "expected_ports", _sorted_ports(self.expected_ports))
+        object.__setattr__(self, "mapped_ports", _sorted_ports(self.mapped_ports))
+        object.__setattr__(self, "missing_ports", _sorted_ports(self.missing_ports))
+
+    @property
+    def stale(self) -> bool:
+        return self.reason in {
+            "state_stale_by_age",
+            "wsl_ip_changed",
+            "missing_ports",
+            "generated_at_missing",
+            "generated_at_invalid",
+        }
+
+
+def _sorted_ports(ports: tuple[int, ...]) -> tuple[int, ...]:
+    return tuple(sorted({int(port) for port in ports}))

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 import platform
 import re
@@ -13,7 +12,6 @@ import sys
 import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
 from pathlib import Path
 
 from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
@@ -22,6 +20,11 @@ from tiny_swarm_world.domain.preflight import (
     HostEnvironmentReport,
     SetupPath,
     WindowsWslBridgeStatus,
+)
+from tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state import (
+    DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS,
+    current_wsl_ipv4,
+    windows_wsl_bridge_status,
 )
 from tiny_swarm_world.infrastructure.project_paths import ProjectPaths, default_project_paths
 
@@ -55,8 +58,6 @@ WSL_MARKERS = ("microsoft", "wsl")
 WSL_ENVIRONMENT_KEYS = ("WSL_DISTRO_NAME", "WSL_INTEROP")
 WSL_INTEROP_MARKER_FILES = (("proc", "sys", "fs", "binfmt_misc", "WSLInterop"),)
 API_STATUS_PATH = "/api/status"
-WINDOWS_WSL_BRIDGE_STATE = Path("tools/windows/.tws-wsl-bridge.state.json")
-DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 
 
 class HostPreflightProbe(PortHostPreflightProbe):
@@ -235,73 +236,12 @@ class HostPreflightProbe(PortHostPreflightProbe):
         self,
         expected_ports: Sequence[int],
     ) -> WindowsWslBridgeStatus:
-        state_path = self.root / WINDOWS_WSL_BRIDGE_STATE
-        relative_state_path = WINDOWS_WSL_BRIDGE_STATE.as_posix()
-        expected = tuple(int(port) for port in expected_ports)
-        if not state_path.exists():
-            return WindowsWslBridgeStatus(
-                prepared=False,
-                reason="state_missing",
-                state_path=relative_state_path,
-                expected_ports=expected,
-                missing_ports=expected,
-            )
-
-        try:
-            raw_state = json.loads(state_path.read_text(encoding="utf-8-sig"))
-        except (OSError, json.JSONDecodeError):
-            return WindowsWslBridgeStatus(
-                prepared=False,
-                reason="state_invalid",
-                state_path=relative_state_path,
-                expected_ports=expected,
-                missing_ports=expected,
-            )
-        if not isinstance(raw_state, Mapping):
-            return WindowsWslBridgeStatus(
-                prepared=False,
-                reason="state_invalid",
-                state_path=relative_state_path,
-                expected_ports=expected,
-                missing_ports=expected,
-            )
-
-        mapped_ports = _mapped_ports_from_bridge_state(raw_state)
-        missing_ports = tuple(sorted(set(expected) - set(mapped_ports)))
-        generated_at = str(raw_state.get("generatedAt", ""))
-        listen_address = str(raw_state.get("listenAddress", ""))
-        state_wsl_ip = str(raw_state.get("wslIp", ""))
-        current_wsl_ip = _current_wsl_ipv4()
-        state_age_seconds = _state_age_seconds(generated_at)
-
-        def bridge_status(prepared: bool, reason: str) -> WindowsWslBridgeStatus:
-            return WindowsWslBridgeStatus(
-                prepared=prepared,
-                reason=reason,
-                state_path=relative_state_path,
-                current_wsl_ip=current_wsl_ip,
-                state_wsl_ip=state_wsl_ip,
-                generated_at=generated_at,
-                listen_address=listen_address,
-                expected_ports=expected,
-                mapped_ports=mapped_ports,
-                missing_ports=missing_ports,
-                state_age_seconds=state_age_seconds,
-            )
-
-        if not generated_at:
-            return bridge_status(False, "generated_at_missing")
-        if state_age_seconds is None:
-            return bridge_status(False, "generated_at_invalid")
-        if state_age_seconds > self.windows_wsl_bridge_state_max_age_seconds:
-            return bridge_status(False, "state_stale_by_age")
-        if not current_wsl_ip:
-            return bridge_status(False, "wsl_ip_unavailable")
-        if state_wsl_ip != current_wsl_ip:
-            return bridge_status(False, "wsl_ip_changed")
-        if missing_ports:
-            return bridge_status(False, "missing_ports")
-        return bridge_status(True, "prepared")
+        return windows_wsl_bridge_status(
+            self.root,
+            expected_ports,
+            max_age_seconds=self.windows_wsl_bridge_state_max_age_seconds,
+            current_wsl_ipv4=current_wsl_ipv4,
+        )
 
     def _tracked_text_files(self) -> tuple[Path, ...]:
         suffixes = {".py", ".sh", ".yaml", ".yml", ".json", ".md", ".adoc"}
@@ -450,66 +390,6 @@ class HostPreflightProbe(PortHostPreflightProbe):
             )
         except OSError:
             return ""
-
-
-def _mapped_ports_from_bridge_state(state: Mapping[object, object]) -> tuple[int, ...]:
-    mappings = state.get("mappings", ())
-    if not isinstance(mappings, Sequence) or isinstance(mappings, str):
-        return ()
-    ports: set[int] = set()
-    for mapping in mappings:
-        if not isinstance(mapping, Mapping):
-            continue
-        try:
-            ports.add(int(mapping.get("listenPort", 0)))
-        except (TypeError, ValueError):
-            continue
-    return tuple(sorted(port for port in ports if port > 0))
-
-
-def _state_age_seconds(generated_at: str) -> int | None:
-    generated = _parse_bridge_timestamp(generated_at)
-    if generated is None:
-        return None
-    now = datetime.now(UTC)
-    return max(0, int((now - generated).total_seconds()))
-
-
-def _parse_bridge_timestamp(value: str) -> datetime | None:
-    if not value:
-        return None
-    normalized = value.strip()
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
-    normalized = re.sub(r"(\.\d{6})\d+$", r"\1", normalized)
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
-
-
-def _current_wsl_ipv4() -> str:
-    try:
-        completed = subprocess.run(
-            ["hostname", "-I"],
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if completed.returncode != 0:
-        return ""
-    for part in completed.stdout.split():
-        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", part):
-            return part
-    return ""
 
 
 def _token_fingerprints(text: str) -> tuple[str, ...]:

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import platform
 import re
@@ -12,6 +13,7 @@ import sys
 import urllib.error
 import urllib.request
 from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 
 from tiny_swarm_world.application.ports.preflight import PortHostPreflightProbe
@@ -19,6 +21,7 @@ from tiny_swarm_world.domain.preflight import (
     HostEnvironmentKind,
     HostEnvironmentReport,
     SetupPath,
+    WindowsWslBridgeStatus,
 )
 from tiny_swarm_world.infrastructure.project_paths import ProjectPaths, default_project_paths
 
@@ -52,6 +55,8 @@ WSL_MARKERS = ("microsoft", "wsl")
 WSL_ENVIRONMENT_KEYS = ("WSL_DISTRO_NAME", "WSL_INTEROP")
 WSL_INTEROP_MARKER_FILES = (("proc", "sys", "fs", "binfmt_misc", "WSLInterop"),)
 API_STATUS_PATH = "/api/status"
+WINDOWS_WSL_BRIDGE_STATE = Path("tools/windows/.tws-wsl-bridge.state.json")
+DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
 
 
 class HostPreflightProbe(PortHostPreflightProbe):
@@ -62,6 +67,7 @@ class HostPreflightProbe(PortHostPreflightProbe):
         *,
         os_root: Path | None = None,
         project_paths: ProjectPaths | None = None,
+        windows_wsl_bridge_state_max_age_seconds: int = DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS,
     ):
         self.root = root or (project_paths or default_project_paths()).repository_root
         self.os_root = os_root or Path("/")
@@ -70,6 +76,7 @@ class HostPreflightProbe(PortHostPreflightProbe):
             if executable_fallback_directories is None
             else executable_fallback_directories
         )
+        self.windows_wsl_bridge_state_max_age_seconds = windows_wsl_bridge_state_max_age_seconds
 
     def is_linux_or_wsl(self) -> bool:
         return platform.system().lower() == "linux"
@@ -224,6 +231,78 @@ class HostPreflightProbe(PortHostPreflightProbe):
                     found.add(identifier)
         return tuple(sorted(found))
 
+    def windows_wsl_bridge_status(
+        self,
+        expected_ports: Sequence[int],
+    ) -> WindowsWslBridgeStatus:
+        state_path = self.root / WINDOWS_WSL_BRIDGE_STATE
+        relative_state_path = WINDOWS_WSL_BRIDGE_STATE.as_posix()
+        expected = tuple(int(port) for port in expected_ports)
+        if not state_path.exists():
+            return WindowsWslBridgeStatus(
+                prepared=False,
+                reason="state_missing",
+                state_path=relative_state_path,
+                expected_ports=expected,
+                missing_ports=expected,
+            )
+
+        try:
+            raw_state = json.loads(state_path.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError):
+            return WindowsWslBridgeStatus(
+                prepared=False,
+                reason="state_invalid",
+                state_path=relative_state_path,
+                expected_ports=expected,
+                missing_ports=expected,
+            )
+        if not isinstance(raw_state, Mapping):
+            return WindowsWslBridgeStatus(
+                prepared=False,
+                reason="state_invalid",
+                state_path=relative_state_path,
+                expected_ports=expected,
+                missing_ports=expected,
+            )
+
+        mapped_ports = _mapped_ports_from_bridge_state(raw_state)
+        missing_ports = tuple(sorted(set(expected) - set(mapped_ports)))
+        generated_at = str(raw_state.get("generatedAt", ""))
+        listen_address = str(raw_state.get("listenAddress", ""))
+        state_wsl_ip = str(raw_state.get("wslIp", ""))
+        current_wsl_ip = _current_wsl_ipv4()
+        state_age_seconds = _state_age_seconds(generated_at)
+
+        def bridge_status(prepared: bool, reason: str) -> WindowsWslBridgeStatus:
+            return WindowsWslBridgeStatus(
+                prepared=prepared,
+                reason=reason,
+                state_path=relative_state_path,
+                current_wsl_ip=current_wsl_ip,
+                state_wsl_ip=state_wsl_ip,
+                generated_at=generated_at,
+                listen_address=listen_address,
+                expected_ports=expected,
+                mapped_ports=mapped_ports,
+                missing_ports=missing_ports,
+                state_age_seconds=state_age_seconds,
+            )
+
+        if not generated_at:
+            return bridge_status(False, "generated_at_missing")
+        if state_age_seconds is None:
+            return bridge_status(False, "generated_at_invalid")
+        if state_age_seconds > self.windows_wsl_bridge_state_max_age_seconds:
+            return bridge_status(False, "state_stale_by_age")
+        if not current_wsl_ip:
+            return bridge_status(False, "wsl_ip_unavailable")
+        if state_wsl_ip != current_wsl_ip:
+            return bridge_status(False, "wsl_ip_changed")
+        if missing_ports:
+            return bridge_status(False, "missing_ports")
+        return bridge_status(True, "prepared")
+
     def _tracked_text_files(self) -> tuple[Path, ...]:
         suffixes = {".py", ".sh", ".yaml", ".yml", ".json", ".md", ".adoc"}
         completed = subprocess.run(
@@ -371,6 +450,66 @@ class HostPreflightProbe(PortHostPreflightProbe):
             )
         except OSError:
             return ""
+
+
+def _mapped_ports_from_bridge_state(state: Mapping[object, object]) -> tuple[int, ...]:
+    mappings = state.get("mappings", ())
+    if not isinstance(mappings, Sequence) or isinstance(mappings, str):
+        return ()
+    ports: set[int] = set()
+    for mapping in mappings:
+        if not isinstance(mapping, Mapping):
+            continue
+        try:
+            ports.add(int(mapping.get("listenPort", 0)))
+        except (TypeError, ValueError):
+            continue
+    return tuple(sorted(port for port in ports if port > 0))
+
+
+def _state_age_seconds(generated_at: str) -> int | None:
+    generated = _parse_bridge_timestamp(generated_at)
+    if generated is None:
+        return None
+    now = datetime.now(UTC)
+    return max(0, int((now - generated).total_seconds()))
+
+
+def _parse_bridge_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
+    normalized = re.sub(r"(\.\d{6})\d+$", r"\1", normalized)
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _current_wsl_ipv4() -> str:
+    try:
+        completed = subprocess.run(
+            ["hostname", "-I"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    for part in completed.stdout.split():
+        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", part):
+            return part
+    return ""
 
 
 def _token_fingerprints(text: str) -> tuple[str, ...]:

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/windows_wsl_bridge_state.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/windows_wsl_bridge_state.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tiny_swarm_world.domain.preflight import WindowsWslBridgeStatus
+
+
+WINDOWS_WSL_BRIDGE_STATE = Path("tools/windows/.tws-wsl-bridge.state.json")
+DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def windows_wsl_bridge_status(
+    root: Path,
+    expected_ports: Sequence[int],
+    *,
+    state_path: Path = WINDOWS_WSL_BRIDGE_STATE,
+    max_age_seconds: int = DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS,
+    current_wsl_ipv4: Callable[[], str] = lambda: _current_wsl_ipv4(),
+) -> WindowsWslBridgeStatus:
+    absolute_state_path = root / state_path
+    relative_state_path = state_path.as_posix()
+    expected = tuple(int(port) for port in expected_ports)
+    if not absolute_state_path.exists():
+        return WindowsWslBridgeStatus(
+            prepared=False,
+            reason="state_missing",
+            state_path=relative_state_path,
+            expected_ports=expected,
+            missing_ports=expected,
+        )
+
+    try:
+        raw_state = json.loads(absolute_state_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return WindowsWslBridgeStatus(
+            prepared=False,
+            reason="state_invalid",
+            state_path=relative_state_path,
+            expected_ports=expected,
+            missing_ports=expected,
+        )
+    if not isinstance(raw_state, Mapping):
+        return WindowsWslBridgeStatus(
+            prepared=False,
+            reason="state_invalid",
+            state_path=relative_state_path,
+            expected_ports=expected,
+            missing_ports=expected,
+        )
+
+    mapped_ports = _mapped_ports_from_bridge_state(raw_state)
+    missing_ports = tuple(sorted(set(expected) - set(mapped_ports)))
+    generated_at = str(raw_state.get("generatedAt", ""))
+    listen_address = str(raw_state.get("listenAddress", ""))
+    state_wsl_ip = str(raw_state.get("wslIp", ""))
+    current_wsl_ip = current_wsl_ipv4()
+    state_age_seconds = _state_age_seconds(generated_at)
+
+    def bridge_status(prepared: bool, reason: str) -> WindowsWslBridgeStatus:
+        return WindowsWslBridgeStatus(
+            prepared=prepared,
+            reason=reason,
+            state_path=relative_state_path,
+            current_wsl_ip=current_wsl_ip,
+            state_wsl_ip=state_wsl_ip,
+            generated_at=generated_at,
+            listen_address=listen_address,
+            expected_ports=expected,
+            mapped_ports=mapped_ports,
+            missing_ports=missing_ports,
+            state_age_seconds=state_age_seconds,
+        )
+
+    if not generated_at:
+        return bridge_status(False, "generated_at_missing")
+    if state_age_seconds is None:
+        return bridge_status(False, "generated_at_invalid")
+    if state_age_seconds > max_age_seconds:
+        return bridge_status(False, "state_stale_by_age")
+    if not current_wsl_ip:
+        return bridge_status(False, "wsl_ip_unavailable")
+    if state_wsl_ip != current_wsl_ip:
+        return bridge_status(False, "wsl_ip_changed")
+    if missing_ports:
+        return bridge_status(False, "missing_ports")
+    return bridge_status(True, "prepared")
+
+
+def current_wsl_ipv4() -> str:
+    return _current_wsl_ipv4()
+
+
+def _mapped_ports_from_bridge_state(state: Mapping[object, object]) -> tuple[int, ...]:
+    mappings = state.get("mappings", ())
+    if not isinstance(mappings, Sequence) or isinstance(mappings, str):
+        return ()
+    ports: set[int] = set()
+    for mapping in mappings:
+        if not isinstance(mapping, Mapping):
+            continue
+        try:
+            ports.add(int(mapping.get("listenPort", 0)))
+        except (TypeError, ValueError):
+            continue
+    return tuple(sorted(port for port in ports if port > 0))
+
+
+def _state_age_seconds(generated_at: str) -> int | None:
+    generated = _parse_bridge_timestamp(generated_at)
+    if generated is None:
+        return None
+    now = datetime.now(UTC)
+    return max(0, int((now - generated).total_seconds()))
+
+
+def _parse_bridge_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
+    normalized = re.sub(r"(\.\d{6})\d+$", r"\1", normalized)
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _current_wsl_ipv4() -> str:
+    try:
+        completed = subprocess.run(
+            ["hostname", "-I"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    for part in completed.stdout.split():
+        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", part):
+            return part
+    return ""

--- a/src/tiny_swarm_world/infrastructure/composition.py
+++ b/src/tiny_swarm_world/infrastructure/composition.py
@@ -243,6 +243,7 @@ DEFAULT_INFISICAL_READINESS_ATTEMPTS = 720
 DEFAULT_INFISICAL_READINESS_INTERVAL_SECONDS = 5.0
 SWARM_REGISTRY_ENDPOINT_ENVIRONMENT = "TSW_SWARM_REGISTRY_ENDPOINT"
 DEFAULT_SWARM_REGISTRY_ENDPOINT = "127.0.0.1:13500"
+WINDOWS_EXPOSURE_ENVIRONMENT = "TSW_WINDOWS_EXPOSURE"
 LXC_PROXY_LISTEN_ADDRESS_ENVIRONMENT = "TSW_LXC_PROXY_LISTEN_ADDRESS"
 DEFAULT_LXC_PROXY_LISTEN_ADDRESS = "0.0.0.0"
 DEFAULT_NEXUS_CACHE_CONTAINER = "tiny-swarm-nexus-cache"
@@ -1453,7 +1454,10 @@ def _preflight_configuration_for_provider(
     service_profile: ServiceStackProfile | str,
     node_provider_request: NodeProviderSelectionRequest | None,
 ) -> PreflightConfiguration:
-    configuration = default_preflight_configuration(service_profile=service_profile)
+    configuration = replace(
+        default_preflight_configuration(service_profile=service_profile),
+        windows_wsl_bridge_required=_windows_wsl_bridge_required(),
+    )
     provider_request = node_provider_request or _default_node_provider_request()
     if provider_request.requested_provider is not NodeProviderKind.LXC_NATIVE:
         return replace(
@@ -1505,6 +1509,11 @@ def _preflight_configuration_for_provider(
             ),
         ),
     )
+
+
+def _windows_wsl_bridge_required() -> bool:
+    value = os.environ.get(WINDOWS_EXPOSURE_ENVIRONMENT, "").strip().casefold()
+    return value not in {"0", "false", "no", "off", "disabled"}
 
 
 def _platform_init_steps(

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -18,7 +18,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
 
-
 RESET_CONFIRMATION = "RESET_TINY_SWARM_PLATFORM"
 DEFAULT_SERVICE_PROFILE = "service-access"
 DEFAULT_INFISICAL_LOGIN_EMAIL = "admin@tiny-swarm-world.local"
@@ -573,55 +572,27 @@ def _windows_wsl_bridge_guard(
             expected_ports=expected_ports,
             missing_ports=expected_ports,
         )
-    try:
-        state = json.loads(state_path.read_text(encoding="utf-8-sig"))
-    except (OSError, json.JSONDecodeError):
-        return WindowsWslBridgeGuardResult(
-            False,
-            "state_invalid",
-            state_path,
-            expected_ports=expected_ports,
-            missing_ports=expected_ports,
-        )
-    if not isinstance(state, Mapping):
-        return WindowsWslBridgeGuardResult(
-            False,
-            "state_invalid",
-            state_path,
-            expected_ports=expected_ports,
-            missing_ports=expected_ports,
-        )
+    from tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state import (
+        current_wsl_ipv4,
+        windows_wsl_bridge_status,
+    )
 
-    mapped_ports = _windows_wsl_bridge_mapped_ports(state)
-    missing_ports = tuple(sorted(set(expected_ports) - set(mapped_ports)))
-    current_wsl_ip = _current_wsl_ipv4()
-    state_wsl_ip = str(state.get("wslIp", ""))
-    generated_at = str(state.get("generatedAt", ""))
-    state_age_seconds = _bridge_state_age_seconds(generated_at)
-
-    def result(passed: bool, reason: str) -> WindowsWslBridgeGuardResult:
-        return WindowsWslBridgeGuardResult(
-            passed,
-            reason,
-            state_path,
-            current_wsl_ip=current_wsl_ip,
-            state_wsl_ip=state_wsl_ip,
-            expected_ports=expected_ports,
-            mapped_ports=mapped_ports,
-            missing_ports=missing_ports,
-        )
-
-    if state_age_seconds is None:
-        return result(False, "generated_at_invalid")
-    if state_age_seconds > WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS:
-        return result(False, "state_stale_by_age")
-    if not current_wsl_ip:
-        return result(False, "wsl_ip_unavailable")
-    if state_wsl_ip != current_wsl_ip:
-        return result(False, "wsl_ip_changed")
-    if missing_ports:
-        return result(False, "missing_ports")
-    return result(True, "prepared")
+    status = windows_wsl_bridge_status(
+        cwd,
+        expected_ports,
+        max_age_seconds=WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS,
+        current_wsl_ipv4=current_wsl_ipv4,
+    )
+    return WindowsWslBridgeGuardResult(
+        status.prepared,
+        status.reason,
+        state_path,
+        current_wsl_ip=status.current_wsl_ip,
+        state_wsl_ip=status.state_wsl_ip,
+        expected_ports=status.expected_ports,
+        mapped_ports=status.mapped_ports,
+        missing_ports=status.missing_ports,
+    )
 
 
 def _windows_exposure_required(env: Mapping[str, str]) -> bool:
@@ -669,67 +640,6 @@ def _windows_wsl_bridge_expected_ports(cwd: Path) -> tuple[int, ...]:
 
     commit_current()
     return tuple(sorted(ports))
-
-
-def _windows_wsl_bridge_mapped_ports(state: Mapping[object, object]) -> tuple[int, ...]:
-    mappings = state.get("mappings", ())
-    if not isinstance(mappings, Sequence) or isinstance(mappings, str):
-        return ()
-    ports: set[int] = set()
-    for mapping in mappings:
-        if not isinstance(mapping, Mapping):
-            continue
-        try:
-            port = int(mapping.get("listenPort", 0))
-        except (TypeError, ValueError):
-            continue
-        if port > 0:
-            ports.add(port)
-    return tuple(sorted(ports))
-
-
-def _current_wsl_ipv4() -> str:
-    try:
-        completed = subprocess.run(
-            ["hostname", "-I"],
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            timeout=5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return ""
-    if completed.returncode != 0:
-        return ""
-    for value in completed.stdout.split():
-        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", value):
-            return value
-    return ""
-
-
-def _bridge_state_age_seconds(generated_at: str) -> int | None:
-    parsed = _parse_bridge_timestamp(generated_at)
-    if parsed is None:
-        return None
-    return max(0, int((datetime.now(UTC) - parsed).total_seconds()))
-
-
-def _parse_bridge_timestamp(value: str) -> datetime | None:
-    if not value:
-        return None
-    normalized = value.strip()
-    if normalized.endswith("Z"):
-        normalized = f"{normalized[:-1]}+00:00"
-    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
-    normalized = re.sub(r"(\.\d{6})\d+$", r"\1", normalized)
-    try:
-        parsed = datetime.fromisoformat(normalized)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
 
 
 def _clean_yaml_scalar(value: str) -> str:

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -6,15 +6,17 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import secrets
 import shlex
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Any, Protocol
 
 
 RESET_CONFIRMATION = "RESET_TINY_SWARM_PLATFORM"
@@ -26,6 +28,9 @@ DEFAULT_INFISICAL_SECRET_ENV_FILE = ".tiny-swarm/secrets/bootstrap.local.env"
 DEFAULT_GENERATED_SECRET_ENV_FILE = ".tiny-swarm/secrets/generated.local.env"
 DEFAULT_NATIVE_LINUX_VENV = ".tiny-swarm-world/install-venv"
 DEFAULT_SECRET_MANIFEST_PATH = Path("infra/config/secrets/infisical-secrets.yaml")
+WINDOWS_WSL_BRIDGE_STATE_PATH = Path("tools/windows/.tws-wsl-bridge.state.json")
+WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+WINDOWS_EXPOSURE_ENVIRONMENT = "TSW_WINDOWS_EXPOSURE"
 INSTALLER_REQUIRED_SOURCES = frozenset({"generated_local_secret", "placeholder_only"})
 SECRET_MODES = ("generated", "fixed", "infisical")
 DEFAULT_LOCAL_SERVICE_URL_EXPORTS = {
@@ -71,6 +76,18 @@ class InstallerSecretEntry:
     key: str
     source: str
     required: bool
+
+
+@dataclass(frozen=True)
+class WindowsWslBridgeGuardResult:
+    passed: bool
+    reason: str
+    state_path: Path
+    current_wsl_ip: str = ""
+    state_wsl_ip: str = ""
+    expected_ports: tuple[int, ...] = ()
+    mapped_ports: tuple[int, ...] = ()
+    missing_ports: tuple[int, ...] = ()
 
 
 class InstallReporter(Protocol):
@@ -323,6 +340,33 @@ def run(
         },
     )
 
+    bridge_guard = _windows_wsl_bridge_guard(host_runtime, install_env, cwd)
+    _append_context(
+        evidence_dir,
+        _windows_wsl_bridge_context(bridge_guard),
+    )
+    if not bridge_guard.passed:
+        install_reporter.report(
+            _phase_event(
+                "INSTALL_FINISHED",
+                "FAILED",
+                "windows-wsl-bridge",
+                reason="Windows <-> WSL bridge is not prepared.",
+                evidence_path=evidence_dir,
+                suggested_commands=_windows_wsl_bridge_suggested_commands(bridge_guard.reason),
+            )
+        )
+        _print_windows_wsl_bridge_failure(bridge_guard, evidence_dir)
+        _append_context(
+            evidence_dir,
+            {
+                "reset_skipped_due_to_windows_wsl_bridge": "yes",
+                "setup_skipped_due_to_windows_wsl_bridge": "yes",
+                "finished_utc": _utc_timestamp(),
+            },
+        )
+        return 1
+
     reset_command = _workflow_command(
         python_bin,
         "platform reset",
@@ -503,6 +547,193 @@ def detect_host_runtime(env: Mapping[str, str]) -> HostRuntime:
     if "microsoft" in kernel_text or "wsl" in kernel_text or "microsoft" in version_text or "wsl" in version_text:
         return HostRuntime("wsl2", "kernel_signal")
     return HostRuntime("native_linux", "uname_linux_without_wsl_signal")
+
+
+def _windows_wsl_bridge_guard(
+    host_runtime: HostRuntime,
+    env: Mapping[str, str],
+    cwd: Path,
+) -> WindowsWslBridgeGuardResult:
+    state_path = cwd / WINDOWS_WSL_BRIDGE_STATE_PATH
+    expected_ports = _windows_wsl_bridge_expected_ports(cwd)
+    if host_runtime.name != "wsl2":
+        return WindowsWslBridgeGuardResult(True, "not_wsl2", state_path, expected_ports=expected_ports)
+    if not _windows_exposure_required(env):
+        return WindowsWslBridgeGuardResult(
+            True,
+            "windows_exposure_disabled",
+            state_path,
+            expected_ports=expected_ports,
+        )
+    if not state_path.exists():
+        return WindowsWslBridgeGuardResult(
+            False,
+            "state_missing",
+            state_path,
+            expected_ports=expected_ports,
+            missing_ports=expected_ports,
+        )
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return WindowsWslBridgeGuardResult(
+            False,
+            "state_invalid",
+            state_path,
+            expected_ports=expected_ports,
+            missing_ports=expected_ports,
+        )
+    if not isinstance(state, Mapping):
+        return WindowsWslBridgeGuardResult(
+            False,
+            "state_invalid",
+            state_path,
+            expected_ports=expected_ports,
+            missing_ports=expected_ports,
+        )
+
+    mapped_ports = _windows_wsl_bridge_mapped_ports(state)
+    missing_ports = tuple(sorted(set(expected_ports) - set(mapped_ports)))
+    current_wsl_ip = _current_wsl_ipv4()
+    state_wsl_ip = str(state.get("wslIp", ""))
+    generated_at = str(state.get("generatedAt", ""))
+    state_age_seconds = _bridge_state_age_seconds(generated_at)
+
+    def result(passed: bool, reason: str) -> WindowsWslBridgeGuardResult:
+        return WindowsWslBridgeGuardResult(
+            passed,
+            reason,
+            state_path,
+            current_wsl_ip=current_wsl_ip,
+            state_wsl_ip=state_wsl_ip,
+            expected_ports=expected_ports,
+            mapped_ports=mapped_ports,
+            missing_ports=missing_ports,
+        )
+
+    if state_age_seconds is None:
+        return result(False, "generated_at_invalid")
+    if state_age_seconds > WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS:
+        return result(False, "state_stale_by_age")
+    if not current_wsl_ip:
+        return result(False, "wsl_ip_unavailable")
+    if state_wsl_ip != current_wsl_ip:
+        return result(False, "wsl_ip_changed")
+    if missing_ports:
+        return result(False, "missing_ports")
+    return result(True, "prepared")
+
+
+def _windows_exposure_required(env: Mapping[str, str]) -> bool:
+    value = env.get(WINDOWS_EXPOSURE_ENVIRONMENT, "").strip().casefold()
+    return value not in {"0", "false", "no", "off", "disabled"}
+
+
+def _windows_wsl_bridge_expected_ports(cwd: Path) -> tuple[int, ...]:
+    registry_path = cwd / "infra" / "config" / "ports.yaml"
+    ports: set[int] = set()
+    current: dict[str, str] | None = None
+    in_ports = False
+
+    def commit_current() -> None:
+        if current is None or "external_port" not in current:
+            return
+        protocol = current.get("protocol", "tcp").casefold()
+        if protocol != "tcp":
+            return
+        ports.add(int(current["external_port"]))
+
+    for line in _read_text(registry_path).splitlines():
+        if re.match(r"^ports:\s*$", line):
+            in_ports = True
+            continue
+        if not in_ports:
+            continue
+        if re.match(r"^\S", line) and not re.match(r"^ports:\s*$", line):
+            break
+        match = re.match(r"^\s*-\s+id:\s*(.+?)\s*$", line)
+        if match:
+            commit_current()
+            current = {"id": _clean_yaml_scalar(match.group(1))}
+            continue
+        if current is None:
+            continue
+        match = re.match(r"^\s+external_port:\s*(\d+)\s*$", line)
+        if match:
+            current["external_port"] = match.group(1)
+            continue
+        match = re.match(r"^\s+protocol:\s*(\S+)\s*$", line)
+        if match:
+            current["protocol"] = _clean_yaml_scalar(match.group(1))
+            continue
+
+    commit_current()
+    return tuple(sorted(ports))
+
+
+def _windows_wsl_bridge_mapped_ports(state: Mapping[object, object]) -> tuple[int, ...]:
+    mappings = state.get("mappings", ())
+    if not isinstance(mappings, Sequence) or isinstance(mappings, str):
+        return ()
+    ports: set[int] = set()
+    for mapping in mappings:
+        if not isinstance(mapping, Mapping):
+            continue
+        try:
+            port = int(mapping.get("listenPort", 0))
+        except (TypeError, ValueError):
+            continue
+        if port > 0:
+            ports.add(port)
+    return tuple(sorted(ports))
+
+
+def _current_wsl_ipv4() -> str:
+    try:
+        completed = subprocess.run(
+            ["hostname", "-I"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    for value in completed.stdout.split():
+        if re.fullmatch(r"\d{1,3}(?:\.\d{1,3}){3}", value):
+            return value
+    return ""
+
+
+def _bridge_state_age_seconds(generated_at: str) -> int | None:
+    parsed = _parse_bridge_timestamp(generated_at)
+    if parsed is None:
+        return None
+    return max(0, int((datetime.now(UTC) - parsed).total_seconds()))
+
+
+def _parse_bridge_timestamp(value: str) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
+    normalized = re.sub(r"(\.\d{6})\d+$", r"\1", normalized)
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _clean_yaml_scalar(value: str) -> str:
+    return value.strip().strip('"').strip("'")
 
 
 def ensure_python_environment(
@@ -981,6 +1212,68 @@ def _append_context(evidence_dir: Path, values: Mapping[str, str], *, replace: b
     with (evidence_dir / "context.txt").open(mode, encoding="utf-8") as context:
         for key, value in values.items():
             context.write(f"{key}={value}\n")
+
+
+def _windows_wsl_bridge_context(
+    guard: WindowsWslBridgeGuardResult,
+) -> dict[str, str]:
+    return {
+        "windows_wsl_bridge_passed": "yes" if guard.passed else "no",
+        "windows_wsl_bridge_reason": guard.reason,
+        "windows_wsl_bridge_state_path": _relative_display_path(guard.state_path),
+        "windows_wsl_bridge_current_wsl_ip": guard.current_wsl_ip,
+        "windows_wsl_bridge_state_wsl_ip": guard.state_wsl_ip,
+        "windows_wsl_bridge_expected_ports": _format_ints(guard.expected_ports),
+        "windows_wsl_bridge_mapped_ports": _format_ints(guard.mapped_ports),
+        "windows_wsl_bridge_missing_ports": _format_ints(guard.missing_ports),
+    }
+
+
+def _windows_wsl_bridge_suggested_commands(reason: str) -> tuple[str, ...]:
+    if reason in {"wsl_ip_changed", "state_stale_by_age"}:
+        return (
+            'powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"',
+            "powershell.exe -ExecutionPolicy Bypass -File tools/windows/tws-wsl-bridge.ps1 -Action install",
+        )
+    return (
+        "powershell.exe -ExecutionPolicy Bypass -File tools/windows/tws-wsl-bridge.ps1 -Action install",
+    )
+
+
+def _print_windows_wsl_bridge_failure(
+    guard: WindowsWslBridgeGuardResult,
+    evidence_dir: Path,
+) -> None:
+    print("[FAIL] Windows <-> WSL bridge is not prepared.", file=sys.stderr)
+    print(f"Reason: {guard.reason}", file=sys.stderr)
+    print(f"State file: {_relative_display_path(guard.state_path)}", file=sys.stderr)
+    if guard.current_wsl_ip or guard.state_wsl_ip:
+        print(f"Current WSL IP: {guard.current_wsl_ip or 'unknown'}", file=sys.stderr)
+        print(f"State WSL IP: {guard.state_wsl_ip or 'unknown'}", file=sys.stderr)
+    if guard.missing_ports:
+        print(f"Missing bridge ports: {_format_ints(guard.missing_ports)}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Run PowerShell as Administrator:", file=sys.stderr)
+    print("  tools/windows/tws-wsl-bridge.ps1 -Action install", file=sys.stderr)
+    if guard.reason in {"wsl_ip_changed", "state_stale_by_age"}:
+        print("", file=sys.stderr)
+        print("Or refresh the existing scheduled task:", file=sys.stderr)
+        print("  Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("To run WSL2 without Windows localhost exposure, set:", file=sys.stderr)
+    print("  TSW_WINDOWS_EXPOSURE=disabled", file=sys.stderr)
+    print(f"Evidence directory: {evidence_dir.as_posix()}", file=sys.stderr)
+
+
+def _relative_display_path(path: Path) -> str:
+    try:
+        return path.relative_to(Path.cwd()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _format_ints(values: Sequence[int]) -> str:
+    return ",".join(str(value) for value in values)
 
 
 def _print_install_plan(cwd: Path, options: InstallerOptions, evidence_dir: Path, secret_env_file: Path) -> None:

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -34,6 +34,7 @@ from tiny_swarm_world.domain.preflight import (
     SetupProfile,
     SetupSecretRequirement,
     SetupServiceRequirement,
+    WindowsWslBridgeStatus,
     default_preflight_configuration,
 )
 
@@ -399,6 +400,78 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.passed)
         self.assertFalse(any(check_id.startswith("RUNTIME-") for check_id in checks_by_id))
 
+    async def test_wsl2_live_preflight_blocks_when_windows_bridge_state_is_missing(self):
+        result = await PreflightService(
+            _fake_probe(
+                host_environment=_wsl2_environment(),
+                windows_bridge_status=WindowsWslBridgeStatus(
+                    prepared=False,
+                    reason="state_missing",
+                    state_path="tools/windows/.tws-wsl-bridge.state.json",
+                    expected_ports=(80, 10000),
+                    missing_ports=(80, 10000),
+                ),
+            ),
+            port_registry=_bridge_port_registry(),
+        ).run(LiveConsent(live_flag=True, confirmed=True))
+
+        failed_by_id = {check.check_id: check for check in result.failed_checks}
+        bridge_check = failed_by_id["WINDOWS-WSL-BRIDGE"]
+
+        self.assertFalse(result.passed)
+        self.assertEqual("WINDOWS_EXPOSURE", bridge_check.category.value)
+        self.assertIn("Windows <-> WSL bridge is not prepared", bridge_check.message)
+        self.assertIn("tools/windows/tws-wsl-bridge.ps1 -Action install", bridge_check.remediation)
+        self.assertEqual("80,10000", bridge_check.evidence["missing_ports"])
+
+    async def test_wsl2_live_preflight_passes_when_windows_bridge_state_is_prepared(self):
+        result = await PreflightService(
+            _fake_probe(host_environment=_wsl2_environment()),
+            port_registry=_bridge_port_registry(),
+        ).run(LiveConsent(live_flag=True, confirmed=True))
+
+        checks_by_id = {check.check_id: check for check in result.checks}
+        bridge_check = checks_by_id["WINDOWS-WSL-BRIDGE"]
+
+        self.assertTrue(result.passed)
+        self.assertEqual(PreflightStatus.PASSED, bridge_check.status)
+        self.assertEqual("80,10000", bridge_check.evidence["expected_ports"])
+
+    async def test_native_linux_live_preflight_does_not_require_windows_bridge(self):
+        result = await PreflightService(
+            _fake_probe(),
+            port_registry=_bridge_port_registry(),
+        ).run(LiveConsent(live_flag=True, confirmed=True))
+
+        self.assertTrue(result.passed)
+        self.assertNotIn("WINDOWS-WSL-BRIDGE", {check.check_id for check in result.checks})
+
+    async def test_wsl2_live_preflight_allows_explicitly_disabled_windows_exposure(self):
+        configuration = replace(
+            default_preflight_configuration(),
+            windows_wsl_bridge_required=False,
+        )
+
+        result = await PreflightService(
+            _fake_probe(
+                host_environment=_wsl2_environment(),
+                windows_bridge_status=WindowsWslBridgeStatus(
+                    prepared=False,
+                    reason="state_missing",
+                    state_path="tools/windows/.tws-wsl-bridge.state.json",
+                ),
+            ),
+            configuration,
+            port_registry=_bridge_port_registry(),
+        ).run(LiveConsent(live_flag=True, confirmed=True))
+
+        checks_by_id = {check.check_id: check for check in result.checks}
+        bridge_check = checks_by_id["WINDOWS-WSL-BRIDGE"]
+
+        self.assertTrue(result.passed)
+        self.assertEqual(PreflightStatus.PASSED, bridge_check.status)
+        self.assertEqual("false", bridge_check.evidence["required"])
+
     async def test_legacy_boolean_host_probe_still_runs_live_preflight(self):
         probe = _LegacyBooleanProbe()
 
@@ -666,6 +739,7 @@ class _FakeProbeOptions:
     disk_free_bytes_value: int = 120 * 1024**3
     python_version_value: str = "3.12.3"
     host_environment: HostEnvironmentReport | None = None
+    windows_bridge_status: WindowsWslBridgeStatus | None = None
 
 
 def _fake_probe(**overrides: Any) -> "_FakeProbe":
@@ -693,6 +767,7 @@ class _FakeProbe(PortHostPreflightProbe):
             remediation=("Verify runtime readiness before live setup.",),
             evidence={"classification": "native_linux"},
         )
+        self.windows_bridge_status = selected.windows_bridge_status
 
     def is_linux_or_wsl(self) -> bool:
         return self.host_compatible
@@ -741,6 +816,24 @@ class _FakeProbe(PortHostPreflightProbe):
         fingerprints: Mapping[str, str],
     ) -> Sequence[str]:
         return self.forbidden_fingerprints
+
+    def windows_wsl_bridge_status(
+        self,
+        expected_ports: Sequence[int],
+    ) -> WindowsWslBridgeStatus:
+        if self.windows_bridge_status is not None:
+            return self.windows_bridge_status
+        return WindowsWslBridgeStatus(
+            prepared=True,
+            reason="prepared",
+            state_path="tools/windows/.tws-wsl-bridge.state.json",
+            current_wsl_ip="172.20.0.2",
+            state_wsl_ip="172.20.0.2",
+            generated_at="2026-07-05T09:00:00+00:00",
+            listen_address="0.0.0.0",
+            expected_ports=tuple(expected_ports),
+            mapped_ports=tuple(expected_ports),
+        )
 
 
 class _LegacyBooleanProbe(PortHostPreflightProbe):
@@ -795,3 +888,44 @@ class _RaisingConfigurationValidation:
 
     def validate(self) -> ConfigurationValidationResult:
         raise self.error
+
+
+def _wsl2_environment() -> HostEnvironmentReport:
+    return HostEnvironmentReport(
+        environment=HostEnvironmentKind.WSL2,
+        setup_path=SetupPath.WSL2,
+        remediation=("Verify WSL2 Incus readiness before live setup.",),
+        evidence={"classification": "wsl2"},
+    )
+
+
+def _bridge_port_registry() -> PortRegistry:
+    return PortRegistry(
+        ranges=(),
+        mappings=(
+            ServicePortMapping(
+                service_id="traefik",
+                port_id="traefik-http",
+                internal_port=80,
+                external_port=80,
+                exposure=PortExposureClass.PUBLIC_INGRESS,
+                protocol="tcp",
+            ),
+            ServicePortMapping(
+                service_id="service-access",
+                port_id="service-access-http",
+                internal_port=80,
+                external_port=10000,
+                exposure=PortExposureClass.DIAGNOSTIC,
+                protocol="tcp",
+            ),
+            ServicePortMapping(
+                service_id="dns-test",
+                port_id="dns-test",
+                internal_port=53,
+                external_port=1053,
+                exposure=PortExposureClass.DIAGNOSTIC,
+                protocol="udp",
+            ),
+        ),
+    )

--- a/tests/application/services/platform/test_preflight_service.py
+++ b/tests/application/services/platform/test_preflight_service.py
@@ -424,6 +424,30 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertIn("tools/windows/tws-wsl-bridge.ps1 -Action install", bridge_check.remediation)
         self.assertEqual("80,10000", bridge_check.evidence["missing_ports"])
 
+    async def test_wsl2_live_preflight_reports_stale_bridge_refresh_guidance(self):
+        result = await PreflightService(
+            _fake_probe(
+                host_environment=_wsl2_environment(),
+                windows_bridge_status=WindowsWslBridgeStatus(
+                    prepared=False,
+                    reason="wsl_ip_changed",
+                    state_path="tools/windows/.tws-wsl-bridge.state.json",
+                    current_wsl_ip="172.21.0.9",
+                    state_wsl_ip="172.20.0.2",
+                    expected_ports=(80,),
+                    mapped_ports=(80,),
+                    state_age_seconds=42,
+                ),
+            ),
+            port_registry=_bridge_port_registry(),
+        ).run(LiveConsent(live_flag=True, confirmed=True))
+
+        bridge_check = {check.check_id: check for check in result.failed_checks}["WINDOWS-WSL-BRIDGE"]
+
+        self.assertFalse(result.passed)
+        self.assertEqual("42", bridge_check.evidence["state_age_seconds"])
+        self.assertIn("Start-ScheduledTask", bridge_check.remediation)
+
     async def test_wsl2_live_preflight_passes_when_windows_bridge_state_is_prepared(self):
         result = await PreflightService(
             _fake_probe(host_environment=_wsl2_environment()),
@@ -436,6 +460,15 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.passed)
         self.assertEqual(PreflightStatus.PASSED, bridge_check.status)
         self.assertEqual("80,10000", bridge_check.evidence["expected_ports"])
+
+    async def test_windows_bridge_expected_ports_falls_back_to_required_ports_without_registry(self):
+        configuration = default_preflight_configuration()
+        service = PreflightService(_fake_probe(), configuration)
+
+        self.assertEqual(
+            tuple(required.port for required in configuration.required_ports),
+            service._windows_bridge_expected_ports(),
+        )
 
     async def test_native_linux_live_preflight_does_not_require_windows_bridge(self):
         result = await PreflightService(
@@ -486,6 +519,14 @@ class TestPreflightService(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("native_linux", host_check.evidence["environment"])
         self.assertEqual("legacy_boolean_compatible", host_check.evidence["classification"])
         self.assertFalse(any(check_id.startswith("RUNTIME-") for check_id in checks_by_id))
+
+    def test_legacy_boolean_probe_uses_default_windows_bridge_status(self):
+        status = _LegacyBooleanProbe().windows_wsl_bridge_status((10000, 80))
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("unsupported_probe", status.reason)
+        self.assertEqual((80, 10000), status.expected_ports)
+        self.assertEqual((80, 10000), status.missing_ports)
 
     async def test_static_local_password_defaults_do_not_satisfy_missing_secret_values(self):
         result = await PreflightService(

--- a/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
+++ b/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import os
 import socket
 import ssl
@@ -7,6 +8,7 @@ import subprocess
 import tempfile
 import urllib.error
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -371,6 +373,67 @@ class TestHostPreflightProbe(unittest.TestCase):
         self.assertEqual("unknown_unsupported", report.evidence["classification"])
         self.assertEqual("darwin", report.evidence["kernel_family"])
 
+    def test_windows_wsl_bridge_status_reports_missing_state_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            probe = HostPreflightProbe(Path(temporary_directory))
+
+            status = probe.windows_wsl_bridge_status((80, 10000))
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("state_missing", status.reason)
+        self.assertEqual((80, 10000), status.missing_ports)
+        self.assertEqual("tools/windows/.tws-wsl-bridge.state.json", status.state_path)
+
+    def test_windows_wsl_bridge_status_accepts_current_ip_and_all_expected_ports(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            _write_bridge_state(root, wsl_ip="172.20.0.2", ports=(80, 10000))
+            probe = HostPreflightProbe(root)
+
+            with patch(
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                return_value="172.20.0.2",
+            ):
+                status = probe.windows_wsl_bridge_status((80, 10000))
+
+        self.assertTrue(status.prepared)
+        self.assertEqual("prepared", status.reason)
+        self.assertEqual((80, 10000), status.mapped_ports)
+        self.assertEqual((), status.missing_ports)
+
+    def test_windows_wsl_bridge_status_detects_changed_wsl_ip(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            _write_bridge_state(root, wsl_ip="172.20.0.2", ports=(80,))
+            probe = HostPreflightProbe(root)
+
+            with patch(
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                return_value="172.21.0.9",
+            ):
+                status = probe.windows_wsl_bridge_status((80,))
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("wsl_ip_changed", status.reason)
+        self.assertEqual("172.20.0.2", status.state_wsl_ip)
+        self.assertEqual("172.21.0.9", status.current_wsl_ip)
+
+    def test_windows_wsl_bridge_status_detects_missing_expected_ports(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            _write_bridge_state(root, wsl_ip="172.20.0.2", ports=(80,))
+            probe = HostPreflightProbe(root)
+
+            with patch(
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                return_value="172.20.0.2",
+            ):
+                status = probe.windows_wsl_bridge_status((80, 10000))
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("missing_ports", status.reason)
+        self.assertEqual((10000,), status.missing_ports)
+
     def test_secret_available_uses_environment_without_reading_values(self):
         probe = HostPreflightProbe(Path.cwd())
 
@@ -696,3 +759,19 @@ def _write_os_signal(root: Path, *parts: str, text: str) -> None:
     target = root.joinpath(*parts)
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(text, encoding="utf-8")
+
+
+def _write_bridge_state(root: Path, *, wsl_ip: str, ports: tuple[int, ...]) -> None:
+    target = root / "tools" / "windows" / ".tws-wsl-bridge.state.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    state = {
+        "generatedAt": datetime.now(UTC).isoformat(),
+        "action": "install",
+        "wslIp": wsl_ip,
+        "listenAddress": "0.0.0.0",
+        "mappings": [
+            {"name": f"port-{port}", "listenPort": port, "connectPort": port}
+            for port in ports
+        ],
+    }
+    target.write_text(json.dumps(state), encoding="utf-8")

--- a/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
+++ b/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
@@ -391,7 +391,7 @@ class TestHostPreflightProbe(unittest.TestCase):
             probe = HostPreflightProbe(root)
 
             with patch(
-                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe.current_wsl_ipv4",
                 return_value="172.20.0.2",
             ):
                 status = probe.windows_wsl_bridge_status((80, 10000))
@@ -408,7 +408,7 @@ class TestHostPreflightProbe(unittest.TestCase):
             probe = HostPreflightProbe(root)
 
             with patch(
-                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe.current_wsl_ipv4",
                 return_value="172.21.0.9",
             ):
                 status = probe.windows_wsl_bridge_status((80,))
@@ -425,7 +425,7 @@ class TestHostPreflightProbe(unittest.TestCase):
             probe = HostPreflightProbe(root)
 
             with patch(
-                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe._current_wsl_ipv4",
+                "tiny_swarm_world.infrastructure.adapters.preflight.host_preflight_probe.current_wsl_ipv4",
                 return_value="172.20.0.2",
             ):
                 status = probe.windows_wsl_bridge_status((80, 10000))

--- a/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
+++ b/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
@@ -1,0 +1,177 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state import (
+    current_wsl_ipv4,
+    windows_wsl_bridge_status,
+)
+
+
+class TestWindowsWslBridgeState(unittest.TestCase):
+    def test_reports_invalid_json_state(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            state_path = _state_path(root)
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text("{not-json", encoding="utf-8")
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("state_invalid", status.reason)
+        self.assertEqual((80,), status.missing_ports)
+
+    def test_reports_missing_generated_timestamp(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(root, {"wslIp": "172.20.0.2", "mappings": [_mapping(80)]})
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("generated_at_missing", status.reason)
+
+    def test_reports_invalid_generated_timestamp(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": "not-a-date",
+                    "wslIp": "172.20.0.2",
+                    "mappings": [_mapping(80)],
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("generated_at_invalid", status.reason)
+
+    def test_reports_stale_state_by_age(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": "2000-01-01T00:00:00Z",
+                    "wslIp": "172.20.0.2",
+                    "mappings": [_mapping(80)],
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                max_age_seconds=1,
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("state_stale_by_age", status.reason)
+        self.assertIsNotNone(status.state_age_seconds)
+
+    def test_reports_unavailable_current_wsl_ip(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": datetime.now(UTC).isoformat(),
+                    "wslIp": "172.20.0.2",
+                    "mappings": [_mapping(80)],
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("wsl_ip_unavailable", status.reason)
+
+    def test_ignores_invalid_mapping_entries(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": datetime.now(UTC).isoformat(),
+                    "wslIp": "172.20.0.2",
+                    "mappings": [
+                        {"listenPort": "invalid"},
+                        {"listenPort": 0},
+                        "not-a-mapping",
+                        _mapping(80),
+                    ],
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80, 10000),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("missing_ports", status.reason)
+        self.assertEqual((80,), status.mapped_ports)
+        self.assertEqual((10000,), status.missing_ports)
+
+    def test_current_wsl_ipv4_reads_first_ipv4_from_hostname_output(self):
+        completed = subprocess.CompletedProcess(
+            ["hostname", "-I"],
+            0,
+            stdout="fe80::1 172.20.0.2 172.20.0.3\n",
+            stderr="",
+        )
+
+        with patch(
+            "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.subprocess.run",
+            return_value=completed,
+        ):
+            self.assertEqual("172.20.0.2", current_wsl_ipv4())
+
+    def test_current_wsl_ipv4_returns_empty_on_timeout(self):
+        with patch(
+            "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(["hostname", "-I"], 5),
+        ):
+            self.assertEqual("", current_wsl_ipv4())
+
+
+def _state_path(root: Path) -> Path:
+    return root / "tools" / "windows" / ".tws-wsl-bridge.state.json"
+
+
+def _write_state(root: Path, state: object) -> None:
+    state_path = _state_path(root)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+
+def _mapping(port: int) -> dict[str, int]:
+    return {"listenPort": port, "connectPort": port}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
+++ b/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
@@ -10,6 +10,7 @@ from tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state
     current_wsl_ipv4,
     windows_wsl_bridge_status,
 )
+from tiny_swarm_world.domain.preflight import WindowsWslBridgeStatus
 
 
 class TestWindowsWslBridgeState(unittest.TestCase):
@@ -29,6 +30,20 @@ class TestWindowsWslBridgeState(unittest.TestCase):
         self.assertFalse(status.prepared)
         self.assertEqual("state_invalid", status.reason)
         self.assertEqual((80,), status.missing_ports)
+
+    def test_reports_non_mapping_state_as_invalid(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(root, ["not", "a", "mapping"])
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("state_invalid", status.reason)
 
     def test_reports_missing_generated_timestamp(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -88,6 +103,26 @@ class TestWindowsWslBridgeState(unittest.TestCase):
         self.assertEqual("state_stale_by_age", status.reason)
         self.assertIsNotNone(status.state_age_seconds)
 
+    def test_accepts_naive_generated_timestamp_as_utc(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": datetime.now(UTC).replace(tzinfo=None).isoformat(),
+                    "wslIp": "172.20.0.2",
+                    "mappings": [_mapping(80)],
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertTrue(status.prepared)
+
     def test_reports_unavailable_current_wsl_ip(self):
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
@@ -108,6 +143,28 @@ class TestWindowsWslBridgeState(unittest.TestCase):
 
         self.assertFalse(status.prepared)
         self.assertEqual("wsl_ip_unavailable", status.reason)
+
+    def test_reports_missing_ports_when_mappings_are_not_a_list(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": datetime.now(UTC).isoformat(),
+                    "wslIp": "172.20.0.2",
+                    "mappings": "not-a-list",
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("missing_ports", status.reason)
+        self.assertEqual((), status.mapped_ports)
 
     def test_ignores_invalid_mapping_entries(self):
         with tempfile.TemporaryDirectory() as tempdir:
@@ -151,12 +208,49 @@ class TestWindowsWslBridgeState(unittest.TestCase):
         ):
             self.assertEqual("172.20.0.2", current_wsl_ipv4())
 
+    def test_current_wsl_ipv4_returns_empty_on_nonzero_exit(self):
+        completed = subprocess.CompletedProcess(
+            ["hostname", "-I"],
+            1,
+            stdout="172.20.0.2\n",
+            stderr="failed",
+        )
+
+        with patch(
+            "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.subprocess.run",
+            return_value=completed,
+        ):
+            self.assertEqual("", current_wsl_ipv4())
+
+    def test_current_wsl_ipv4_returns_empty_without_ipv4_output(self):
+        completed = subprocess.CompletedProcess(
+            ["hostname", "-I"],
+            0,
+            stdout="fe80::1\n",
+            stderr="",
+        )
+
+        with patch(
+            "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.subprocess.run",
+            return_value=completed,
+        ):
+            self.assertEqual("", current_wsl_ipv4())
+
     def test_current_wsl_ipv4_returns_empty_on_timeout(self):
         with patch(
             "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.subprocess.run",
             side_effect=subprocess.TimeoutExpired(["hostname", "-I"], 5),
         ):
             self.assertEqual("", current_wsl_ipv4())
+
+    def test_windows_wsl_bridge_status_stale_property_marks_repair_reasons(self):
+        status = WindowsWslBridgeStatus(
+            prepared=False,
+            reason="generated_at_missing",
+            state_path="tools/windows/.tws-wsl-bridge.state.json",
+        )
+
+        self.assertTrue(status.stale)
 
 
 def _state_path(root: Path) -> Path:

--- a/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
+++ b/tests/infrastructure/adapters/repositories/test_port_registry_yaml_repository.py
@@ -13,11 +13,15 @@ class TestPortRegistryYamlRepository(unittest.TestCase):
         registry = PortRegistryYamlRepository().load()
 
         self.assertEqual(11, len(registry.ranges))
-        self.assertEqual(23, len(registry.mappings))
+        self.assertEqual(24, len(registry.mappings))
         self.assertEqual((80, 443), tuple(port.external_port for port in registry.preflight_ports))
         self.assertEqual(
             PortExposureClass.PUBLIC_INGRESS,
             registry.mapping_for_port_id("traefik-http").exposure,
+        )
+        self.assertEqual(
+            8086,
+            registry.mapping_for_port_id("service-access-legacy-http").external_port,
         )
 
     def test_missing_port_registry_defaults_to_empty_registry(self):

--- a/tests/infrastructure/test_composition.py
+++ b/tests/infrastructure/test_composition.py
@@ -196,6 +196,14 @@ class TestComposition(unittest.TestCase):
         self.assertIn("project_paths", repository_class.call_args.kwargs)
         repository_class.return_value.load.assert_called_once_with()
 
+    def test_windows_wsl_bridge_required_by_default(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(composition._windows_wsl_bridge_required())
+
+    def test_windows_wsl_bridge_can_be_disabled_by_operator_environment(self):
+        with patch.dict(os.environ, {"TSW_WINDOWS_EXPOSURE": "disabled"}, clear=True):
+            self.assertFalse(composition._windows_wsl_bridge_required())
+
     def test_build_configuration_validation_service_uses_env_file_and_process_environment(self):
         with TemporaryDirectory() as temporary_directory:
             env_file = Path(temporary_directory) / "operator.env"

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -392,6 +392,7 @@ class TestInstallScript(unittest.TestCase):
         with _install_script_fixture(
             extra_environment={
                 "TSW_INSTALL_TEST_HOST_RUNTIME": "wsl2",
+                "TSW_WINDOWS_EXPOSURE": "disabled",
                 "WSL_DISTRO_NAME": "Ubuntu",
             },
         ) as fixture:
@@ -404,6 +405,7 @@ class TestInstallScript(unittest.TestCase):
             context = (evidence_dir / "context.txt").read_text()
             self.assertIn("host_runtime_type=wsl2", context)
             self.assertIn("host_runtime_detection_source=test_override", context)
+            self.assertIn("windows_wsl_bridge_reason=windows_exposure_disabled", context)
 
     def test_native_linux_and_wsl2_use_distinct_evidence_directories(self):
         with _install_script_fixture() as native_fixture:
@@ -419,6 +421,7 @@ class TestInstallScript(unittest.TestCase):
         with _install_script_fixture(
             extra_environment={
                 "TSW_INSTALL_TEST_HOST_RUNTIME": "wsl2",
+                "TSW_WINDOWS_EXPOSURE": "disabled",
                 "WSL_DISTRO_NAME": "Ubuntu",
             },
         ) as wsl_fixture:
@@ -430,6 +433,26 @@ class TestInstallScript(unittest.TestCase):
                 ".tiny-swarm-world/evidence/installation-tests/wsl2/",
                 wsl_evidence_dir.as_posix(),
             )
+
+    def test_wsl_install_aborts_before_reset_when_windows_bridge_is_missing(self):
+        with _install_script_fixture(
+            extra_environment={
+                "TSW_INSTALL_TEST_HOST_RUNTIME": "wsl2",
+                "WSL_DISTRO_NAME": "Ubuntu",
+            },
+        ) as fixture:
+            result = fixture.run()
+
+            self.assertEqual(1, result.returncode)
+            self.assertEqual([], fixture.recorded_commands())
+            evidence_dir = fixture.single_evidence_dir("wsl2")
+            context = (evidence_dir / "context.txt").read_text()
+            self.assertIn("windows_wsl_bridge_passed=no", context)
+            self.assertIn("windows_wsl_bridge_reason=state_missing", context)
+            self.assertIn("reset_skipped_due_to_windows_wsl_bridge=yes", context)
+            self.assertFalse((evidence_dir / "reset-run.exit").exists())
+            self.assertFalse((evidence_dir / "setup-run.exit").exists())
+            self.assertIn("Windows <-> WSL bridge is not prepared", result.stderr)
 
 
 class _InstallScriptFixture:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,7 +1,9 @@
+import json
 import stat
 import subprocess
 import tempfile
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -239,6 +241,59 @@ class TestInstaller(unittest.TestCase):
             with self.assertRaisesRegex(installer.InstallerError, "was not provided"):
                 installer._confirm_reset(options)
 
+    def test_windows_wsl_bridge_guard_passes_for_native_linux_without_state(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            guard = installer._windows_wsl_bridge_guard(
+                installer.HostRuntime("native_linux", "test"),
+                {},
+                Path(tempdir),
+            )
+
+        self.assertTrue(guard.passed)
+        self.assertEqual("not_wsl2", guard.reason)
+
+    def test_windows_wsl_bridge_guard_blocks_wsl_without_state(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_ports_registry(root, (80, 10000))
+
+            guard = installer._windows_wsl_bridge_guard(
+                installer.HostRuntime("wsl2", "test"),
+                {},
+                root,
+            )
+
+        self.assertFalse(guard.passed)
+        self.assertEqual("state_missing", guard.reason)
+        self.assertEqual((80, 10000), guard.missing_ports)
+
+    def test_windows_wsl_bridge_guard_accepts_current_state(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_ports_registry(root, (80, 10000))
+            _write_windows_bridge_state(root, "172.20.0.2", (80, 10000))
+
+            with patch.object(installer, "_current_wsl_ipv4", return_value="172.20.0.2"):
+                guard = installer._windows_wsl_bridge_guard(
+                    installer.HostRuntime("wsl2", "test"),
+                    {},
+                    root,
+                )
+
+        self.assertTrue(guard.passed)
+        self.assertEqual("prepared", guard.reason)
+
+    def test_windows_wsl_bridge_guard_can_be_disabled(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            guard = installer._windows_wsl_bridge_guard(
+                installer.HostRuntime("wsl2", "test"),
+                {"TSW_WINDOWS_EXPOSURE": "disabled"},
+                Path(tempdir),
+            )
+
+        self.assertTrue(guard.passed)
+        self.assertEqual("windows_exposure_disabled", guard.reason)
+
     def test_suggested_checks_for_phase_returns_phase_specific_commands(self):
         self.assertEqual(
             (
@@ -345,6 +400,44 @@ class TestInstaller(unittest.TestCase):
 
     def test_setup_failure_guidance_stays_silent_for_other_setup_blocks(self):
         self.assertEqual((), installer._setup_failure_guidance_lines("failed_to_apply"))
+
+
+def _write_ports_registry(root: Path, ports: tuple[int, ...]) -> None:
+    registry = root / "infra" / "config" / "ports.yaml"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "ports:",
+    ]
+    for index, port in enumerate(ports):
+        lines.extend(
+            (
+                f"  - id: port-{index}",
+                f"    service_id: service-{index}",
+                f"    internal_port: {port}",
+                f"    external_port: {port}",
+                "    exposure: diagnostic",
+                "    protocol: tcp",
+            )
+        )
+    registry.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _write_windows_bridge_state(root: Path, wsl_ip: str, ports: tuple[int, ...]) -> None:
+    state_path = root / "tools" / "windows" / ".tws-wsl-bridge.state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state = {
+        "generatedAt": datetime.now(UTC).isoformat(),
+        "wslIp": wsl_ip,
+        "mappings": [
+            {
+                "name": f"port-{port}",
+                "listenPort": port,
+                "connectPort": port,
+            }
+            for port in ports
+        ],
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -273,7 +273,10 @@ class TestInstaller(unittest.TestCase):
             _write_ports_registry(root, (80, 10000))
             _write_windows_bridge_state(root, "172.20.0.2", (80, 10000))
 
-            with patch.object(installer, "_current_wsl_ipv4", return_value="172.20.0.2"):
+            with patch(
+                "tiny_swarm_world.infrastructure.adapters.preflight.windows_wsl_bridge_state.current_wsl_ipv4",
+                return_value="172.20.0.2",
+            ):
                 guard = installer._windows_wsl_bridge_guard(
                     installer.HostRuntime("wsl2", "test"),
                     {},

--- a/tools/windows/CODEX_WORKFLOW_WINDOWS_WSL_BRIDGE.md
+++ b/tools/windows/CODEX_WORKFLOW_WINDOWS_WSL_BRIDGE.md
@@ -1,0 +1,164 @@
+# Codex Workflow: Windows <-> WSL Missing Link Pre-Installation Mechanism
+
+## Context
+
+Tiny Swarm World runs under WSL, but Windows must be able to access services through a browser before and after installation. WSL is treated as the guest system. Windows must explicitly bridge traffic to the current WSL IP.
+
+The missing link must be implemented under:
+
+```text
+tools/windows
+```
+
+## Goal
+
+Create a Windows-side pre-installation mechanism that prepares and refreshes the network bridge between Windows and WSL before `./install.sh` is allowed to run.
+
+## Required files
+
+```text
+tools/windows/
+  tws-wsl-bridge.ps1
+  tws-wsl-bridge.config.json
+  README.windows-wsl-bridge.md
+  optional/
+    tws_dns_resolver.py
+```
+
+## Functional requirements
+
+### 1. Admin boundary
+
+The PowerShell bridge script must fail fast unless it runs elevated for actions that mutate Windows state:
+
+- install
+- refresh
+- uninstall
+
+The verify/status actions may run non-elevated where possible.
+
+### 2. WSL IP detection
+
+The script must read the current WSL IP with:
+
+```powershell
+wsl.exe hostname -I
+```
+
+or with an explicit distro:
+
+```powershell
+wsl.exe -d <distro> -e hostname -I
+```
+
+The distro must be configurable.
+
+### 3. Portproxy reconciliation
+
+The script must delete and recreate Tiny Swarm managed TCP portproxy rules using the current WSL IP.
+
+Required default ports are every TCP entry with an `external_port` in:
+
+```text
+infra/config/ports.yaml
+```
+
+Each port maps listenPort -> connectPort unless explicitly configured otherwise.
+
+### 4. Firewall reconciliation
+
+The script must create Windows Firewall inbound allow rules for each configured listen port.
+
+Firewall rules must be identifiable and removable by a Tiny Swarm prefix.
+
+### 5. Hostname reconciliation
+
+The script must add a managed block to the Windows hosts file:
+
+```text
+# >>> Tiny Swarm World WSL Bridge >>>
+127.0.0.1 tws.local gateway.tws.local service-access.tws.local ...
+# <<< Tiny Swarm World WSL Bridge <<<
+```
+
+It must preserve all unrelated hosts-file entries.
+
+### 6. Scheduled Task
+
+The install action must register a Scheduled Task named:
+
+```text
+TinySwarmWorld-WslBridge
+```
+
+The task must run:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File tools/windows/tws-wsl-bridge.ps1 -Action refresh
+```
+
+It must run with highest privileges and be triggerable manually.
+
+### 7. Installer integration
+
+Before live infrastructure installation, `install.sh` must verify that the Windows bridge has either:
+
+- a recent `.tws-wsl-bridge.state.json`, or
+- the platform is not WSL, or
+- Windows exposure was explicitly disabled.
+
+If WSL is detected and Windows exposure is required, the installer must stop before mutating platform state with a precise message:
+
+```text
+Windows <-> WSL bridge is not prepared.
+Run PowerShell as Administrator:
+  tools/windows/tws-wsl-bridge.ps1 -Action install
+```
+
+### 8. Verification layering
+
+The installer must distinguish:
+
+- deployment readiness
+- WSL host exposure readiness
+- Windows exposure readiness
+
+A Windows exposure failure must not be reported as a Docker Swarm deployment failure.
+
+## Acceptance criteria
+
+1. Running the bridge once as Administrator creates:
+   - portproxy rules
+   - firewall rules
+   - hosts-file managed block
+   - scheduled task
+   - `.tws-wsl-bridge.state.json`
+
+2. Running the bridge repeatedly is idempotent.
+
+3. `uninstall` removes only Tiny Swarm managed entries.
+
+4. After WSL IP changes, `Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge` refreshes the portproxy connect address.
+
+5. Tiny Swarm installation fails early if WSL is used and the bridge is missing.
+
+6. Tiny Swarm installation does not fail deployment verification merely because Windows exposure is broken.
+
+7. No hard-coded Windows port list is maintained outside `infra/config/ports.yaml`.
+
+## Evidence required
+
+Codex must provide evidence files or command output for:
+
+```powershell
+netsh interface portproxy show v4tov4
+Get-NetFirewallRule | Where-Object DisplayName -like "Tiny Swarm World TCP *"
+Get-Content C:\Windows\System32\drivers\etc\hosts
+Get-ScheduledTask -TaskName TinySwarmWorld-WslBridge
+```
+
+and from WSL:
+
+```bash
+powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"
+```

--- a/tools/windows/README.windows-wsl-bridge.md
+++ b/tools/windows/README.windows-wsl-bridge.md
@@ -1,0 +1,154 @@
+# Tiny Swarm World Windows <-> WSL Bridge
+
+This directory contains the Windows-side preparation mechanism for Tiny Swarm World when WSL is treated as the guest system.
+
+The bridge is intentionally a **pre-installation step**. It prepares Windows before `./install.sh` runs in WSL.
+
+## Why this exists
+
+Tiny Swarm World runs services inside WSL, then inside Incus/LXC and Docker Swarm. Windows does not reliably discover that nested network path by itself.
+
+This bridge reconciles:
+
+1. Windows `netsh interface portproxy` rules
+2. Windows Firewall inbound rules
+3. Windows `hosts` entries for stable `*.tws.local` names
+4. A Scheduled Task that refreshes the bridge after logon or WSL IP changes
+
+No additional Windows software is required for the default mechanism.
+
+TCP ports and route hostnames are read from `infra/config/ports.yaml`.
+`tws-wsl-bridge.config.json` contains only Windows-side settings such as the
+WSL distro, listen address, hosts address, firewall prefix and extra hostname
+aliases.
+
+## One-time install
+
+Open **PowerShell as Administrator**:
+
+```powershell
+cd D:\Projects\Tiny-Swarm-World
+
+Set-ExecutionPolicy -Scope Process Bypass
+
+.\tools\windows\tws-wsl-bridge.ps1 -Action install
+```
+
+If your WSL distro is not the default distro, edit:
+
+```json
+{
+  "distro": "auto"
+}
+```
+
+in `tools/windows/tws-wsl-bridge.config.json`.
+
+Examples:
+
+```json
+"distro": "Ubuntu-24.04"
+```
+
+or:
+
+```json
+"distro": "Debian"
+```
+
+## Refresh after WSL restart
+
+If WSL was shut down, the WSL IP can change. Refresh the bridge from Windows:
+
+```powershell
+Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
+```
+
+Or from WSL:
+
+```bash
+powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"
+```
+
+## Verify
+
+From Windows PowerShell:
+
+```powershell
+.\tools\windows\tws-wsl-bridge.ps1 -Action status
+.\tools\windows\tws-wsl-bridge.ps1 -Action verify
+```
+
+`verify` may fail before Tiny Swarm services are actually running. That is expected. The bridge can exist before the services listen.
+
+## Tiny Swarm installer preflight
+
+When WSL2 live setup requires Windows exposure, `./install.sh` checks for:
+
+- `tools/windows/.tws-wsl-bridge.state.json`
+- a current WSL IP matching the state file
+- all external TCP ports from `infra/config/ports.yaml` in the state file
+
+If this check fails, setup stops before platform mutation with
+`WINDOWS-WSL-BRIDGE`. To run WSL2 without Windows localhost/browser exposure,
+set `TSW_WINDOWS_EXPOSURE=disabled` explicitly before setup.
+
+## Run Tiny Swarm installation after bridge preparation
+
+Inside WSL:
+
+```bash
+cd /mnt/d/Projects/Tiny-Swarm-World
+
+./install.sh --headless --confirm-reset --non-interactive-live-approval
+```
+
+## Browser entry points
+
+After installation:
+
+```text
+http://gateway.tws.local
+https://gateway.tws.local
+http://service-access.tws.local
+http://localhost:10000
+http://localhost:10080
+https://localhost:10443
+http://localhost:10001
+http://localhost:11080
+http://localhost:12000
+http://localhost:13081
+http://localhost:14080
+http://localhost:15090
+http://localhost:15300
+http://localhost:16080
+http://localhost:17080
+http://localhost:18080
+```
+
+The `*.tws.local` entries are not wildcard DNS entries. The default mechanism
+uses the Windows hosts file. Hostnames come from explicit aliases in
+`tws-wsl-bridge.config.json` plus `route_host` values in
+`infra/config/ports.yaml`.
+
+## Uninstall
+
+Open PowerShell as Administrator:
+
+```powershell
+.\tools\windows\tws-wsl-bridge.ps1 -Action uninstall
+```
+
+This removes only the managed Tiny Swarm portproxy rules, firewall rules, hosts block and scheduled task.
+
+## Optional DNS resolver
+
+`optional\tws_dns_resolver.py` is included only for experiments with a real `tws.local` zone. It is **not** the default path because binding DNS on Windows port 53 and integrating it into Windows name resolution is more fragile than using explicit hosts entries.
+
+Default recommendation:
+
+```text
+Use hosts-file entries for known Tiny Swarm service names.
+Use portproxy for TCP access.
+Use Scheduled Task for automatic refresh.
+```

--- a/tools/windows/optional/tws_dns_resolver.py
+++ b/tools/windows/optional/tws_dns_resolver.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+r"""
+Optional Tiny Swarm World DNS resolver for tws.local.
+
+This is not the default bridge mechanism. Prefer the PowerShell bridge with
+explicit Windows hosts-file entries.
+
+Requirements on Windows:
+  py -m pip install dnslib
+
+Example:
+  py .\tools\windows\optional\tws_dns_resolver.py --distro Debian --zone tws.local --address 127.0.0.1 --port 53
+
+Caveats:
+  - Port 53 may require Administrator privileges.
+  - Windows name resolution must be configured to query this resolver.
+  - DNS uses UDP by default; netsh portproxy is TCP-only and is not suitable
+    as a generic DNS UDP forwarder.
+"""
+
+import argparse
+import subprocess
+import time
+from typing import Optional
+
+from dnslib import A, QTYPE, RCODE, RR
+from dnslib.server import BaseResolver, DNSServer
+
+
+class TwsResolver(BaseResolver):
+    def __init__(self, distro: str, zone: str, ttl: int, cache_seconds: int) -> None:
+        self.distro = distro
+        self.zone = zone.strip(".").lower() + "."
+        self.ttl = ttl
+        self.cache_seconds = cache_seconds
+        self._cached_ip: Optional[str] = None
+        self._cached_until = 0.0
+
+    def resolve(self, request, handler):
+        reply = request.reply()
+        qname = str(request.q.qname).lower()
+        qtype = QTYPE[request.q.qtype]
+
+        if not qname.endswith(self.zone):
+            reply.header.rcode = RCODE.NXDOMAIN
+            return reply
+
+        if qtype not in ("A", "ANY"):
+            return reply
+
+        wsl_ip = self.get_wsl_ip()
+        reply.add_answer(RR(request.q.qname, QTYPE.A, rdata=A(wsl_ip), ttl=self.ttl))
+        return reply
+
+    def get_wsl_ip(self) -> str:
+        now = time.time()
+        if self._cached_ip and now < self._cached_until:
+            return self._cached_ip
+
+        if self.distro == "auto":
+            cmd = ["wsl.exe", "hostname", "-I"]
+        else:
+            cmd = ["wsl.exe", "-d", self.distro, "-e", "hostname", "-I"]
+
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=True)
+        ip = result.stdout.split()[0]
+
+        self._cached_ip = ip
+        self._cached_until = now + self.cache_seconds
+        return ip
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--distro", default="auto", help="WSL distro name, e.g. Debian or Ubuntu-24.04. Use auto for default distro.")
+    parser.add_argument("--zone", default="tws.local", help="DNS zone suffix.")
+    parser.add_argument("--address", default="127.0.0.1", help="Address to bind.")
+    parser.add_argument("--port", default=53, type=int, help="DNS port.")
+    parser.add_argument("--ttl", default=60, type=int)
+    parser.add_argument("--cache-seconds", default=10, type=int)
+    args = parser.parse_args()
+
+    resolver = TwsResolver(
+        distro=args.distro,
+        zone=args.zone,
+        ttl=args.ttl,
+        cache_seconds=args.cache_seconds,
+    )
+
+    server = DNSServer(resolver, address=args.address, port=args.port)
+    server.start()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/windows/tws-wsl-bridge.config.json
+++ b/tools/windows/tws-wsl-bridge.config.json
@@ -1,0 +1,21 @@
+{
+  "distro": "auto",
+  "listenAddress": "0.0.0.0",
+  "hostsAddress": "127.0.0.1",
+  "firewallRulePrefix": "Tiny Swarm World",
+  "hostNames": [
+    "tws.local",
+    "gateway.tws.local",
+    "service-access.tws.local",
+    "portainer.tws.local",
+    "jenkins.tws.local",
+    "sonarqube.tws.local",
+    "nexus.tws.local",
+    "nexus-docker.tws.local",
+    "pulsar.tws.local",
+    "pulsar-manager.tws.local",
+    "swagger.tws.local",
+    "infisical.tws.local",
+    "tiny-swarm.tws.local"
+  ]
+}

--- a/tools/windows/tws-wsl-bridge.ps1
+++ b/tools/windows/tws-wsl-bridge.ps1
@@ -1,0 +1,646 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Tiny Swarm World Windows <-> WSL bridge.
+
+.DESCRIPTION
+  Prepares the Windows side before a Tiny Swarm World installation in WSL.
+  It reconciles:
+    - Windows portproxy rules -> current WSL IP
+    - Windows Firewall inbound rules
+    - Windows hosts-file entries for known tws.local names
+    - Optional Scheduled Task for refresh after logon / WSL IP changes
+
+  Run from an elevated PowerShell once:
+    .\tools\windows\tws-wsl-bridge.ps1 -Action install
+
+  Refresh later:
+    Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
+#>
+
+[CmdletBinding()]
+param(
+    [ValidateSet("install", "refresh", "verify", "status", "uninstall")]
+    [string]$Action = "refresh",
+
+    [string]$ConfigPath = (Join-Path $PSScriptRoot "tws-wsl-bridge.config.json"),
+
+    [string]$TaskName = "TinySwarmWorld-WslBridge",
+
+    [int]$ConnectTimeoutMs = 1500
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$HostsPath = Join-Path $env:windir "System32\drivers\etc\hosts"
+$HostsStart = "# >>> Tiny Swarm World WSL Bridge >>>"
+$HostsEnd = "# <<< Tiny Swarm World WSL Bridge <<<"
+$StatePath = Join-Path $PSScriptRoot ".tws-wsl-bridge.state.json"
+
+function Get-TswRepositoryRoot {
+    return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot "..\..")).Path
+}
+
+function Test-IsAdministrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Assert-Administrator {
+    if (-not (Test-IsAdministrator)) {
+        throw "This action needs an elevated PowerShell. Start PowerShell as Administrator and run the command again."
+    }
+}
+
+function Read-BridgeConfig {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Config file not found: $Path"
+    }
+
+    return Get-Content -LiteralPath $Path -Raw -Encoding UTF8 | ConvertFrom-Json
+}
+
+function Convert-ToArray {
+    param($Value)
+    if ($null -eq $Value) { return @() }
+    if ($Value -is [System.Array]) { return @($Value) }
+    return @($Value)
+}
+
+function Get-WslIp {
+    param($Config)
+
+    $distro = ""
+    if ($Config.PSObject.Properties.Name -contains "distro") {
+        $distro = [string]$Config.distro
+    }
+
+    if ([string]::IsNullOrWhiteSpace($distro) -or $distro -eq "auto") {
+        $raw = & wsl.exe hostname -I 2>$null
+    } else {
+        $raw = & wsl.exe -d $distro -e hostname -I 2>$null
+    }
+
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace(($raw -join " "))) {
+        throw "Could not determine WSL IP. Check that WSL is installed and the configured distro is running. Configured distro: '$distro'"
+    }
+
+    $ip = (($raw -join " ").Trim().Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries))[0]
+
+    if ($ip -notmatch '^\d{1,3}(\.\d{1,3}){3}$') {
+        throw "Invalid WSL IPv4 address returned by WSL: '$ip'"
+    }
+
+    return $ip
+}
+
+function Get-ListenAddress {
+    param($Config)
+    if ($Config.PSObject.Properties.Name -contains "listenAddress" -and -not [string]::IsNullOrWhiteSpace([string]$Config.listenAddress)) {
+        return [string]$Config.listenAddress
+    }
+    return "0.0.0.0"
+}
+
+function Get-HostsAddress {
+    param($Config)
+    if ($Config.PSObject.Properties.Name -contains "hostsAddress" -and -not [string]::IsNullOrWhiteSpace([string]$Config.hostsAddress)) {
+        return [string]$Config.hostsAddress
+    }
+    return "127.0.0.1"
+}
+
+function Get-FirewallRulePrefix {
+    param($Config)
+    if ($Config.PSObject.Properties.Name -contains "firewallRulePrefix" -and -not [string]::IsNullOrWhiteSpace([string]$Config.firewallRulePrefix)) {
+        return [string]$Config.firewallRulePrefix
+    }
+    return "Tiny Swarm World"
+}
+
+function Add-TswRegistryPortMapping {
+    param(
+        [System.Collections.ArrayList] $Mappings,
+        [hashtable] $Entry
+    )
+
+    if (-not $Entry.ContainsKey("external_port")) {
+        return
+    }
+
+    $protocol = "tcp"
+    if ($Entry.ContainsKey("protocol")) {
+        $protocol = [string] $Entry["protocol"]
+    }
+
+    if ($protocol.ToLowerInvariant() -ne "tcp") {
+        return
+    }
+
+    $port = [int] $Entry["external_port"]
+    $name = "port-$port"
+    if ($Entry.ContainsKey("id") -and -not [string]::IsNullOrWhiteSpace([string] $Entry["id"])) {
+        $name = [string] $Entry["id"]
+    }
+
+    [void] $Mappings.Add([pscustomobject]@{
+        Name        = $name
+        ListenPort  = $port
+        ConnectPort = $port
+    })
+}
+
+function Add-TswRegistryHostName {
+    param(
+        [System.Collections.ArrayList] $HostNames,
+        [hashtable] $Entry
+    )
+
+    if (-not $Entry.ContainsKey("route_host")) {
+        return
+    }
+
+    $hostName = [string] $Entry["route_host"]
+    if (-not [string]::IsNullOrWhiteSpace($hostName)) {
+        [void] $HostNames.Add($hostName)
+    }
+}
+
+function Read-TswPortRegistry {
+    param([string] $RegistryPath)
+
+    $mappings = [System.Collections.ArrayList]::new()
+    $hostNames = [System.Collections.ArrayList]::new()
+    if (-not (Test-Path -LiteralPath $RegistryPath)) {
+        return [pscustomobject]@{ Mappings = @(); HostNames = @() }
+    }
+
+    $inPorts = $false
+    $current = $null
+
+    foreach ($line in Get-Content -LiteralPath $RegistryPath) {
+        if ($line -match "^ports:\s*$") {
+            $inPorts = $true
+            continue
+        }
+        if (-not $inPorts) {
+            continue
+        }
+        if ($line -match "^\S" -and $line -notmatch "^ports:\s*$") {
+            break
+        }
+        if ($line -match "^\s*-\s+id:\s*(.+?)\s*$") {
+            if ($null -ne $current) {
+                Add-TswRegistryPortMapping -Mappings $mappings -Entry $current
+                Add-TswRegistryHostName -HostNames $hostNames -Entry $current
+            }
+            $current = @{ id = $Matches[1].Trim().Trim('"').Trim("'") }
+            continue
+        }
+        if ($null -eq $current) {
+            continue
+        }
+        if ($line -match "^\s+external_port:\s*(\d+)\s*$") {
+            $current["external_port"] = [int] $Matches[1]
+            continue
+        }
+        if ($line -match "^\s+protocol:\s*(\S+)\s*$") {
+            $current["protocol"] = $Matches[1].Trim().Trim('"').Trim("'")
+            continue
+        }
+        if ($line -match "^\s+route_host:\s*(\S+)\s*$") {
+            $current["route_host"] = $Matches[1].Trim().Trim('"').Trim("'")
+            continue
+        }
+    }
+
+    if ($null -ne $current) {
+        Add-TswRegistryPortMapping -Mappings $mappings -Entry $current
+        Add-TswRegistryHostName -HostNames $hostNames -Entry $current
+    }
+
+    return [pscustomobject]@{
+        Mappings = @($mappings | Sort-Object ListenPort -Unique)
+        HostNames = @($hostNames | Sort-Object -Unique)
+    }
+}
+
+function Get-ConfigPortMappings {
+    param($Config)
+
+    $result = @()
+    $propertyNames = $Config.PSObject.Properties.Name
+    $mappingProperties = @("additionalPortMappings", "portMappings")
+
+    foreach ($propertyName in $mappingProperties) {
+        if (-not ($propertyNames -contains $propertyName)) {
+            continue
+        }
+        foreach ($m in (Convert-ToArray $Config.$propertyName)) {
+            $name = "port-$($m.listenPort)"
+            if ($m.PSObject.Properties.Name -contains "name" -and -not [string]::IsNullOrWhiteSpace([string]$m.name)) {
+                $name = [string]$m.name
+            }
+
+            $result += [pscustomobject]@{
+                Name        = $name
+                ListenPort  = [int]$m.listenPort
+                ConnectPort = [int]$m.connectPort
+            }
+        }
+    }
+
+    if ($propertyNames -contains "ports") {
+        foreach ($p in (Convert-ToArray $Config.ports)) {
+            $port = [int]$p
+            $result += [pscustomobject]@{
+                Name        = "port-$port"
+                ListenPort  = $port
+                ConnectPort = $port
+            }
+        }
+    }
+
+    return $result
+}
+
+function Get-PortMappings {
+    param(
+        $Config,
+        $RegistryMappings
+    )
+
+    $result = @()
+    $seenPorts = [System.Collections.Generic.HashSet[int]]::new()
+
+    foreach ($m in (Convert-ToArray $RegistryMappings)) {
+        if ($seenPorts.Add([int] $m.ListenPort)) {
+            $result += $m
+        }
+    }
+
+    foreach ($m in (Get-ConfigPortMappings $Config)) {
+        if ($seenPorts.Add([int] $m.ListenPort)) {
+            $result += $m
+        }
+    }
+
+    if ($result.Count -eq 0) {
+        throw "No ports configured. Add external TCP ports to infra\config\ports.yaml or provide additionalPortMappings in $ConfigPath."
+    }
+
+    return $result | Sort-Object ListenPort -Unique
+}
+
+function Remove-PortProxy {
+    param(
+        [string]$ListenAddress,
+        [int]$ListenPort
+    )
+
+    $null = & netsh interface portproxy delete v4tov4 "listenaddress=$ListenAddress" "listenport=$ListenPort" protocol=tcp 2>$null
+}
+
+function Add-PortProxy {
+    param(
+        [string]$ListenAddress,
+        [int]$ListenPort,
+        [string]$ConnectAddress,
+        [int]$ConnectPort
+    )
+
+    $output = & netsh interface portproxy add v4tov4 "listenaddress=$ListenAddress" "listenport=$ListenPort" "connectaddress=$ConnectAddress" "connectport=$ConnectPort" protocol=tcp 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to add portproxy $ListenAddress`:$ListenPort -> $ConnectAddress`:$ConnectPort. Output: $($output -join ' ')"
+    }
+}
+
+function Reconcile-PortProxy {
+    param(
+        $Config,
+        [string]$WslIp,
+        $Mappings
+    )
+
+    $listenAddress = Get-ListenAddress $Config
+
+    foreach ($m in $Mappings) {
+        Remove-PortProxy -ListenAddress $listenAddress -ListenPort $m.ListenPort
+        Add-PortProxy -ListenAddress $listenAddress -ListenPort $m.ListenPort -ConnectAddress $WslIp -ConnectPort $m.ConnectPort
+        Write-Host ("PORTPROXY {0}:{1} -> {2}:{3} ({4})" -f $listenAddress, $m.ListenPort, $WslIp, $m.ConnectPort, $m.Name)
+    }
+}
+
+function Reconcile-FirewallRules {
+    param(
+        $Config,
+        $Mappings
+    )
+
+    $prefix = Get-FirewallRulePrefix $Config
+
+    Get-NetFirewallRule -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like "$prefix TCP *" } |
+        Remove-NetFirewallRule -ErrorAction SilentlyContinue
+
+    foreach ($port in (($Mappings | Select-Object -ExpandProperty ListenPort) | Sort-Object -Unique)) {
+        $ruleName = "$prefix TCP $port"
+        New-NetFirewallRule `
+            -DisplayName $ruleName `
+            -Direction Inbound `
+            -Action Allow `
+            -Protocol TCP `
+            -LocalPort $port `
+            -Profile Any | Out-Null
+
+        Write-Host ("FIREWALL allow TCP {0}" -f $port)
+    }
+}
+
+function Remove-ManagedHostsBlock {
+    if (-not (Test-Path -LiteralPath $HostsPath)) {
+        return ""
+    }
+
+    $content = Get-Content -LiteralPath $HostsPath -Raw -ErrorAction Stop
+    $startEsc = [regex]::Escape($HostsStart)
+    $endEsc = [regex]::Escape($HostsEnd)
+    $pattern = "(?ms)^[ \t]*$startEsc.*?^[ \t]*$endEsc[ \t]*(\r?\n)?"
+    return [regex]::Replace($content, $pattern, "")
+}
+
+function Get-BridgeHostNames {
+    param(
+        $Config,
+        $RegistryHostNames
+    )
+
+    $hostNames = @()
+    if (-not ($Config.PSObject.Properties.Name -contains "hostNames")) {
+        $hostNames = @()
+    } else {
+        $hostNames = @(Convert-ToArray $Config.hostNames | ForEach-Object { [string]$_ })
+    }
+
+    $hostNames += @(Convert-ToArray $RegistryHostNames | ForEach-Object { [string]$_ })
+    return @($hostNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique)
+}
+
+function Reconcile-HostsFile {
+    param(
+        $Config,
+        $HostNames
+    )
+
+    $hostNames = @(Convert-ToArray $HostNames)
+    if ($hostNames.Count -eq 0) {
+        return
+    }
+
+    $hostsAddress = Get-HostsAddress $Config
+    $content = Remove-ManagedHostsBlock
+
+    $block = @()
+    $block += $HostsStart
+
+    $line = "$hostsAddress`t$($hostNames -join ' ')"
+    $block += $line
+
+    $block += $HostsEnd
+
+    $newContent = $content.TrimEnd() + [Environment]::NewLine + ($block -join [Environment]::NewLine) + [Environment]::NewLine
+
+    Set-Content -LiteralPath $HostsPath -Value $newContent -Encoding ASCII -Force
+    Write-Host ("HOSTS {0} -> {1}" -f ($hostNames -join ", "), $hostsAddress)
+}
+
+function Remove-HostsFileBlock {
+    $content = Remove-ManagedHostsBlock
+    Set-Content -LiteralPath $HostsPath -Value ($content.TrimEnd() + [Environment]::NewLine) -Encoding ASCII -Force
+    Write-Host "HOSTS managed Tiny Swarm block removed"
+}
+
+function Register-BridgeTask {
+    param([string]$ResolvedConfigPath)
+
+    $scriptPath = $PSCommandPath
+    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`" -Action refresh -ConfigPath `"$ResolvedConfigPath`""
+
+    $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $arguments
+    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Highest
+    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew
+
+    Register-ScheduledTask `
+        -TaskName $TaskName `
+        -Action $action `
+        -Trigger $trigger `
+        -Principal $principal `
+        -Settings $settings `
+        -Description "Refresh Tiny Swarm World Windows <-> WSL bridge after WSL IP changes." `
+        -Force | Out-Null
+
+    Write-Host "TASK registered: $TaskName"
+}
+
+function Unregister-BridgeTask {
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($null -ne $task) {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+        Write-Host "TASK removed: $TaskName"
+    }
+}
+
+function Remove-BridgeFirewallRules {
+    param($Config)
+
+    $prefix = Get-FirewallRulePrefix $Config
+
+    Get-NetFirewallRule -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -like "$prefix TCP *" } |
+        Remove-NetFirewallRule -ErrorAction SilentlyContinue
+
+    Write-Host "FIREWALL managed Tiny Swarm rules removed"
+}
+
+function Remove-BridgePortProxy {
+    param(
+        $Config,
+        $Mappings
+    )
+
+    $listenAddress = Get-ListenAddress $Config
+    foreach ($m in $Mappings) {
+        Remove-PortProxy -ListenAddress $listenAddress -ListenPort $m.ListenPort
+        Write-Host ("PORTPROXY removed {0}:{1}" -f $listenAddress, $m.ListenPort)
+    }
+}
+
+function Test-TcpPort {
+    param(
+        [string]$HostName,
+        [int]$Port,
+        [int]$TimeoutMs
+    )
+
+    $client = New-Object System.Net.Sockets.TcpClient
+    try {
+        $async = $client.BeginConnect($HostName, $Port, $null, $null)
+        $ok = $async.AsyncWaitHandle.WaitOne($TimeoutMs, $false)
+        if ($ok) {
+            $client.EndConnect($async)
+            return $true
+        }
+        return $false
+    } catch {
+        return $false
+    } finally {
+        $client.Close()
+    }
+}
+
+function Verify-Bridge {
+    param(
+        $Config,
+        $Mappings
+    )
+
+    $failed = @()
+
+    foreach ($m in $Mappings) {
+        $ok = Test-TcpPort -HostName "127.0.0.1" -Port $m.ListenPort -TimeoutMs $ConnectTimeoutMs
+        if ($ok) {
+            Write-Host ("VERIFY OK   127.0.0.1:{0} ({1})" -f $m.ListenPort, $m.Name)
+        } else {
+            Write-Host ("VERIFY FAIL 127.0.0.1:{0} ({1})" -f $m.ListenPort, $m.Name) -ForegroundColor Yellow
+            $failed += $m
+        }
+    }
+
+    if ($failed.Count -gt 0) {
+        throw "Windows bridge verification failed for $($failed.Count) port(s). This can also mean the Tiny Swarm services are not running yet."
+    }
+}
+
+function Write-StateFile {
+    param(
+        $Config,
+        [string]$WslIp,
+        $Mappings,
+        $HostNames,
+        [string]$RegistryPath
+    )
+
+    $state = [ordered]@{
+        generatedAt        = (Get-Date).ToString("o")
+        action             = $Action
+        wslIp              = $WslIp
+        listenAddress      = (Get-ListenAddress $Config)
+        hostsAddress       = (Get-HostsAddress $Config)
+        configPath         = (Resolve-Path -LiteralPath $ConfigPath).Path
+        registryPath       = $RegistryPath
+        hostNames          = @($HostNames)
+        mappings           = @($Mappings | ForEach-Object {
+            [ordered]@{
+                name        = $_.Name
+                listenPort  = $_.ListenPort
+                connectPort = $_.ConnectPort
+            }
+        })
+    }
+
+    $state | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $StatePath -Encoding UTF8
+    Write-Host "STATE written: $StatePath"
+}
+
+function Show-Status {
+    param(
+        $Config,
+        $Mappings,
+        $HostNames
+    )
+
+    Write-Host "Tiny Swarm World Windows <-> WSL bridge status"
+    Write-Host ("Config: {0}" -f (Resolve-Path -LiteralPath $ConfigPath).Path)
+    Write-Host ("Ports: {0}" -f (($Mappings | Select-Object -ExpandProperty ListenPort) -join ", "))
+    Write-Host ("Hosts: {0}" -f ($HostNames -join ", "))
+
+    try {
+        $wslIp = Get-WslIp $Config
+        Write-Host ("WSL IP: {0}" -f $wslIp)
+    } catch {
+        Write-Host ("WSL IP: unavailable - {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "Portproxy:"
+    & netsh interface portproxy show v4tov4
+
+    Write-Host ""
+    Write-Host "Scheduled task:"
+    Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue | Format-List TaskName, State, TaskPath
+
+    Write-Host ""
+    Write-Host "Managed hosts block present:"
+    if ((Test-Path -LiteralPath $HostsPath) -and ((Get-Content -LiteralPath $HostsPath -Raw) -like "*$HostsStart*")) {
+        Write-Host "yes"
+    } else {
+        Write-Host "no"
+    }
+}
+
+$config = Read-BridgeConfig -Path $ConfigPath
+$registryPath = Join-Path (Get-TswRepositoryRoot) "infra\config\ports.yaml"
+$registry = Read-TswPortRegistry -RegistryPath $registryPath
+$mappings = @(Get-PortMappings $config $registry.Mappings)
+$hostNames = @(Get-BridgeHostNames $config $registry.HostNames)
+
+switch ($Action) {
+    "install" {
+        Assert-Administrator
+        $resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
+        $wslIp = Get-WslIp $config
+        Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
+        Reconcile-FirewallRules -Config $config -Mappings $mappings
+        Reconcile-HostsFile -Config $config -HostNames $hostNames
+        Register-BridgeTask -ResolvedConfigPath $resolvedConfig
+        Write-StateFile -Config $config -WslIp $wslIp -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
+        Write-Host ""
+        Write-Host "Installed. You can refresh later with:"
+        Write-Host "  Start-ScheduledTask -TaskName $TaskName"
+    }
+
+    "refresh" {
+        Assert-Administrator
+        $wslIp = Get-WslIp $config
+        Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
+        Reconcile-FirewallRules -Config $config -Mappings $mappings
+        Reconcile-HostsFile -Config $config -HostNames $hostNames
+        Write-StateFile -Config $config -WslIp $wslIp -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
+        Write-Host "Refresh completed."
+    }
+
+    "verify" {
+        Verify-Bridge -Config $config -Mappings $mappings
+    }
+
+    "status" {
+        Show-Status -Config $config -Mappings $mappings -HostNames $hostNames
+    }
+
+    "uninstall" {
+        Assert-Administrator
+        Remove-BridgePortProxy -Config $config -Mappings $mappings
+        Remove-BridgeFirewallRules -Config $config
+        Remove-HostsFileBlock
+        Unregister-BridgeTask
+        if (Test-Path -LiteralPath $StatePath) {
+            Remove-Item -LiteralPath $StatePath -Force
+        }
+        Write-Host "Uninstalled."
+    }
+}


### PR DESCRIPTION
## Summary
- Add the committed Windows WSL bridge package under `tools/windows`.
- Make WSL2 installation fail before reset/setup mutation when the Windows bridge state is missing, stale, points at an old WSL IP, or lacks required TCP ports.
- Wire the same non-mutating bridge status into live preflight and platform evidence.
- Read Windows bridge ports and route hosts from `infra/config/ports.yaml`; keep existing `*.tsw.local` registry names and packaged `*.tws.local` aliases.
- Document the elevated PowerShell install/refresh path and the `TSW_WINDOWS_EXPOSURE=disabled` operator opt-out.

## Changed Areas
- Installer precondition: `src/tiny_swarm_world/installer.py`
- Preflight model/service/adapter: `src/tiny_swarm_world/domain/preflight`, `src/tiny_swarm_world/application/services/platform/preflight_service.py`, `src/tiny_swarm_world/infrastructure/adapters/preflight/host_preflight_probe.py`
- Central port registry: `infra/config/ports.yaml`
- Windows bridge package: `tools/windows/**`
- Documentation: `documentation/system/network.adoc`, `documentation/user_guide/troubleshooting.adoc`, `tools/windows/README.windows-wsl-bridge.md`
- Regression tests: `tests/**`

## Verification
- PASS: `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python tools/quality_gate.py quality`
- PASS: PowerShell AST parser checks for `tools/windows/tws-wsl-bridge.ps1` and existing Windows helper scripts
- PASS: `git diff --check`
- PASS: staged diff check and added-line secret scan

## Impact
- WSL2 installs now require an explicitly prepared Windows-to-WSL bridge before managed reset/setup starts when Windows localhost exposure is enabled.
- Native Linux installs are unaffected.
- Windows portproxy and firewall mutations remain outside `install.sh` and require elevated PowerShell.

## Risks And Limitations
- The WSL-side precondition validates the bridge state file, WSL IP, age, and mapped ports; it cannot prove elevated Windows firewall state from inside WSL.
- Operators who do not need Windows localhost exposure can set `TSW_WINDOWS_EXPOSURE=disabled`.

## Push Auto
- This PR is intended for `push auto`: wait/retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run repository cleanup after merge verification.
