### PR TITLE
feat(wsl): validate Windows bridge prerequisites

### DIFF
--- a/documentation/system/network.adoc
+++ b/documentation/system/network.adoc
@@ -87,8 +87,15 @@ elevated PowerShell before starting a WSL2 live installation:
 [source,powershell]
 ----
 Set-ExecutionPolicy -Scope Process Bypass
+.\tools\windows\tws-wsl-bridge.ps1 -Action prerequisites
 .\tools\windows\tws-wsl-bridge.ps1 -Action install
 ----
+
+The prerequisite action is read-only and requires Windows 10 or 11, a running
+WSL 2 distribution with systemd as PID 1, elevated PowerShell, a running IP
+Helper service, and the Windows Firewall and Scheduled Task cmdlets. The
+dedicated reproducible setup and repair guide is
+`tools/windows/README.windows-wsl-bridge.md`.
 
 The bridge writes `tools/windows/.tws-wsl-bridge.state.json`. The file is
 local runtime state and ignored by Git. During WSL2 live preflight,

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -300,6 +300,23 @@ resolution must map the routed names to the local machine; DNS does not route
 traffic by itself. It only makes the browser send the correct host name to
 Traefik.
 
+When the services must be reachable from a Windows browser, first prepare the
+Windows side from elevated PowerShell. The prerequisite action is read-only;
+the install action creates the managed portproxy, Firewall, hosts-file,
+Scheduled Task, and local bridge-state contract:
+
+[source,powershell]
+----
+Set-ExecutionPolicy -Scope Process Bypass
+.\tools\windows\tws-wsl-bridge.ps1 -Action prerequisites
+.\tools\windows\tws-wsl-bridge.ps1 -Action install
+----
+
+See `tools/windows/README.windows-wsl-bridge.md` for WSL 2, systemd, IP Helper,
+repair, status, and verification instructions. `install.sh` stops before any
+platform mutation when this Windows bridge state is required but missing or
+stale.
+
 For WSL/Linux shell checks, add the routed names to `/etc/hosts`. If a
 matching `tsw.local` line already exists, update that line instead of adding
 duplicates:

--- a/tests/test_windows_wsl_bridge_assets.py
+++ b/tests/test_windows_wsl_bridge_assets.py
@@ -1,0 +1,66 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_SCRIPT = REPOSITORY_ROOT / "tools" / "windows" / "tws-wsl-bridge.ps1"
+BRIDGE_GUIDE = REPOSITORY_ROOT / "tools" / "windows" / "README.windows-wsl-bridge.md"
+NETWORK_GUIDE = REPOSITORY_ROOT / "documentation" / "system" / "network.adoc"
+
+
+class TestWindowsWslBridgeAssets(unittest.TestCase):
+    def test_bridge_script_exposes_read_only_prerequisite_action(self):
+        script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'ValidateSet("prerequisites", "install", "refresh", "verify", "status", "uninstall")',
+            script,
+        )
+        self.assertIn('"prerequisites" {', script)
+        self.assertIn("No bridge state was changed.", script)
+        self.assertIn("function Get-BridgePrerequisiteResults", script)
+        self.assertIn("function Assert-BridgePrerequisites", script)
+
+    def test_install_and_refresh_gate_mutations_on_prerequisites(self):
+        script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+
+        for action in ("install", "refresh"):
+            with self.subTest(action=action):
+                block = _switch_block(script, action)
+                prerequisite_index = block.index("Assert-BridgePrerequisites")
+                reconcile_index = block.index("Reconcile-PortProxy")
+                self.assertLess(prerequisite_index, reconcile_index)
+
+    def test_bridge_guides_document_reproducible_preparation(self):
+        bridge_guide = BRIDGE_GUIDE.read_text(encoding="utf-8")
+        network_guide = NETWORK_GUIDE.read_text(encoding="utf-8")
+
+        for expected in (
+            "-Action prerequisites",
+            "-Action install",
+            "systemd",
+            "iphlpsvc",
+            "Prepared-state contract",
+            "infra/config/ports.yaml",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, bridge_guide)
+
+        self.assertIn("-Action prerequisites", network_guide)
+        self.assertIn("tools/windows/README.windows-wsl-bridge.md", network_guide)
+
+
+def _switch_block(script: str, action: str) -> str:
+    match = re.search(
+        rf'^    "{re.escape(action)}" \{{(?P<body>.*?)^    \}}',
+        script,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Missing PowerShell switch block for {action}")
+    return match.group("body")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/windows/README.windows-wsl-bridge.md
+++ b/tools/windows/README.windows-wsl-bridge.md
@@ -22,6 +22,76 @@ TCP ports and route hostnames are read from `infra/config/ports.yaml`.
 WSL distro, listen address, hosts address, firewall prefix and extra hostname
 aliases.
 
+## Prerequisites
+
+The supported bridge path requires:
+
+1. Windows 10 or Windows 11 with WSL 2 installed
+2. A running WSL 2 distribution; the default distribution is used unless
+   `distro` is set in `tws-wsl-bridge.config.json`
+3. `systemd` as PID 1 inside that distribution
+4. Windows PowerShell 5.1 or newer, opened as Administrator
+5. The Windows IP Helper service (`iphlpsvc`) running
+6. Windows Firewall and Scheduled Task cmdlets
+7. The tracked bridge config and `infra/config/ports.yaml`
+
+Check all prerequisites without changing portproxy, Firewall, hosts, task, or
+state-file data:
+
+```powershell
+cd D:\Projects\Tiny-Swarm-World
+Set-ExecutionPolicy -Scope Process Bypass
+.\tools\windows\tws-wsl-bridge.ps1 -Action prerequisites
+```
+
+The check is ready only when every line reports `PREREQUISITE OK`. A normal,
+non-elevated PowerShell deliberately reports `administrator` as failed because
+the subsequent install needs elevation.
+
+### Reach the prerequisite state
+
+Install or update WSL and make WSL 2 the default from elevated PowerShell:
+
+```powershell
+wsl --install
+wsl --update
+wsl --set-default-version 2
+wsl --list --verbose
+```
+
+If the selected distribution is still version 1, convert it explicitly:
+
+```powershell
+wsl --set-version <DistributionName> 2
+```
+
+Enable systemd inside the selected WSL distribution by adding this content to
+`/etc/wsl.conf`:
+
+```ini
+[boot]
+systemd=true
+```
+
+Then restart WSL from Windows and verify PID 1:
+
+```powershell
+wsl --shutdown
+wsl -d <DistributionName> --exec sh -lc "ps -p 1 -o comm="
+```
+
+The result must be `systemd`. If IP Helper is stopped, start it from elevated
+PowerShell:
+
+```powershell
+Start-Service iphlpsvc
+Set-Service iphlpsvc -StartupType Automatic
+```
+
+Re-run `-Action prerequisites` after each repair. Installing WSL or converting
+a distribution can require a reboot; the bridge script does not hide that
+host-level lifecycle.
+
 ## One-time install
 
 Open **PowerShell as Administrator**:
@@ -33,6 +103,10 @@ Set-ExecutionPolicy -Scope Process Bypass
 
 .\tools\windows\tws-wsl-bridge.ps1 -Action install
 ```
+
+`install` repeats the prerequisite gate before making changes. It then
+reconciles only Tiny Swarm World's registry-defined TCP mappings and managed
+Windows artifacts. Re-running it is the supported repair path.
 
 If your WSL distro is not the default distro, edit:
 
@@ -79,7 +153,35 @@ From Windows PowerShell:
 .\tools\windows\tws-wsl-bridge.ps1 -Action verify
 ```
 
-`verify` may fail before Tiny Swarm services are actually running. That is expected. The bridge can exist before the services listen.
+Use the actions for different evidence:
+
+- `prerequisites` proves that Windows and WSL can support the bridge.
+- `status` shows configured ports, the current WSL IP, portproxy state, the
+  Scheduled Task, and the managed hosts block.
+- `verify` performs live TCP connections to every registry-defined Windows
+  localhost port.
+
+`verify` may fail before Tiny Swarm services are actually running. That is
+expected and does not invalidate a successful prerequisite or bridge install.
+After the Tiny Swarm installation, all ports belonging to deployed services
+must be checked again as live service evidence.
+
+## Prepared-state contract
+
+The Windows/WSL bridge is prepared for `install.sh` when:
+
+- `prerequisites` passes;
+- the managed portproxy rules target the current WSL IPv4 address;
+- matching Tiny Swarm World Firewall rules exist;
+- the managed `*.tsw.local` hosts block exists;
+- `TinySwarmWorld-WslBridge` is registered for refresh after logon;
+- `tools/windows/.tws-wsl-bridge.state.json` exists, is recent, records the
+  current WSL IP, and contains every external TCP port from
+  `infra/config/ports.yaml`.
+
+Run `-Action install` to create this complete state. Run `-Action refresh`
+after a WSL address change. The generated state file is ignored by Git and
+must not be committed.
 
 ## Tiny Swarm installer preflight
 

--- a/tools/windows/tws-wsl-bridge.ps1
+++ b/tools/windows/tws-wsl-bridge.ps1
@@ -11,6 +11,9 @@
     - Windows hosts-file entries for known tws.local names
     - Optional Scheduled Task for refresh after logon / WSL IP changes
 
+  Check Windows and WSL prerequisites without changing state:
+    .\tools\windows\tws-wsl-bridge.ps1 -Action prerequisites
+
   Run from an elevated PowerShell once:
     .\tools\windows\tws-wsl-bridge.ps1 -Action install
 
@@ -20,7 +23,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet("install", "refresh", "verify", "status", "uninstall")]
+    [ValidateSet("prerequisites", "install", "refresh", "verify", "status", "uninstall")]
     [string]$Action = "refresh",
 
     [string]$ConfigPath = (Join-Path $PSScriptRoot "tws-wsl-bridge.config.json"),
@@ -51,6 +54,164 @@ function Test-IsAdministrator {
 function Assert-Administrator {
     if (-not (Test-IsAdministrator)) {
         throw "This action needs an elevated PowerShell. Start PowerShell as Administrator and run the command again."
+    }
+}
+
+function Get-ConfiguredDistro {
+    param($Config)
+
+    if ($Config.PSObject.Properties.Name -contains "distro") {
+        return [string]$Config.distro
+    }
+    return "auto"
+}
+
+function Invoke-WslShellText {
+    param(
+        $Config,
+        [string]$Command
+    )
+
+    $distro = Get-ConfiguredDistro $Config
+    if ([string]::IsNullOrWhiteSpace($distro) -or $distro -eq "auto") {
+        $raw = & wsl.exe sh -lc $Command 2>$null
+    } else {
+        $raw = & wsl.exe -d $distro -e sh -lc $Command 2>$null
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "WSL command failed for configured distro '$distro': $Command"
+    }
+
+    return ($raw -join "`n").Trim()
+}
+
+function New-BridgePrerequisiteResult {
+    param(
+        [string]$Name,
+        [bool]$Passed,
+        [string]$Message
+    )
+
+    return [pscustomobject]@{
+        Name    = $Name
+        Passed  = $Passed
+        Message = $Message
+    }
+}
+
+function Get-BridgePrerequisiteResults {
+    param($Config)
+
+    $results = [System.Collections.ArrayList]::new()
+    $windowsDetected = [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "windows" `
+        -Passed $windowsDetected `
+        -Message $(if ($windowsDetected) { "Windows host detected." } else { "Run this script from Windows PowerShell." })))
+
+    $isAdministrator = Test-IsAdministrator
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "administrator" `
+        -Passed $isAdministrator `
+        -Message $(if ($isAdministrator) { "PowerShell is elevated." } else { "Open PowerShell as Administrator." })))
+
+    $wslAvailable = $null -ne (Get-Command wsl.exe -ErrorAction SilentlyContinue)
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "wsl-command" `
+        -Passed $wslAvailable `
+        -Message $(if ($wslAvailable) { "wsl.exe is available." } else { "Install WSL 2 before preparing the bridge." })))
+
+    $netshAvailable = $null -ne (Get-Command netsh.exe -ErrorAction SilentlyContinue)
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "netsh-command" `
+        -Passed $netshAvailable `
+        -Message $(if ($netshAvailable) { "netsh.exe is available." } else { "netsh.exe is required for Windows portproxy rules." })))
+
+    $firewallAvailable = $null -ne (Get-Command New-NetFirewallRule -ErrorAction SilentlyContinue)
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "firewall-cmdlet" `
+        -Passed $firewallAvailable `
+        -Message $(if ($firewallAvailable) { "Windows Firewall cmdlets are available." } else { "New-NetFirewallRule is unavailable." })))
+
+    $taskAvailable = $null -ne (Get-Command Register-ScheduledTask -ErrorAction SilentlyContinue)
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "task-cmdlet" `
+        -Passed $taskAvailable `
+        -Message $(if ($taskAvailable) { "Scheduled Task cmdlets are available." } else { "Register-ScheduledTask is unavailable." })))
+
+    $ipHelper = Get-Service -Name iphlpsvc -ErrorAction SilentlyContinue
+    $ipHelperRunning = $null -ne $ipHelper -and $ipHelper.Status -eq "Running"
+    [void]$results.Add((New-BridgePrerequisiteResult `
+        -Name "ip-helper" `
+        -Passed $ipHelperRunning `
+        -Message $(if ($ipHelperRunning) { "IP Helper is running." } else { "Start the Windows IP Helper service (iphlpsvc)." })))
+
+    if ($wslAvailable) {
+        try {
+            $kernelRelease = Invoke-WslShellText -Config $Config -Command "uname -r"
+            $isWsl2 = $kernelRelease -match "(?i)(microsoft-standard-wsl2|wsl2)"
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl2-runtime" `
+                -Passed $isWsl2 `
+                -Message $(if ($isWsl2) { "Configured distro is running under WSL 2." } else { "Configured distro is not running under WSL 2." })))
+        } catch {
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl2-runtime" `
+                -Passed $false `
+                -Message $_.Exception.Message))
+        }
+
+        try {
+            $pidOne = Invoke-WslShellText -Config $Config -Command "ps -p 1 -o comm="
+            $systemdRunning = $pidOne.Trim() -eq "systemd"
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl-systemd" `
+                -Passed $systemdRunning `
+                -Message $(if ($systemdRunning) { "systemd is PID 1 in the configured distro." } else { "Enable systemd in the configured WSL distro." })))
+        } catch {
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl-systemd" `
+                -Passed $false `
+                -Message $_.Exception.Message))
+        }
+
+        try {
+            $wslIp = Get-WslIp $Config
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl-ipv4" `
+                -Passed $true `
+                -Message "Current WSL IPv4 address resolved: $wslIp"))
+        } catch {
+            [void]$results.Add((New-BridgePrerequisiteResult `
+                -Name "wsl-ipv4" `
+                -Passed $false `
+                -Message $_.Exception.Message))
+        }
+    }
+
+    return @($results)
+}
+
+function Write-BridgePrerequisiteResults {
+    param($Results)
+
+    foreach ($result in $Results) {
+        $status = if ($result.Passed) { "OK" } else { "FAIL" }
+        $color = if ($result.Passed) { "Green" } else { "Yellow" }
+        Write-Host ("PREREQUISITE {0,-4} {1}: {2}" -f $status, $result.Name, $result.Message) -ForegroundColor $color
+    }
+}
+
+function Assert-BridgePrerequisites {
+    param($Config)
+
+    $results = @(Get-BridgePrerequisiteResults -Config $Config)
+    Write-BridgePrerequisiteResults -Results $results
+    $failed = @($results | Where-Object { -not $_.Passed })
+    if ($failed.Count -gt 0) {
+        $failedNames = $failed.Name -join ", "
+        throw "Windows/WSL bridge prerequisites failed: $failedNames"
     }
 }
 
@@ -600,8 +761,13 @@ $mappings = @(Get-PortMappings $config $registry.Mappings)
 $hostNames = @(Get-BridgeHostNames $config $registry.HostNames)
 
 switch ($Action) {
+    "prerequisites" {
+        Assert-BridgePrerequisites -Config $config
+        Write-Host "Windows/WSL bridge prerequisites are ready. No bridge state was changed."
+    }
+
     "install" {
-        Assert-Administrator
+        Assert-BridgePrerequisites -Config $config
         $resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
         $wslIp = Get-WslIp $config
         Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
@@ -615,7 +781,7 @@ switch ($Action) {
     }
 
     "refresh" {
-        Assert-Administrator
+        Assert-BridgePrerequisites -Config $config
         $wslIp = Get-WslIp $config
         Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
         Reconcile-FirewallRules -Config $config -Mappings $mappings


### PR DESCRIPTION
## Summary
- add a read-only Windows/WSL bridge prerequisite action
- gate bridge installation and refresh before mutating Windows state
- document reproducible WSL 2, systemd, IP Helper, firewall, task, and verification setup
- add regression coverage for the bridge assets

## Verification
- PowerShell parser: passed
- targeted bridge tests: 3 passed
- full quality gate: lint, architecture, typecheck, 1324 tests passed (28 skipped)