### PR TITLE
feat(wsl): add scheduled bridge discovery agent

### DIFF
--- a/documentation/system/network.adoc
+++ b/documentation/system/network.adoc
@@ -97,15 +97,19 @@ Helper service, and the Windows Firewall and Scheduled Task cmdlets. The
 dedicated reproducible setup and repair guide is
 `tools/windows/README.windows-wsl-bridge.md`.
 
-The bridge writes `tools/windows/.tws-wsl-bridge.state.json`. The file is
-local runtime state and ignored by Git. During WSL2 live preflight,
-Tiny Swarm World requires this state to be present, recent, matched to the
-current WSL IP, and to contain every external TCP port from
-`infra/config/ports.yaml`. If the state is missing or stale, setup stops
-before platform mutation with a `WINDOWS-WSL-BRIDGE` preflight failure.
+The install action registers a Windows Scheduled Task discovery agent. It runs
+after logon and periodically, discovers the current WSL IP and reconciles only
+drifted portproxy, Firewall and hosts-file resources. The bridge writes
+`tools/windows/.tws-wsl-bridge.state.json`; this ignored local state contains a
+versioned agent contract and heartbeat. During WSL2 live preflight, Tiny Swarm
+World requires the agent to report `ready`, a heartbeat no older than five
+minutes, the current WSL IP, and every external TCP port from
+`infra/config/ports.yaml`. If the state is missing or stale, setup stops before
+platform mutation with a `WINDOWS-WSL-BRIDGE` preflight failure.
 
-After `wsl --shutdown` or another WSL restart, refresh the bridge from Windows
-or WSL:
+After `wsl --shutdown` or another WSL restart, the agent repairs the changed
+address automatically. To request immediate reconciliation from Windows or
+WSL:
 
 [source,powershell]
 ----
@@ -119,8 +123,9 @@ powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld
 
 The bridge reads TCP ports and route hostnames from `infra/config/ports.yaml`.
 `tools/windows/tws-wsl-bridge.config.json` is limited to Windows-side
-settings such as distro selection, listen address, hosts address, and
-additional hostname aliases. Do not maintain a separate Windows port list.
+settings such as distro selection, listen address, hosts address, discovery
+interval, and additional hostname aliases. Do not maintain a separate Windows
+port list.
 
 Use the older portproxy scripts only for focused Windows-side diagnosis or
 manual repair:

--- a/documentation/user_guide/installation.adoc
+++ b/documentation/user_guide/installation.adoc
@@ -293,7 +293,7 @@ Traefik.
 When the services must be reachable from a Windows browser, first prepare the
 Windows side from elevated PowerShell. The prerequisite action is read-only;
 the install action creates the managed portproxy, Firewall, hosts-file,
-Scheduled Task, and local bridge-state contract:
+Scheduled Task discovery agent, and local bridge-state contract:
 
 [source,powershell]
 ----
@@ -303,9 +303,9 @@ Set-ExecutionPolicy -Scope Process Bypass
 ----
 
 See `tools/windows/README.windows-wsl-bridge.md` for WSL 2, systemd, IP Helper,
-repair, status, and verification instructions. `install.sh` stops before any
-platform mutation when this Windows bridge state is required but missing or
-stale.
+automatic discovery/reconcile, repair, status, and verification instructions.
+`install.sh` stops before any platform mutation when the current discovery
+heartbeat or Windows bridge state is required but missing, degraded, or stale.
 
 For WSL/Linux shell checks, add the routed names to `/etc/hosts`. If a
 matching `tsw.local` line already exists, update that line instead of adding

--- a/documentation/user_guide/troubleshooting.adoc
+++ b/documentation/user_guide/troubleshooting.adoc
@@ -180,7 +180,8 @@ When WSL2 live setup requires Windows browser access, Tiny Swarm World checks
 the Windows-side bridge before platform mutation. A failed
 `WINDOWS-WSL-BRIDGE` preflight check means the Windows portproxy, Firewall,
 hosts-file and Scheduled Task bridge has not been prepared, is stale, or no
-longer matches the current WSL IP.
+longer matches the current WSL IP. A legacy bridge without the scheduled
+discovery-agent contract is also rejected.
 
 Prepare or repair it from elevated Windows PowerShell:
 
@@ -191,7 +192,9 @@ Set-ExecutionPolicy -Scope Process Bypass
 .\tools\windows\tws-wsl-bridge.ps1 -Action install
 ----
 
-After `wsl --shutdown`, refresh the existing bridge:
+After `wsl --shutdown`, the scheduled discovery agent normally repairs the
+changed address within the configured interval. Trigger immediate reconcile
+with:
 
 [source,powershell]
 ----
@@ -206,9 +209,11 @@ state:
 powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"
 ----
 
-The installer does not set Windows portproxy, Firewall, hosts-file or
-Scheduled Task state by itself. To run WSL2 without Windows localhost
-exposure, set `TSW_WINDOWS_EXPOSURE=disabled` explicitly before setup.
+The installer does not set Windows portproxy, Firewall, hosts-file or Scheduled
+Task state by itself. It requires the registered agent to have written a
+`ready` heartbeat within the last five minutes. To run WSL2 without Windows
+localhost exposure, set `TSW_WINDOWS_EXPOSURE=disabled` explicitly before
+setup.
 
 == Setup Preflight Reports Occupied Ports
 

--- a/src/tiny_swarm_world/application/services/platform/preflight_service.py
+++ b/src/tiny_swarm_world/application/services/platform/preflight_service.py
@@ -662,11 +662,11 @@ def _windows_wsl_bridge_remediation(reason: str) -> str:
         "tools/windows/tws-wsl-bridge.ps1 -Action install."
     )
     refresh = (
-        "After WSL IP changes, run: "
+        "Request immediate discovery/reconcile: "
         "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge."
     )
     disable = "Set TSW_WINDOWS_EXPOSURE=disabled only when Windows localhost exposure is not required."
-    if reason in {"wsl_ip_changed", "state_stale_by_age"}:
+    if reason in {"wsl_ip_changed", "state_stale_by_age", "agent_not_ready"}:
         return f"{refresh} If the task is missing, {install} {disable}"
     return f"{install} {disable}"
 

--- a/src/tiny_swarm_world/domain/preflight/windows_wsl_bridge.py
+++ b/src/tiny_swarm_world/domain/preflight/windows_wsl_bridge.py
@@ -30,6 +30,8 @@ class WindowsWslBridgeStatus:
             "missing_ports",
             "generated_at_missing",
             "generated_at_invalid",
+            "agent_contract_missing",
+            "agent_not_ready",
         }
 
 

--- a/src/tiny_swarm_world/infrastructure/adapters/preflight/windows_wsl_bridge_state.py
+++ b/src/tiny_swarm_world/infrastructure/adapters/preflight/windows_wsl_bridge_state.py
@@ -11,7 +11,9 @@ from tiny_swarm_world.domain.preflight import WindowsWslBridgeStatus
 
 
 WINDOWS_WSL_BRIDGE_STATE = Path("tools/windows/.tws-wsl-bridge.state.json")
-DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+WINDOWS_WSL_BRIDGE_CONTRACT_VERSION = 2
+WINDOWS_WSL_BRIDGE_AGENT_MODE = "scheduled-discovery"
+DEFAULT_WINDOWS_WSL_BRIDGE_STATE_MAX_AGE_SECONDS = 5 * 60
 
 
 def windows_wsl_bridge_status(
@@ -58,6 +60,9 @@ def windows_wsl_bridge_status(
     generated_at = str(raw_state.get("generatedAt", ""))
     listen_address = str(raw_state.get("listenAddress", ""))
     state_wsl_ip = str(raw_state.get("wslIp", ""))
+    contract_version = raw_state.get("contractVersion")
+    agent_mode = str(raw_state.get("agentMode", ""))
+    agent_status = str(raw_state.get("agentStatus", ""))
     current_wsl_ip = current_wsl_ipv4()
     state_age_seconds = _state_age_seconds(generated_at)
 
@@ -88,6 +93,10 @@ def windows_wsl_bridge_status(
         return bridge_status(False, "wsl_ip_changed")
     if missing_ports:
         return bridge_status(False, "missing_ports")
+    if contract_version != WINDOWS_WSL_BRIDGE_CONTRACT_VERSION or agent_mode != WINDOWS_WSL_BRIDGE_AGENT_MODE:
+        return bridge_status(False, "agent_contract_missing")
+    if agent_status != "ready":
+        return bridge_status(False, "agent_not_ready")
     return bridge_status(True, "prepared")
 
 

--- a/src/tiny_swarm_world/installer.py
+++ b/src/tiny_swarm_world/installer.py
@@ -28,7 +28,7 @@ DEFAULT_GENERATED_SECRET_ENV_FILE = ".tiny-swarm/secrets/generated.local.env"
 DEFAULT_NATIVE_LINUX_VENV = ".tiny-swarm-world/install-venv"
 DEFAULT_SECRET_MANIFEST_PATH = Path("infra/config/secrets/infisical-secrets.yaml")
 WINDOWS_WSL_BRIDGE_STATE_PATH = Path("tools/windows/.tws-wsl-bridge.state.json")
-WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+WINDOWS_WSL_BRIDGE_MAX_AGE_SECONDS = 5 * 60
 WINDOWS_EXPOSURE_ENVIRONMENT = "TSW_WINDOWS_EXPOSURE"
 INSTALLER_REQUIRED_SOURCES = frozenset({"generated_local_secret", "placeholder_only"})
 SECRET_MODES = ("generated", "fixed", "infisical")
@@ -1153,7 +1153,7 @@ def _windows_wsl_bridge_context(
 
 
 def _windows_wsl_bridge_suggested_commands(reason: str) -> tuple[str, ...]:
-    if reason in {"wsl_ip_changed", "state_stale_by_age"}:
+    if reason in {"wsl_ip_changed", "state_stale_by_age", "agent_not_ready"}:
         return (
             'powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"',
             "powershell.exe -ExecutionPolicy Bypass -File tools/windows/tws-wsl-bridge.ps1 -Action install",
@@ -1178,7 +1178,7 @@ def _print_windows_wsl_bridge_failure(
     print("", file=sys.stderr)
     print("Run PowerShell as Administrator:", file=sys.stderr)
     print("  tools/windows/tws-wsl-bridge.ps1 -Action install", file=sys.stderr)
-    if guard.reason in {"wsl_ip_changed", "state_stale_by_age"}:
+    if guard.reason in {"wsl_ip_changed", "state_stale_by_age", "agent_not_ready"}:
         print("", file=sys.stderr)
         print("Or refresh the existing scheduled task:", file=sys.stderr)
         print("  Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge", file=sys.stderr)

--- a/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
+++ b/tests/infrastructure/adapters/preflight/test_host_preflight_probe.py
@@ -767,6 +767,9 @@ def _write_bridge_state(root: Path, *, wsl_ip: str, ports: tuple[int, ...]) -> N
     target = root / "tools" / "windows" / ".tws-wsl-bridge.state.json"
     target.parent.mkdir(parents=True, exist_ok=True)
     state = {
+        "contractVersion": 2,
+        "agentMode": "scheduled-discovery",
+        "agentStatus": "ready",
         "generatedAt": datetime.now(UTC).isoformat(),
         "action": "install",
         "wslIp": wsl_ip,

--- a/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
+++ b/tests/infrastructure/adapters/preflight/test_windows_wsl_bridge_state.py
@@ -208,6 +208,53 @@ class TestWindowsWslBridgeState(unittest.TestCase):
         ):
             self.assertEqual("172.20.0.2", current_wsl_ipv4())
 
+    def test_reports_legacy_state_without_discovery_agent_contract(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            state_path = _state_path(root)
+            state_path.parent.mkdir(parents=True)
+            state_path.write_text(
+                json.dumps(
+                    {
+                        "generatedAt": datetime.now(UTC).isoformat(),
+                        "wslIp": "172.20.0.2",
+                        "mappings": [_mapping(80)],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("agent_contract_missing", status.reason)
+
+    def test_reports_degraded_discovery_agent(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            _write_state(
+                root,
+                {
+                    "generatedAt": datetime.now(UTC).isoformat(),
+                    "wslIp": "172.20.0.2",
+                    "mappings": [_mapping(80)],
+                    "agentStatus": "degraded",
+                },
+            )
+
+            status = windows_wsl_bridge_status(
+                root,
+                (80,),
+                current_wsl_ipv4=lambda: "172.20.0.2",
+            )
+
+        self.assertFalse(status.prepared)
+        self.assertEqual("agent_not_ready", status.reason)
+
     def test_current_wsl_ipv4_returns_empty_on_nonzero_exit(self):
         completed = subprocess.CompletedProcess(
             ["hostname", "-I"],
@@ -260,6 +307,10 @@ def _state_path(root: Path) -> Path:
 def _write_state(root: Path, state: object) -> None:
     state_path = _state_path(root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(state, dict):
+        state.setdefault("contractVersion", 2)
+        state.setdefault("agentMode", "scheduled-discovery")
+        state.setdefault("agentStatus", "ready")
     state_path.write_text(json.dumps(state), encoding="utf-8")
 
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -456,6 +456,9 @@ def _write_windows_bridge_state(root: Path, wsl_ip: str, ports: tuple[int, ...])
     state_path = root / "tools" / "windows" / ".tws-wsl-bridge.state.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state = {
+        "contractVersion": 2,
+        "agentMode": "scheduled-discovery",
+        "agentStatus": "ready",
         "generatedAt": datetime.now(UTC).isoformat(),
         "wslIp": wsl_ip,
         "mappings": [

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,8 +1,10 @@
+import io
 import json
 import stat
 import subprocess
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -323,6 +325,31 @@ class TestInstaller(unittest.TestCase):
 
         self.assertTrue(guard.passed)
         self.assertEqual("windows_exposure_disabled", guard.reason)
+
+    def test_windows_wsl_bridge_agent_not_ready_suggests_task_refresh(self):
+        self.assertEqual(
+            (
+                'powershell.exe -NoProfile -Command "Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge"',
+                "powershell.exe -ExecutionPolicy Bypass -File tools/windows/tws-wsl-bridge.ps1 -Action install",
+            ),
+            installer._windows_wsl_bridge_suggested_commands("agent_not_ready"),
+        )
+
+    def test_print_windows_wsl_bridge_failure_for_agent_not_ready_mentions_refresh(self):
+        guard = installer.WindowsWslBridgeGuardResult(
+            passed=False,
+            reason="agent_not_ready",
+            state_path=Path("tools/windows/.tws-wsl-bridge.state.json"),
+        )
+        stderr = io.StringIO()
+
+        with redirect_stderr(stderr):
+            installer._print_windows_wsl_bridge_failure(guard, Path(".tiny-swarm-world/evidence/test"))
+
+        rendered = stderr.getvalue()
+        self.assertIn("Reason: agent_not_ready", rendered)
+        self.assertIn("Or refresh the existing scheduled task:", rendered)
+        self.assertIn("Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge", rendered)
 
     def test_suggested_checks_for_phase_returns_phase_specific_commands(self):
         self.assertEqual(

--- a/tests/test_windows_wsl_bridge_assets.py
+++ b/tests/test_windows_wsl_bridge_assets.py
@@ -6,6 +6,7 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 BRIDGE_SCRIPT = REPOSITORY_ROOT / "tools" / "windows" / "tws-wsl-bridge.ps1"
 BRIDGE_GUIDE = REPOSITORY_ROOT / "tools" / "windows" / "README.windows-wsl-bridge.md"
+BRIDGE_CONFIG = REPOSITORY_ROOT / "tools" / "windows" / "tws-wsl-bridge.config.json"
 NETWORK_GUIDE = REPOSITORY_ROOT / "documentation" / "system" / "network.adoc"
 
 
@@ -14,7 +15,7 @@ class TestWindowsWslBridgeAssets(unittest.TestCase):
         script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
 
         self.assertIn(
-            'ValidateSet("prerequisites", "install", "refresh", "verify", "status", "uninstall")',
+            'ValidateSet("prerequisites", "discover", "install", "reconcile", "refresh", "verify", "status", "uninstall")',
             script,
         )
         self.assertIn('"prerequisites" {', script)
@@ -22,15 +23,57 @@ class TestWindowsWslBridgeAssets(unittest.TestCase):
         self.assertIn("function Get-BridgePrerequisiteResults", script)
         self.assertIn("function Assert-BridgePrerequisites", script)
 
-    def test_install_and_refresh_gate_mutations_on_prerequisites(self):
+    def test_install_and_reconcile_gate_mutations_on_prerequisites(self):
         script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
 
-        for action in ("install", "refresh"):
+        for action in ("install", "reconcile", "refresh"):
             with self.subTest(action=action):
                 block = _switch_block(script, action)
                 prerequisite_index = block.index("Assert-BridgePrerequisites")
-                reconcile_index = block.index("Reconcile-PortProxy")
+                reconcile_index = block.index("Invoke-BridgeReconcile")
                 self.assertLess(prerequisite_index, reconcile_index)
+
+    def test_bridge_registers_periodic_discovery_reconcile_agent(self):
+        script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+        config = BRIDGE_CONFIG.read_text(encoding="utf-8")
+        install_block = _switch_block(script, "install")
+
+        self.assertIn("function Get-BridgeDiscovery", script)
+        self.assertIn("function Invoke-BridgeReconcile", script)
+        self.assertIn("-Action reconcile", script)
+        self.assertIn("New-ScheduledTaskTrigger -AtLogOn", script)
+        self.assertIn("-RepetitionInterval", script)
+        self.assertIn('contractVersion    = 2', script)
+        self.assertIn('agentMode          = "scheduled-discovery"', script)
+        self.assertLess(install_block.index("Register-BridgeTask"), install_block.index("Invoke-BridgeReconcile"))
+        self.assertIn('"discoveryIntervalMinutes": 1', config)
+
+    def test_resource_reconcile_paths_are_no_op_when_state_matches(self):
+        script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+
+        for expected in (
+            "Test-PortProxyMappingsReady",
+            "PORTPROXY unchanged",
+            "Test-FirewallRuleReady",
+            "FIREWALL unchanged",
+            "Test-HostsFileReady",
+            "HOSTS unchanged",
+        ):
+            with self.subTest(expected=expected):
+                self.assertIn(expected, script)
+
+    def test_reconcile_records_discovery_before_failing_on_remaining_drift(self):
+        script = BRIDGE_SCRIPT.read_text(encoding="utf-8")
+        block = _function_block(script, "Invoke-BridgeReconcile")
+
+        pending_state_index = block.index("reconcile_in_progress")
+        mutation_index = block.index("Reconcile-PortProxy")
+        discovery_index = block.index("Get-BridgeDiscovery")
+        state_index = block.rindex("Write-StateFile")
+        failure_index = block.index("if (-not $discovery.Ready)")
+        self.assertLess(pending_state_index, mutation_index)
+        self.assertLess(discovery_index, state_index)
+        self.assertLess(state_index, failure_index)
 
     def test_bridge_guides_document_reproducible_preparation(self):
         bridge_guide = BRIDGE_GUIDE.read_text(encoding="utf-8")
@@ -43,6 +86,7 @@ class TestWindowsWslBridgeAssets(unittest.TestCase):
             "iphlpsvc",
             "Prepared-state contract",
             "infra/config/ports.yaml",
+            "scheduled discovery agent",
         ):
             with self.subTest(expected=expected):
                 self.assertIn(expected, bridge_guide)
@@ -59,6 +103,17 @@ def _switch_block(script: str, action: str) -> str:
     )
     if match is None:
         raise AssertionError(f"Missing PowerShell switch block for {action}")
+    return match.group("body")
+
+
+def _function_block(script: str, name: str) -> str:
+    match = re.search(
+        rf"^function {re.escape(name)} \{{(?P<body>.*?)^\}}",
+        script,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Missing PowerShell function {name}")
     return match.group("body")
 
 

--- a/tools/windows/README.windows-wsl-bridge.md
+++ b/tools/windows/README.windows-wsl-bridge.md
@@ -2,7 +2,9 @@
 
 This directory contains the Windows-side preparation mechanism for Tiny Swarm World when WSL is treated as the guest system.
 
-The bridge is intentionally a **pre-installation step**. It prepares Windows before `./install.sh` runs in WSL.
+The bridge is intentionally a **one-time pre-installation step**. It prepares
+Windows before `./install.sh` runs in WSL and registers a scheduled discovery
+agent that keeps the bridge aligned with the current WSL address afterwards.
 
 ## Why this exists
 
@@ -13,7 +15,8 @@ This bridge reconciles:
 1. Windows `netsh interface portproxy` rules
 2. Windows Firewall inbound rules
 3. Windows `hosts` entries for stable `*.tws.local` names
-4. A Scheduled Task that refreshes the bridge after logon or WSL IP changes
+4. A Scheduled Task that discovers and reconciles drift after logon and every
+   configured interval
 
 No additional Windows software is required for the default mechanism.
 
@@ -104,9 +107,10 @@ Set-ExecutionPolicy -Scope Process Bypass
 .\tools\windows\tws-wsl-bridge.ps1 -Action install
 ```
 
-`install` repeats the prerequisite gate before making changes. It then
-reconciles only Tiny Swarm World's registry-defined TCP mappings and managed
-Windows artifacts. Re-running it is the supported repair path.
+`install` repeats the prerequisite gate before making changes. It registers the
+scheduled discovery agent and then reconciles only Tiny Swarm World's
+registry-defined TCP mappings and managed Windows artifacts. Re-running it is
+the supported repair and agent-upgrade path.
 
 If your WSL distro is not the default distro, edit:
 
@@ -117,6 +121,9 @@ If your WSL distro is not the default distro, edit:
 ```
 
 in `tools/windows/tws-wsl-bridge.config.json`.
+
+`discoveryIntervalMinutes` controls the periodic reconcile interval and must be
+between 1 and 60. The default is one minute.
 
 Examples:
 
@@ -130,9 +137,16 @@ or:
 "distro": "Debian"
 ```
 
-## Refresh after WSL restart
+## Automatic discovery after WSL restart
 
-If WSL was shut down, the WSL IP can change. Refresh the bridge from Windows:
+The scheduled discovery agent runs after Windows logon and once per configured
+interval. It reads the current WSL IPv4 address and the repository port
+registry, compares them with the observed Windows portproxy, Firewall and
+hosts-file state, and changes only drifted resources. An unchanged run is a
+no-op apart from renewing the prepared-state heartbeat.
+
+If immediate recovery is needed before the next interval, trigger the agent
+from Windows:
 
 ```powershell
 Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
@@ -156,6 +170,8 @@ From Windows PowerShell:
 Use the actions for different evidence:
 
 - `prerequisites` proves that Windows and WSL can support the bridge.
+- `discover` is read-only and reports `READY` or the detected drift reasons.
+- `reconcile` is the idempotent action used by the scheduled discovery agent.
 - `status` shows configured ports, the current WSL IP, portproxy state, the
   Scheduled Task, and the managed hosts block.
 - `verify` performs live TCP connections to every registry-defined Windows
@@ -174,26 +190,36 @@ The Windows/WSL bridge is prepared for `install.sh` when:
 - the managed portproxy rules target the current WSL IPv4 address;
 - matching Tiny Swarm World Firewall rules exist;
 - the managed `*.tsw.local` hosts block exists;
-- `TinySwarmWorld-WslBridge` is registered for refresh after logon;
+- `TinySwarmWorld-WslBridge` is registered for discovery/reconcile after logon
+  and periodically;
 - `tools/windows/.tws-wsl-bridge.state.json` exists, is recent, records the
   current WSL IP, and contains every external TCP port from
-  `infra/config/ports.yaml`.
+  `infra/config/ports.yaml`;
+- the state reports contract version 2, agent mode `scheduled-discovery`, and
+  agent status `ready`.
 
-Run `-Action install` to create this complete state. Run `-Action refresh`
-after a WSL address change. The generated state file is ignored by Git and
-must not be committed.
+Run `-Action install` once to create this complete state and scheduled agent.
+`refresh` remains a compatibility alias for `reconcile`. The generated state
+file is ignored by Git and must not be committed.
 
 ## Tiny Swarm installer preflight
 
 When WSL2 live setup requires Windows exposure, `./install.sh` checks for:
 
 - `tools/windows/.tws-wsl-bridge.state.json`
+- the scheduled-discovery agent contract and `ready` status
+- a discovery heartbeat no older than five minutes
 - a current WSL IP matching the state file
 - all external TCP ports from `infra/config/ports.yaml` in the state file
 
 If this check fails, setup stops before platform mutation with
 `WINDOWS-WSL-BRIDGE`. To run WSL2 without Windows localhost/browser exposure,
 set `TSW_WINDOWS_EXPOSURE=disabled` explicitly before setup.
+
+Consequently, a successful WSL installation with Windows exposure enabled has
+already passed a current automatic-bridge contract. The agent continues to
+repair later WSL address changes without modifying the native Linux install
+path.
 
 ## Run Tiny Swarm installation after bridge preparation
 
@@ -252,5 +278,5 @@ Default recommendation:
 ```text
 Use hosts-file entries for known Tiny Swarm service names.
 Use portproxy for TCP access.
-Use Scheduled Task for automatic refresh.
+Use the Scheduled Task discovery agent for automatic reconcile.
 ```

--- a/tools/windows/tws-wsl-bridge.config.json
+++ b/tools/windows/tws-wsl-bridge.config.json
@@ -3,6 +3,7 @@
   "listenAddress": "0.0.0.0",
   "hostsAddress": "127.0.0.1",
   "firewallRulePrefix": "Tiny Swarm World",
+  "discoveryIntervalMinutes": 1,
   "hostNames": [
     "tws.local",
     "gateway.tws.local",

--- a/tools/windows/tws-wsl-bridge.ps1
+++ b/tools/windows/tws-wsl-bridge.ps1
@@ -9,7 +9,7 @@
     - Windows portproxy rules -> current WSL IP
     - Windows Firewall inbound rules
     - Windows hosts-file entries for known tws.local names
-    - Optional Scheduled Task for refresh after logon / WSL IP changes
+    - Scheduled discovery/reconcile task after logon and at a fixed interval
 
   Check Windows and WSL prerequisites without changing state:
     .\tools\windows\tws-wsl-bridge.ps1 -Action prerequisites
@@ -17,13 +17,13 @@
   Run from an elevated PowerShell once:
     .\tools\windows\tws-wsl-bridge.ps1 -Action install
 
-  Refresh later:
+  Trigger discovery/reconcile manually:
     Start-ScheduledTask -TaskName TinySwarmWorld-WslBridge
 #>
 
 [CmdletBinding()]
 param(
-    [ValidateSet("prerequisites", "install", "refresh", "verify", "status", "uninstall")]
+    [ValidateSet("prerequisites", "discover", "install", "reconcile", "refresh", "verify", "status", "uninstall")]
     [string]$Action = "refresh",
 
     [string]$ConfigPath = (Join-Path $PSScriptRoot "tws-wsl-bridge.config.json"),
@@ -283,6 +283,19 @@ function Get-FirewallRulePrefix {
     return "Tiny Swarm World"
 }
 
+function Get-DiscoveryIntervalMinutes {
+    param($Config)
+
+    $interval = 1
+    if ($Config.PSObject.Properties.Name -contains "discoveryIntervalMinutes") {
+        $interval = [int]$Config.discoveryIntervalMinutes
+    }
+    if ($interval -lt 1 -or $interval -gt 60) {
+        throw "discoveryIntervalMinutes must be between 1 and 60."
+    }
+    return $interval
+}
+
 function Add-TswRegistryPortMapping {
     param(
         [System.Collections.ArrayList] $Mappings,
@@ -480,7 +493,68 @@ function Add-PortProxy {
     }
 }
 
-function Reconcile-PortProxy {
+function Get-PortProxyRecords {
+    $records = [System.Collections.ArrayList]::new()
+    $output = & netsh interface portproxy show v4tov4 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to inspect Windows portproxy state."
+    }
+
+    foreach ($line in $output) {
+        if ($line -match '^\s*(\d{1,3}(?:\.\d{1,3}){3})\s+(\d+)\s+(\d{1,3}(?:\.\d{1,3}){3})\s+(\d+)\s*$') {
+            [void]$records.Add([pscustomobject]@{
+                ListenAddress  = $Matches[1]
+                ListenPort     = [int]$Matches[2]
+                ConnectAddress = $Matches[3]
+                ConnectPort    = [int]$Matches[4]
+            })
+        }
+    }
+    return @($records)
+}
+
+function Get-PreviousBridgeState {
+    if (-not (Test-Path -LiteralPath $StatePath)) {
+        return $null
+    }
+    try {
+        return Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+}
+
+function Remove-StalePortProxyMappings {
+    param(
+        $Config,
+        $Mappings
+    )
+
+    $previous = Get-PreviousBridgeState
+    if ($null -eq $previous -or -not ($previous.PSObject.Properties.Name -contains "mappings")) {
+        return
+    }
+
+    $listenAddress = Get-ListenAddress $Config
+    $previousListenAddress = $listenAddress
+    if ($previous.PSObject.Properties.Name -contains "listenAddress" -and -not [string]::IsNullOrWhiteSpace([string]$previous.listenAddress)) {
+        $previousListenAddress = [string]$previous.listenAddress
+    }
+    $desiredPorts = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($mapping in $Mappings) {
+        [void]$desiredPorts.Add([int]$mapping.ListenPort)
+    }
+
+    foreach ($mapping in (Convert-ToArray $previous.mappings)) {
+        $port = [int]$mapping.listenPort
+        if ($previousListenAddress -ne $listenAddress -or -not $desiredPorts.Contains($port)) {
+            Remove-PortProxy -ListenAddress $previousListenAddress -ListenPort $port
+            Write-Host ("PORTPROXY stale mapping removed {0}:{1}" -f $previousListenAddress, $port)
+        }
+    }
+}
+
+function Test-PortProxyMappingsReady {
     param(
         $Config,
         [string]$WslIp,
@@ -488,12 +562,91 @@ function Reconcile-PortProxy {
     )
 
     $listenAddress = Get-ListenAddress $Config
+    $records = @(Get-PortProxyRecords)
+    foreach ($mapping in $Mappings) {
+        $matches = @($records | Where-Object {
+            $_.ListenAddress -eq $listenAddress -and
+            $_.ListenPort -eq [int]$mapping.ListenPort -and
+            $_.ConnectAddress -eq $WslIp -and
+            $_.ConnectPort -eq [int]$mapping.ConnectPort
+        })
+        if ($matches.Count -ne 1) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Reconcile-PortProxy {
+    param(
+        $Config,
+        [string]$WslIp,
+        $Mappings
+    )
+
+    Remove-StalePortProxyMappings -Config $Config -Mappings $Mappings
+    $listenAddress = Get-ListenAddress $Config
+    $records = @(Get-PortProxyRecords)
 
     foreach ($m in $Mappings) {
+        $matches = @($records | Where-Object {
+            $_.ListenAddress -eq $listenAddress -and
+            $_.ListenPort -eq [int]$m.ListenPort -and
+            $_.ConnectAddress -eq $WslIp -and
+            $_.ConnectPort -eq [int]$m.ConnectPort
+        })
+        if ($matches.Count -eq 1) {
+            Write-Host ("PORTPROXY unchanged {0}:{1} -> {2}:{3} ({4})" -f $listenAddress, $m.ListenPort, $WslIp, $m.ConnectPort, $m.Name)
+            continue
+        }
         Remove-PortProxy -ListenAddress $listenAddress -ListenPort $m.ListenPort
         Add-PortProxy -ListenAddress $listenAddress -ListenPort $m.ListenPort -ConnectAddress $WslIp -ConnectPort $m.ConnectPort
         Write-Host ("PORTPROXY {0}:{1} -> {2}:{3} ({4})" -f $listenAddress, $m.ListenPort, $WslIp, $m.ConnectPort, $m.Name)
     }
+}
+
+function Test-FirewallRuleReady {
+    param(
+        $Config,
+        [int]$Port
+    )
+
+    $prefix = Get-FirewallRulePrefix $Config
+    $ruleName = "$prefix TCP $Port"
+    $rules = @(Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -eq $ruleName })
+    if ($rules.Count -ne 1) {
+        return $false
+    }
+    $rule = $rules[0]
+    if ($rule.Enabled.ToString() -ne "True" -or $rule.Direction.ToString() -ne "Inbound" -or $rule.Action.ToString() -ne "Allow") {
+        return $false
+    }
+    $filters = @($rule | Get-NetFirewallPortFilter -ErrorAction SilentlyContinue)
+    $matchingFilters = @($filters | Where-Object {
+        $_.LocalPort.ToString() -eq $Port.ToString() -and
+        $_.Protocol.ToString() -in @("TCP", "6")
+    })
+    return $matchingFilters.Count -eq 1
+}
+
+function Test-FirewallRulesReady {
+    param(
+        $Config,
+        $Mappings
+    )
+
+    $prefix = Get-FirewallRulePrefix $Config
+    $desiredPorts = @(($Mappings | Select-Object -ExpandProperty ListenPort) | Sort-Object -Unique)
+    $managedRules = @(Get-NetFirewallRule -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -like "$prefix TCP *" })
+    if ($managedRules.Count -ne $desiredPorts.Count) {
+        return $false
+    }
+    foreach ($port in $desiredPorts) {
+        if (-not (Test-FirewallRuleReady -Config $Config -Port $port)) {
+            return $false
+        }
+    }
+    return $true
 }
 
 function Reconcile-FirewallRules {
@@ -504,12 +657,25 @@ function Reconcile-FirewallRules {
 
     $prefix = Get-FirewallRulePrefix $Config
 
+    $desiredPorts = @(($Mappings | Select-Object -ExpandProperty ListenPort) | Sort-Object -Unique)
+    $desiredNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($port in $desiredPorts) {
+        [void]$desiredNames.Add("$prefix TCP $port")
+    }
+
     Get-NetFirewallRule -ErrorAction SilentlyContinue |
-        Where-Object { $_.DisplayName -like "$prefix TCP *" } |
+        Where-Object { $_.DisplayName -like "$prefix TCP *" -and -not $desiredNames.Contains($_.DisplayName) } |
         Remove-NetFirewallRule -ErrorAction SilentlyContinue
 
-    foreach ($port in (($Mappings | Select-Object -ExpandProperty ListenPort) | Sort-Object -Unique)) {
+    foreach ($port in $desiredPorts) {
         $ruleName = "$prefix TCP $port"
+        if (Test-FirewallRuleReady -Config $Config -Port $port) {
+            Write-Host ("FIREWALL unchanged TCP {0}" -f $port)
+            continue
+        }
+        Get-NetFirewallRule -DisplayName $ruleName -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -eq $ruleName } |
+            Remove-NetFirewallRule -ErrorAction SilentlyContinue
         New-NetFirewallRule `
             -DisplayName $ruleName `
             -Direction Inbound `
@@ -551,6 +717,45 @@ function Get-BridgeHostNames {
     return @($hostNames | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Sort-Object -Unique)
 }
 
+function Get-ReconciledHostsContent {
+    param(
+        $Config,
+        $HostNames
+    )
+
+    $hostNames = @(Convert-ToArray $HostNames)
+    $content = Remove-ManagedHostsBlock
+    if ($hostNames.Count -eq 0) {
+        return $content.TrimEnd() + [Environment]::NewLine
+    }
+
+    $hostsAddress = Get-HostsAddress $Config
+    $block = @(
+        $HostsStart,
+        "$hostsAddress`t$($hostNames -join ' ')",
+        $HostsEnd
+    ) -join [Environment]::NewLine
+    $base = $content.TrimEnd()
+    if ([string]::IsNullOrWhiteSpace($base)) {
+        return $block + [Environment]::NewLine
+    }
+    return $base + [Environment]::NewLine + $block + [Environment]::NewLine
+}
+
+function Test-HostsFileReady {
+    param(
+        $Config,
+        $HostNames
+    )
+
+    if (-not (Test-Path -LiteralPath $HostsPath)) {
+        return $false
+    }
+    $current = Get-Content -LiteralPath $HostsPath -Raw -ErrorAction Stop
+    $desired = Get-ReconciledHostsContent -Config $Config -HostNames $HostNames
+    return $current -eq $desired
+}
+
 function Reconcile-HostsFile {
     param(
         $Config,
@@ -563,19 +768,13 @@ function Reconcile-HostsFile {
     }
 
     $hostsAddress = Get-HostsAddress $Config
-    $content = Remove-ManagedHostsBlock
+    $newContent = Get-ReconciledHostsContent -Config $Config -HostNames $hostNames
+    if ((Test-Path -LiteralPath $HostsPath) -and (Test-HostsFileReady -Config $Config -HostNames $hostNames)) {
+        Write-Host ("HOSTS unchanged {0} -> {1}" -f ($hostNames -join ", "), $hostsAddress)
+        return
+    }
 
-    $block = @()
-    $block += $HostsStart
-
-    $line = "$hostsAddress`t$($hostNames -join ' ')"
-    $block += $line
-
-    $block += $HostsEnd
-
-    $newContent = $content.TrimEnd() + [Environment]::NewLine + ($block -join [Environment]::NewLine) + [Environment]::NewLine
-
-    Set-Content -LiteralPath $HostsPath -Value $newContent -Encoding ASCII -Force
+    [System.IO.File]::WriteAllText($HostsPath, $newContent, [System.Text.Encoding]::ASCII)
     Write-Host ("HOSTS {0} -> {1}" -f ($hostNames -join ", "), $hostsAddress)
 }
 
@@ -586,26 +785,50 @@ function Remove-HostsFileBlock {
 }
 
 function Register-BridgeTask {
-    param([string]$ResolvedConfigPath)
+    param(
+        [string]$ResolvedConfigPath,
+        $Config
+    )
 
     $scriptPath = $PSCommandPath
-    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`" -Action refresh -ConfigPath `"$ResolvedConfigPath`""
+    $intervalMinutes = Get-DiscoveryIntervalMinutes $Config
+    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`" -Action reconcile -ConfigPath `"$ResolvedConfigPath`""
 
     $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $arguments
-    $trigger = New-ScheduledTaskTrigger -AtLogOn
+    $logonTrigger = New-ScheduledTaskTrigger -AtLogOn
+    $periodicTrigger = New-ScheduledTaskTrigger `
+        -Once `
+        -At (Get-Date).AddMinutes($intervalMinutes) `
+        -RepetitionInterval (New-TimeSpan -Minutes $intervalMinutes) `
+        -RepetitionDuration (New-TimeSpan -Days 3650)
+    $triggers = @($logonTrigger, $periodicTrigger)
     $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Highest
-    $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew
+    $settings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -StartWhenAvailable `
+        -MultipleInstances IgnoreNew `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
 
     Register-ScheduledTask `
         -TaskName $TaskName `
         -Action $action `
-        -Trigger $trigger `
+        -Trigger $triggers `
         -Principal $principal `
         -Settings $settings `
-        -Description "Refresh Tiny Swarm World Windows <-> WSL bridge after WSL IP changes." `
+        -Description "Discover and reconcile the Tiny Swarm World Windows <-> WSL bridge after logon and every $intervalMinutes minute(s)." `
         -Force | Out-Null
 
-    Write-Host "TASK registered: $TaskName"
+    Write-Host "TASK registered: $TaskName (logon + every $intervalMinutes minute(s))"
+}
+
+function Test-BridgeTaskReady {
+    $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($null -eq $task) {
+        return $false
+    }
+    $arguments = @($task.Actions | ForEach-Object { [string]$_.Arguments }) -join " "
+    $triggers = @($task.Triggers)
+    return $arguments -match '(?i)-Action\s+reconcile' -and $triggers.Count -ge 2
 }
 
 function Unregister-BridgeTask {
@@ -687,19 +910,103 @@ function Verify-Bridge {
     }
 }
 
+function Get-BridgeDiscovery {
+    param(
+        $Config,
+        [string]$WslIp,
+        $Mappings,
+        $HostNames
+    )
+
+    $driftReasons = [System.Collections.ArrayList]::new()
+    if (-not (Test-PortProxyMappingsReady -Config $Config -WslIp $WslIp -Mappings $Mappings)) {
+        [void]$driftReasons.Add("portproxy_drift")
+    }
+    if (-not (Test-FirewallRulesReady -Config $Config -Mappings $Mappings)) {
+        [void]$driftReasons.Add("firewall_drift")
+    }
+    if (-not (Test-HostsFileReady -Config $Config -HostNames $HostNames)) {
+        [void]$driftReasons.Add("hosts_drift")
+    }
+    if (-not (Test-BridgeTaskReady)) {
+        [void]$driftReasons.Add("scheduled_task_drift")
+    }
+
+    return [pscustomobject]@{
+        Ready                    = $driftReasons.Count -eq 0
+        WslIp                    = $WslIp
+        DiscoveryIntervalMinutes = Get-DiscoveryIntervalMinutes $Config
+        DriftReasons             = @($driftReasons)
+    }
+}
+
+function Write-BridgeDiscovery {
+    param($Discovery)
+
+    $status = if ($Discovery.Ready) { "READY" } else { "DEGRADED" }
+    $reasons = if ($Discovery.DriftReasons.Count -eq 0) { "none" } else { $Discovery.DriftReasons -join "," }
+    Write-Host ("DISCOVERY {0} wslIp={1} intervalMinutes={2} drift={3}" -f $status, $Discovery.WslIp, $Discovery.DiscoveryIntervalMinutes, $reasons)
+}
+
+function Invoke-BridgeReconcile {
+    param(
+        $Config,
+        $Mappings,
+        $HostNames,
+        [string]$RegistryPath
+    )
+
+    $wslIp = Get-WslIp $Config
+    $pendingDiscovery = [pscustomobject]@{
+        Ready                    = $false
+        WslIp                    = $wslIp
+        DiscoveryIntervalMinutes = Get-DiscoveryIntervalMinutes $Config
+        DriftReasons             = @("reconcile_in_progress")
+    }
+    Write-StateFile `
+        -Config $Config `
+        -WslIp $wslIp `
+        -Mappings $Mappings `
+        -HostNames $HostNames `
+        -RegistryPath $RegistryPath `
+        -Discovery $pendingDiscovery
+    Reconcile-PortProxy -Config $Config -WslIp $wslIp -Mappings $Mappings
+    Reconcile-FirewallRules -Config $Config -Mappings $Mappings
+    Reconcile-HostsFile -Config $Config -HostNames $HostNames
+    $discovery = Get-BridgeDiscovery -Config $Config -WslIp $wslIp -Mappings $Mappings -HostNames $HostNames
+    Write-StateFile `
+        -Config $Config `
+        -WslIp $wslIp `
+        -Mappings $Mappings `
+        -HostNames $HostNames `
+        -RegistryPath $RegistryPath `
+        -Discovery $discovery
+    Write-BridgeDiscovery -Discovery $discovery
+    if (-not $discovery.Ready) {
+        throw "Windows/WSL bridge reconcile finished with drift: $($discovery.DriftReasons -join ', ')"
+    }
+}
+
 function Write-StateFile {
     param(
         $Config,
         [string]$WslIp,
         $Mappings,
         $HostNames,
-        [string]$RegistryPath
+        [string]$RegistryPath,
+        $Discovery
     )
 
     $state = [ordered]@{
+        contractVersion    = 2
+        agentMode          = "scheduled-discovery"
+        agentStatus        = $(if ($Discovery.Ready) { "ready" } else { "degraded" })
         generatedAt        = (Get-Date).ToString("o")
         action             = $Action
         wslIp              = $WslIp
+        taskName           = $TaskName
+        discoveryIntervalMinutes = $Discovery.DiscoveryIntervalMinutes
+        driftReasons       = @($Discovery.DriftReasons)
         listenAddress      = (Get-ListenAddress $Config)
         hostsAddress       = (Get-HostsAddress $Config)
         configPath         = (Resolve-Path -LiteralPath $ConfigPath).Path
@@ -730,11 +1037,21 @@ function Show-Status {
     Write-Host ("Ports: {0}" -f (($Mappings | Select-Object -ExpandProperty ListenPort) -join ", "))
     Write-Host ("Hosts: {0}" -f ($HostNames -join ", "))
 
+    $wslIp = ""
     try {
         $wslIp = Get-WslIp $Config
         Write-Host ("WSL IP: {0}" -f $wslIp)
     } catch {
         Write-Host ("WSL IP: unavailable - {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($wslIp)) {
+        try {
+            $discovery = Get-BridgeDiscovery -Config $Config -WslIp $wslIp -Mappings $Mappings -HostNames $HostNames
+            Write-BridgeDiscovery -Discovery $discovery
+        } catch {
+            Write-Host ("DISCOVERY unavailable - {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+        }
     }
 
     Write-Host ""
@@ -766,28 +1083,37 @@ switch ($Action) {
         Write-Host "Windows/WSL bridge prerequisites are ready. No bridge state was changed."
     }
 
+    "discover" {
+        Assert-BridgePrerequisites -Config $config
+        $wslIp = Get-WslIp $config
+        $discovery = Get-BridgeDiscovery -Config $config -WslIp $wslIp -Mappings $mappings -HostNames $hostNames
+        Write-BridgeDiscovery -Discovery $discovery
+        $discovery | ConvertTo-Json -Depth 4
+        if (-not $discovery.Ready) {
+            throw "Windows/WSL bridge discovery found drift: $($discovery.DriftReasons -join ', ')"
+        }
+    }
+
     "install" {
         Assert-BridgePrerequisites -Config $config
         $resolvedConfig = (Resolve-Path -LiteralPath $ConfigPath).Path
-        $wslIp = Get-WslIp $config
-        Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
-        Reconcile-FirewallRules -Config $config -Mappings $mappings
-        Reconcile-HostsFile -Config $config -HostNames $hostNames
-        Register-BridgeTask -ResolvedConfigPath $resolvedConfig
-        Write-StateFile -Config $config -WslIp $wslIp -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
+        Register-BridgeTask -ResolvedConfigPath $resolvedConfig -Config $config
+        Invoke-BridgeReconcile -Config $config -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
         Write-Host ""
-        Write-Host "Installed. You can refresh later with:"
+        Write-Host "Installed. Discovery/reconcile now runs automatically. Trigger it manually with:"
         Write-Host "  Start-ScheduledTask -TaskName $TaskName"
+    }
+
+    "reconcile" {
+        Assert-BridgePrerequisites -Config $config
+        Invoke-BridgeReconcile -Config $config -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
+        Write-Host "Reconcile completed."
     }
 
     "refresh" {
         Assert-BridgePrerequisites -Config $config
-        $wslIp = Get-WslIp $config
-        Reconcile-PortProxy -Config $config -WslIp $wslIp -Mappings $mappings
-        Reconcile-FirewallRules -Config $config -Mappings $mappings
-        Reconcile-HostsFile -Config $config -HostNames $hostNames
-        Write-StateFile -Config $config -WslIp $wslIp -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
-        Write-Host "Refresh completed."
+        Invoke-BridgeReconcile -Config $config -Mappings $mappings -HostNames $hostNames -RegistryPath $registryPath
+        Write-Host "Reconcile completed."
     }
 
     "verify" {


### PR DESCRIPTION
## Summary
- Add scheduled Windows/WSL bridge discovery and reconcile actions.
- Require a versioned scheduled-discovery agent heartbeat in WSL preflight.
- Update bridge documentation and regression tests for the new prepared-state contract.

## Changed Areas
- tools/windows bridge script and config
- Windows/WSL bridge preflight domain and infrastructure validation
- installer remediation and guard behavior
- unit/static tests for bridge state, installer, and PowerShell asset contract
- system and user-guide documentation

## Verification
- git diff --check: passed
- PYTHONPATH=src python3 -m unittest tests.infrastructure.adapters.preflight.test_windows_wsl_bridge_state tests.infrastructure.adapters.preflight.test_host_preflight_probe tests.test_installer tests.test_windows_wsl_bridge_assets tests.application.services.platform.test_preflight_service tests.test_install_script: passed
- .venv/bin/python tools/quality_gate.py quality: passed

Note: python3 tools/quality_gate.py quality could not start with the system WSL interpreter because ruff is not installed there; the repository WSL venv contains the required dev tools and completed the same quality gate successfully.

## Impact
- WSL2 installations with Windows localhost exposure now require the upgraded scheduled discovery agent and a ready heartbeat no older than five minutes.
- Native Linux and explicitly disabled Windows exposure are unchanged.

## Risks And Limitations
- The PowerShell bridge changes are verified by static/unit assertions, not by live Windows portproxy, Firewall, hosts-file, or Scheduled Task mutation in this run.
- No live Incus, Docker Swarm, compose deployment, or service bootstrap commands were run.

## Push Auto Lifecycle
This PR is part of an explicit push auto request. The workflow will wait or retry until required checks are green including SonarQube when configured, merge the PR, delete the merged remote head branch, and run local cleanup after merge verification.
