### PR TITLE
Fix duplicate provider config assertion

### DIFF
--- a/tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py
+++ b/tests/infrastructure/adapters/repositories/test_node_provider_config_yaml_repository.py
@@ -123,7 +123,10 @@ class TestNodeProviderConfigYamlRepository(unittest.TestCase):
     def test_provider_config_load_is_deterministic(self):
         repository = NodeProviderConfigYamlRepository()
 
-        self.assertEqual(repository.load(), repository.load())
+        first_load = repository.load()
+        second_load = repository.load()
+
+        self.assertEqual(first_load, second_load)
 
     def test_missing_provider_config_fails_closed(self):
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
Fixes the Sonar python:S5863 finding by capturing two independent provider config loads before comparing them. Validation: focused unittest and full quality gate passed.